### PR TITLE
fix: rejection promise handling

### DIFF
--- a/apps/extension/src/features/wallet/components/SignPersonalMessage.tsx
+++ b/apps/extension/src/features/wallet/components/SignPersonalMessage.tsx
@@ -152,15 +152,15 @@ function SignPersonalMessage() {
         transactionResult: {
           windowId: pendingMessage.windowId,
           status: "error",
-          error: "Transaction rejected by user",
+          error: "Message signing rejected by user",
         },
       });
 
       // Close the popup window
       window.close();
     } catch (err) {
-      log.error("Failed to reject transaction", err);
-      setError("Failed to reject transaction");
+      log.error("Failed to reject message signing", err);
+      setError("Failed to reject message signing");
     }
   };
 

--- a/apps/extension/src/lib/background/handlers/__tests__/walletHandlers.test.ts
+++ b/apps/extension/src/lib/background/handlers/__tests__/walletHandlers.test.ts
@@ -1,0 +1,587 @@
+import { WalletStandardMessageTypes } from "@evevault/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { WalletActionMessage } from "../../types";
+import { handleApprovePopup } from "../walletHandlers";
+
+const { mockOpenPopupWindow, logMethods } = vi.hoisted(() => ({
+  mockOpenPopupWindow: vi.fn(),
+  logMethods: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("../../services/popupWindow", () => ({
+  openPopupWindow: (action: string) => mockOpenPopupWindow(action),
+}));
+
+vi.mock("@evevault/shared/utils", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@evevault/shared/utils")>();
+  return {
+    ...actual,
+    createLogger: () => logMethods,
+  };
+});
+
+function installChromeMock(
+  storageListeners: Array<
+    (changes: { [key: string]: chrome.storage.StorageChange }) => void
+  >,
+  sendMessageImpl?: typeof chrome.tabs.sendMessage,
+) {
+  globalThis.chrome = {
+    storage: {
+      local: {
+        set: vi.fn(() => Promise.resolve()),
+        remove: vi.fn(() => Promise.resolve()),
+      },
+      onChanged: {
+        addListener: vi.fn(
+          (
+            fn: (changes: {
+              [key: string]: chrome.storage.StorageChange;
+            }) => void,
+          ) => {
+            storageListeners.push(fn);
+          },
+        ),
+        removeListener: vi.fn(),
+      },
+    },
+    tabs: {
+      sendMessage: sendMessageImpl ?? vi.fn(() => Promise.resolve()),
+    },
+  } as unknown as typeof chrome;
+}
+
+describe("handleApprovePopup", () => {
+  let storageListeners: Array<
+    (changes: { [key: string]: chrome.storage.StorageChange }) => void
+  >;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storageListeners = [];
+    mockOpenPopupWindow.mockResolvedValue(99);
+    installChromeMock(storageListeners);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  async function getWrappedListener(
+    message: WalletActionMessage,
+    sender: {
+      tab?: { id?: number };
+    },
+  ) {
+    await handleApprovePopup(
+      message,
+      sender as chrome.runtime.MessageSender,
+      vi.fn(),
+    );
+    const wrapped = storageListeners[storageListeners.length - 1];
+    if (!wrapped) {
+      throw new Error("expected storage onChanged listener to be registered");
+    }
+    return wrapped;
+  }
+
+  describe("when opening the popup fails", () => {
+    it("calls sendResponse with sign_transaction_error when windowId is falsy", async () => {
+      mockOpenPopupWindow.mockResolvedValue(undefined as unknown as number);
+      const sendResponse = vi.fn();
+
+      const result = await handleApprovePopup(
+        { action: WalletStandardMessageTypes.SIGN_TRANSACTION },
+        { tab: { id: 1 } } as chrome.runtime.MessageSender,
+        sendResponse,
+      );
+
+      expect(result).toBe(false);
+      expect(sendResponse).toHaveBeenCalledWith({
+        type: "sign_transaction_error",
+        error: "Failed to open approval popup",
+      });
+      expect(logMethods.error).toHaveBeenCalled();
+    });
+
+    it("calls sendResponse with Error message when openPopupWindow throws an Error", async () => {
+      mockOpenPopupWindow.mockRejectedValue(new Error("popup crashed"));
+      const sendResponse = vi.fn();
+
+      const result = await handleApprovePopup(
+        { action: WalletStandardMessageTypes.SIGN_TRANSACTION },
+        { tab: { id: 1 } } as chrome.runtime.MessageSender,
+        sendResponse,
+      );
+
+      expect(result).toBe(false);
+      expect(sendResponse).toHaveBeenCalledWith({
+        type: "sign_transaction_error",
+        error: "popup crashed",
+      });
+    });
+
+    it("calls sendResponse with a generic message when openPopupWindow throws a non-Error", async () => {
+      mockOpenPopupWindow.mockRejectedValue("boom");
+      const sendResponse = vi.fn();
+
+      await handleApprovePopup(
+        { action: WalletStandardMessageTypes.SIGN_TRANSACTION },
+        { tab: { id: 1 } } as chrome.runtime.MessageSender,
+        sendResponse,
+      );
+
+      expect(sendResponse).toHaveBeenCalledWith({
+        type: "sign_transaction_error",
+        error: "Unknown error occurred",
+      });
+    });
+  });
+
+  describe("on transactionResult success", () => {
+    it("sends sign_success for SIGN_TRANSACTION when status is signed", async () => {
+      const wrapped = await getWrappedListener(
+        {
+          id: "s1",
+          action: WalletStandardMessageTypes.SIGN_TRANSACTION,
+        },
+        { tab: { id: 42 } },
+      );
+
+      wrapped({
+        transactionResult: {
+          newValue: {
+            status: "signed",
+            bytes: new Uint8Array([1, 2]),
+            signature: "sig-bytes",
+          },
+        },
+      });
+
+      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
+        type: "sign_success",
+        bytes: new Uint8Array([1, 2]),
+        signature: "sig-bytes",
+        id: "s1",
+      });
+      expect(chrome.storage.local.remove).toHaveBeenCalledWith([
+        "pendingAction",
+        "transactionResult",
+      ]);
+    });
+
+    it("sends sign_and_execute_transaction_success when all required fields are present", async () => {
+      const wrapped = await getWrappedListener(
+        {
+          id: "s2",
+          action: WalletStandardMessageTypes.SIGN_AND_EXECUTE_TRANSACTION,
+        },
+        { tab: { id: 7 } },
+      );
+
+      wrapped({
+        transactionResult: {
+          newValue: {
+            status: "signed_and_executed",
+            bytes: new Uint8Array([9]),
+            signature: "sig",
+            digest: "dg",
+            effects: "fx",
+          },
+        },
+      });
+
+      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(7, {
+        type: "sign_and_execute_transaction_success",
+        result: {
+          bytes: new Uint8Array([9]),
+          signature: "sig",
+          digest: "dg",
+          effects: "fx",
+        },
+        id: "s2",
+      });
+    });
+
+    it("sends sign_and_execute_transaction_error when digest or effects are missing", async () => {
+      const wrapped = await getWrappedListener(
+        {
+          id: "s3",
+          action: WalletStandardMessageTypes.SIGN_AND_EXECUTE_TRANSACTION,
+        },
+        { tab: { id: 7 } },
+      );
+
+      wrapped({
+        transactionResult: {
+          newValue: {
+            status: "signed_and_executed",
+            bytes: new Uint8Array([1]),
+            signature: "sig",
+          },
+        },
+      });
+
+      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(7, {
+        type: "sign_and_execute_transaction_error",
+        error: "Missing bytes or signature in transaction result",
+        id: "s3",
+      });
+    });
+
+    it("logs when tabs.sendMessage rejects on sign_success", async () => {
+      const sendMessage = vi.fn(() => Promise.reject(new Error("tab gone")));
+      installChromeMock(storageListeners, sendMessage);
+      mockOpenPopupWindow.mockResolvedValue(99);
+
+      const wrapped = await getWrappedListener(
+        {
+          id: "s4",
+          action: WalletStandardMessageTypes.SIGN_TRANSACTION,
+        },
+        { tab: { id: 1 } },
+      );
+
+      wrapped({
+        transactionResult: {
+          newValue: {
+            status: "signed",
+            bytes: new Uint8Array([1]),
+            signature: "sig",
+          },
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(logMethods.error).toHaveBeenCalledWith(
+          "Failed to send success message",
+          expect.any(Error),
+        );
+      });
+    });
+
+    it("logs when tabs.sendMessage rejects for incomplete sign-and-execute result", async () => {
+      const sendMessage = vi.fn(() => Promise.reject(new Error("tab gone")));
+      installChromeMock(storageListeners, sendMessage);
+      mockOpenPopupWindow.mockResolvedValue(99);
+
+      const wrapped = await getWrappedListener(
+        {
+          id: "s5",
+          action: WalletStandardMessageTypes.SIGN_AND_EXECUTE_TRANSACTION,
+        },
+        { tab: { id: 3 } },
+      );
+
+      wrapped({
+        transactionResult: {
+          newValue: {
+            status: "signed_and_executed",
+            bytes: new Uint8Array([1]),
+            signature: "sig",
+          },
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(logMethods.error).toHaveBeenCalledWith(
+          "Failed to send sign_and_execute error",
+          expect.any(Error),
+        );
+      });
+    });
+
+    it("logs when tabs.sendMessage rejects for sign-and-execute success", async () => {
+      const sendMessage = vi.fn(() => Promise.reject(new Error("tab gone")));
+      installChromeMock(storageListeners, sendMessage);
+      mockOpenPopupWindow.mockResolvedValue(99);
+
+      const wrapped = await getWrappedListener(
+        {
+          id: "s6",
+          action: WalletStandardMessageTypes.SIGN_AND_EXECUTE_TRANSACTION,
+        },
+        { tab: { id: 3 } },
+      );
+
+      wrapped({
+        transactionResult: {
+          newValue: {
+            status: "signed_and_executed",
+            bytes: new Uint8Array([1]),
+            signature: "sig",
+            digest: "d",
+            effects: "e",
+          },
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(logMethods.error).toHaveBeenCalledWith(
+          "Failed to send sign_and_execute success",
+          expect.any(Error),
+        );
+      });
+    });
+  });
+
+  describe("on transactionResult error", () => {
+    async function fireTransactionError(
+      message: WalletActionMessage,
+      sender: { tab?: { id?: number } } = { tab: { id: 42 } },
+      errorText = "User said no",
+    ) {
+      const wrapped = await getWrappedListener(message, sender);
+      wrapped({
+        transactionResult: {
+          newValue: {
+            status: "error",
+            error: errorText,
+          },
+        },
+      });
+    }
+
+    it("maps SIGN_TRANSACTION to sign_transaction_error", async () => {
+      await fireTransactionError({
+        id: "req-1",
+        action: WalletStandardMessageTypes.SIGN_TRANSACTION,
+      });
+
+      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
+        type: "sign_transaction_error",
+        error: "User said no",
+        id: "req-1",
+      });
+      expect(logMethods.warn).not.toHaveBeenCalled();
+    });
+
+    it("removeListener is called with the same handler reference as addListener", async () => {
+      const wrapped = await getWrappedListener(
+        {
+          id: "req-remove-pair",
+          action: WalletStandardMessageTypes.SIGN_TRANSACTION,
+        },
+        { tab: { id: 42 } },
+      );
+
+      expect(storageListeners).toHaveLength(1);
+      const registered = storageListeners[0];
+      if (!registered) {
+        throw new Error("expected registered storage listener");
+      }
+
+      wrapped({
+        transactionResult: {
+          newValue: {
+            status: "error",
+            error: "User said no",
+          },
+        },
+      });
+
+      expect(chrome.storage.onChanged.removeListener).toHaveBeenCalledWith(
+        registered,
+      );
+    });
+
+    it("maps SIGN_PERSONAL_MESSAGE to sign_personal_message_error", async () => {
+      await fireTransactionError({
+        id: "req-2",
+        action: WalletStandardMessageTypes.SIGN_PERSONAL_MESSAGE,
+      });
+
+      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
+        type: "sign_personal_message_error",
+        error: "User said no",
+        id: "req-2",
+      });
+      expect(logMethods.warn).not.toHaveBeenCalled();
+    });
+
+    it("maps unknown action to sign_error and logs a warning", async () => {
+      await fireTransactionError({
+        id: "req-3",
+        action: "unknown_wallet_action_for_test",
+      });
+
+      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
+        type: "sign_error",
+        error: "User said no",
+        id: "req-3",
+      });
+      expect(logMethods.warn).toHaveBeenCalledWith("Unknown action", {
+        action: "unknown_wallet_action_for_test",
+      });
+    });
+
+    it("uses sign_and_execute_transaction_error for SIGN_AND_EXECUTE_TRANSACTION", async () => {
+      await fireTransactionError({
+        id: "req-4",
+        action: WalletStandardMessageTypes.SIGN_AND_EXECUTE_TRANSACTION,
+      });
+
+      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
+        type: "sign_and_execute_transaction_error",
+        error: "User said no",
+        id: "req-4",
+      });
+      expect(logMethods.warn).not.toHaveBeenCalled();
+    });
+
+    it("does not call tabs.sendMessage when sender has no tab id (non-execute error)", async () => {
+      await fireTransactionError(
+        {
+          id: "req-5",
+          action: WalletStandardMessageTypes.SIGN_TRANSACTION,
+        },
+        {},
+      );
+
+      expect(chrome.tabs.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it("does not call tabs.sendMessage when sender has no tab id (sign-and-execute error)", async () => {
+      await fireTransactionError(
+        {
+          id: "req-6",
+          action: WalletStandardMessageTypes.SIGN_AND_EXECUTE_TRANSACTION,
+        },
+        {},
+      );
+
+      expect(chrome.tabs.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it("logs when tabs.sendMessage rejects for mapped error type", async () => {
+      const sendMessage = vi.fn(() => Promise.reject(new Error("tab gone")));
+      installChromeMock(storageListeners, sendMessage);
+      mockOpenPopupWindow.mockResolvedValue(99);
+
+      await fireTransactionError({
+        id: "req-7",
+        action: WalletStandardMessageTypes.SIGN_TRANSACTION,
+      });
+
+      await vi.waitFor(() => {
+        expect(logMethods.error).toHaveBeenCalledWith(
+          "Failed to send sign_transaction_error error",
+          expect.any(Error),
+        );
+      });
+    });
+
+    it("logs when tabs.sendMessage rejects for sign-and-execute error result", async () => {
+      const sendMessage = vi.fn(() => Promise.reject(new Error("tab gone")));
+      installChromeMock(storageListeners, sendMessage);
+      mockOpenPopupWindow.mockResolvedValue(99);
+
+      await fireTransactionError({
+        id: "req-8",
+        action: WalletStandardMessageTypes.SIGN_AND_EXECUTE_TRANSACTION,
+      });
+
+      await vi.waitFor(() => {
+        expect(logMethods.error).toHaveBeenCalledWith(
+          "Failed to send sign_and_execute error",
+          expect.any(Error),
+        );
+      });
+    });
+  });
+
+  describe("when storage change is irrelevant", () => {
+    it("does nothing when transactionResult is absent", async () => {
+      const wrapped = await getWrappedListener(
+        { action: WalletStandardMessageTypes.SIGN_TRANSACTION },
+        { tab: { id: 1 } },
+      );
+
+      wrapped({});
+
+      expect(chrome.tabs.sendMessage).not.toHaveBeenCalled();
+      expect(chrome.storage.local.remove).not.toHaveBeenCalled();
+    });
+
+    it("does nothing on success when sender has no tab id", async () => {
+      const wrapped = await getWrappedListener(
+        { action: WalletStandardMessageTypes.SIGN_TRANSACTION },
+        {},
+      );
+
+      wrapped({
+        transactionResult: {
+          newValue: {
+            status: "signed",
+            bytes: new Uint8Array([1]),
+            signature: "sig",
+          },
+        },
+      });
+
+      expect(chrome.tabs.sendMessage).not.toHaveBeenCalled();
+      expect(chrome.storage.local.remove).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("approval timeout", () => {
+    it("removes pending storage and logs after 10 minutes", async () => {
+      vi.useFakeTimers();
+
+      await handleApprovePopup(
+        {
+          action: WalletStandardMessageTypes.SIGN_TRANSACTION,
+        },
+        { tab: { id: 5 } } as chrome.runtime.MessageSender,
+        vi.fn(),
+      );
+
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
+
+      expect(logMethods.warn).toHaveBeenCalledWith(
+        "Transaction approval timed out",
+        {
+          action: WalletStandardMessageTypes.SIGN_TRANSACTION,
+          senderTabId: 5,
+        },
+      );
+      expect(chrome.storage.local.remove).toHaveBeenCalledWith([
+        "pendingAction",
+        "transactionResult",
+      ]);
+    });
+
+    it("clears the timeout when a storage result arrives", async () => {
+      vi.useFakeTimers();
+
+      const wrapped = await getWrappedListener(
+        { action: WalletStandardMessageTypes.SIGN_TRANSACTION },
+        { tab: { id: 2 } },
+      );
+
+      wrapped({
+        transactionResult: {
+          newValue: {
+            status: "signed",
+            bytes: new Uint8Array([1]),
+            signature: "s",
+          },
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
+
+      expect(logMethods.warn).not.toHaveBeenCalledWith(
+        "Transaction approval timed out",
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/apps/extension/src/lib/background/handlers/sponsoredTransactionHandler.ts
+++ b/apps/extension/src/lib/background/handlers/sponsoredTransactionHandler.ts
@@ -123,13 +123,23 @@ async function handleSponsoredTransaction(
       },
     });
 
-    const storageListener = (changes: {
+    let timeoutId: ReturnType<typeof setTimeout>;
+    let registeredListener: (changes: {
+      [key: string]: chrome.storage.StorageChange;
+    }) => void;
+
+    const detachSponsoredListener = () => {
+      clearTimeout(timeoutId);
+      chrome.storage.onChanged.removeListener(registeredListener);
+    };
+
+    const coreListener = (changes: {
       [key: string]: chrome.storage.StorageChange;
     }) => {
       const result = changes.transactionResult?.newValue;
       if (!result || result.windowId !== windowId) return;
 
-      chrome.storage.onChanged.removeListener(storageListener);
+      detachSponsoredListener();
       chrome.storage.local.remove(["pendingAction", "transactionResult"]);
 
       if (
@@ -200,28 +210,23 @@ async function handleSponsoredTransaction(
       }
     };
 
-    chrome.storage.onChanged.addListener(storageListener);
+    registeredListener = (changes: {
+      [key: string]: chrome.storage.StorageChange;
+    }) => {
+      clearTimeout(timeoutId);
+      coreListener(changes);
+    };
 
-    // Clean up after timeout (10 minutes)
-    const timeoutId = setTimeout(
+    timeoutId = setTimeout(
       () => {
-        chrome.storage.onChanged.removeListener(storageListener);
+        detachSponsoredListener();
         chrome.storage.local.remove(["pendingAction", "transactionResult"]);
         log.warn("Sponsored transaction approval timed out", { senderTabId });
       },
       10 * 60 * 1000,
     );
 
-    // Store timeout ID so it can be cleared if transaction completes
-    const originalListener = storageListener;
-    const wrappedListener = (changes: {
-      [key: string]: chrome.storage.StorageChange;
-    }) => {
-      clearTimeout(timeoutId);
-      originalListener(changes);
-    };
-    chrome.storage.onChanged.removeListener(storageListener);
-    chrome.storage.onChanged.addListener(wrappedListener);
+    chrome.storage.onChanged.addListener(registeredListener);
 
     return true;
   } catch (error) {

--- a/apps/extension/src/lib/background/handlers/walletHandlers.ts
+++ b/apps/extension/src/lib/background/handlers/walletHandlers.ts
@@ -103,11 +103,31 @@ async function handleApprovePopup(
             .catch((err) => {
               log.error("Failed to send sign_and_execute error", err);
             });
-        } else {
-          sendResponse({
-            type: "sign_transaction_error",
-            error: result.error,
-          });
+        } else if (typeof senderTabId === "number") {
+          let errorType: string;
+
+          switch (action) {
+            case WalletStandardMessageTypes.SIGN_TRANSACTION:
+              errorType = "sign_transaction_error";
+              break;
+            case WalletStandardMessageTypes.SIGN_PERSONAL_MESSAGE:
+              errorType = "sign_personal_message_error";
+              break;
+            default:
+              log.warn("Unknown action", { action });
+              errorType = "sign_error";
+              break;
+          }
+
+          chrome.tabs
+            .sendMessage(senderTabId, {
+              type: errorType,
+              error: result.error,
+              id: message.id,
+            })
+            .catch((err) => {
+              log.error(`Failed to send ${errorType} error`, err);
+            });
         }
 
         chrome.storage.local.remove(["pendingAction", "transactionResult"]);

--- a/apps/extension/src/lib/background/handlers/walletHandlers.ts
+++ b/apps/extension/src/lib/background/handlers/walletHandlers.ts
@@ -35,7 +35,17 @@ async function handleApprovePopup(
     const isSignAndExecute =
       action === WalletStandardMessageTypes.SIGN_AND_EXECUTE_TRANSACTION;
 
-    const storageListener = (changes: {
+    let timeoutId: ReturnType<typeof setTimeout>;
+    let registeredListener: (changes: {
+      [key: string]: chrome.storage.StorageChange;
+    }) => void;
+
+    const detachApprovalListener = () => {
+      clearTimeout(timeoutId);
+      chrome.storage.onChanged.removeListener(registeredListener);
+    };
+
+    const coreListener = (changes: {
       [key: string]: chrome.storage.StorageChange;
     }) => {
       const result = changes.transactionResult?.newValue;
@@ -89,9 +99,9 @@ async function handleApprovePopup(
         }
 
         chrome.storage.local.remove(["pendingAction", "transactionResult"]);
-        chrome.storage.onChanged.removeListener(storageListener);
+        detachApprovalListener();
       } else if (result?.status === "error") {
-        chrome.storage.onChanged.removeListener(storageListener);
+        detachApprovalListener();
 
         if (isSignAndExecute && senderTabId) {
           chrome.tabs
@@ -134,28 +144,23 @@ async function handleApprovePopup(
       }
     };
 
-    chrome.storage.onChanged.addListener(storageListener);
+    registeredListener = (changes: {
+      [key: string]: chrome.storage.StorageChange;
+    }) => {
+      clearTimeout(timeoutId);
+      coreListener(changes);
+    };
 
-    // Clean up after timeout (10 minutes)
-    const timeoutId = setTimeout(
+    timeoutId = setTimeout(
       () => {
-        chrome.storage.onChanged.removeListener(storageListener);
+        detachApprovalListener();
         chrome.storage.local.remove(["pendingAction", "transactionResult"]);
         log.warn("Transaction approval timed out", { action, senderTabId });
       },
       10 * 60 * 1000,
     );
 
-    // Store timeout ID so it can be cleared if transaction completes
-    const originalListener = storageListener;
-    const wrappedListener = (changes: {
-      [key: string]: chrome.storage.StorageChange;
-    }) => {
-      clearTimeout(timeoutId);
-      originalListener(changes);
-    };
-    chrome.storage.onChanged.removeListener(storageListener);
-    chrome.storage.onChanged.addListener(wrappedListener);
+    chrome.storage.onChanged.addListener(registeredListener);
 
     return true; // Keep message channel open for async response
   } catch (error) {


### PR DESCRIPTION
send rejection error message with `chrome.tabs` so it propagates backwards into dApp for handling