### PR TITLE
fix: use bun run build in Amplify build command

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -12,7 +12,7 @@ applications:
         build:
           commands:
             - export PATH="$HOME/.bun/bin:$PATH"
-            - cd ../.. && bun run build:web
+            - cd ../.. && bun run build
       artifacts:
         baseDirectory: dist
         files:


### PR DESCRIPTION
## Summary

- Changes `cd ../.. && bun run build:web` to `cd ../.. && bun run build` in `amplify.yml`
- The `build:web` script was not being found during Amplify builds, causing build failures

## Test plan

- [ ] Amplify build succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)