### PR TITLE
fix: resolve build failures in shared and web packages

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "bunx --bun vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src",

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "wxt-react-starter",
@@ -30,7 +31,7 @@
     },
     "apps/extension": {
       "name": "@evevault/extension",
-      "version": "0.1.0",
+      "version": "0.0.2",
       "dependencies": {
         "@evevault/shared": "workspace:*",
         "@mysten/dapp-kit": "^0.17.2",


### PR DESCRIPTION
## Summary
- **Shared package**: Remove broken `FileRouteTypes` import from hardcoded `node_modules/` path — this is a generated, app-specific type that can't be resolved during `tsc` build. Replace `RoutePath` with `string` since the shared package shouldn't depend on app-specific route types.
- **Web package**: Force Bun runtime for Vite build (`bunx --bun vite build`) to fix `crypto.hash is not a function` error caused by Vite 7 spawning sub-processes that fall back to Node.js.

## Test plan
- [x] `bun run build` completes successfully for all packages (shared, web, extension)
- [x] All 171 tests pass across the monorepo

🤖 Generated with [Claude Code](https://claude.com/claude-code)