### PR TITLE
fix: update amplify.yml to monorepo applications format

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,20 +1,22 @@
 version: 1
-frontend:
-  phases:
-    preBuild:
-      commands:
-        - sudo yum install -y rsync
-        - curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.1"
-        - export PATH="$HOME/.bun/bin:$PATH"
-        - bun install --frozen-lockfile
-    build:
-      commands:
-        - export PATH="$HOME/.bun/bin:$PATH"
-        - bun run build:web
-  artifacts:
-    baseDirectory: apps/web/dist
-    files:
-      - '**/*'
-  cache:
-    paths:
-      - ~/.bun/install/cache/**/*
+applications:
+  - appRoot: apps/web
+    frontend:
+      phases:
+        preBuild:
+          commands:
+            - sudo yum install -y rsync
+            - curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.1"
+            - export PATH="$HOME/.bun/bin:$PATH"
+            - cd ../.. && bun install --frozen-lockfile
+        build:
+          commands:
+            - export PATH="$HOME/.bun/bin:$PATH"
+            - cd ../.. && bun run build:web
+      artifacts:
+        baseDirectory: dist
+        files:
+          - '**/*'
+      cache:
+        paths:
+          - ~/.bun/install/cache/**/*


### PR DESCRIPTION
## Summary
- Fixes the `CustomerError: Monorepo spec provided without "applications" key` error in Amplify
- The Amplify app was set up as a monorepo in the console, which requires the `applications` key with `appRoot` instead of a top-level `frontend` key
- Adjusts `bun install` and `bun run build:web` to run from the repo root (`../..` from `appRoot`)
- Fixes `baseDirectory` to `dist` (relative to `appRoot: apps/web`, so resolves to `apps/web/dist`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)