### PR TITLE
fix: run build from appRoot instead of cd ../..

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -12,7 +12,7 @@ applications:
         build:
           commands:
             - export PATH="$HOME/.bun/bin:$PATH"
-            - cd ../.. && bun run build
+            - bun run build
       artifacts:
         baseDirectory: dist
         files:


### PR DESCRIPTION
## Summary

- Removes `cd ../..` from the build command in `amplify.yml`
- Runs `bun run build` directly from `apps/web` (the `appRoot`), using `apps/web/package.json`'s build script (`bunx --bun vite build`)
- The `cd ../..` doesn't resolve to the repo root in Amplify's build environment, causing "Script not found" errors

## Test plan

- [ ] Amplify build succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)