### PR TITLE
feat(localnet): backend plumbing

### DIFF
--- a/apps/extension/entrypoints/keeper/__tests__/keeper.lock.test.ts
+++ b/apps/extension/entrypoints/keeper/__tests__/keeper.lock.test.ts
@@ -11,7 +11,7 @@ describe("Keeper CLEAR_EPHKEY message handler", () => {
   let mockEphemeralKey: Ed25519Keypair | null;
   let mockVaultUnlocked: boolean;
   let mockVaultUnlockExpiry: number | null;
-  let mockZkProofs: Record<SuiChain, ZkProofResponse | null>;
+  let mockZkProofs: Partial<Record<SuiChain, ZkProofResponse | null>>;
   let mockSendResponse: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
@@ -23,7 +23,6 @@ describe("Keeper CLEAR_EPHKEY message handler", () => {
       "sui:devnet": { data: undefined, error: undefined } as ZkProofResponse,
       "sui:testnet": { data: undefined, error: undefined } as ZkProofResponse,
       "sui:mainnet": { data: undefined, error: undefined } as ZkProofResponse,
-      "sui:localnet": { data: undefined, error: undefined } as ZkProofResponse,
     };
     mockSendResponse = vi.fn();
   });
@@ -91,7 +90,6 @@ describe("Keeper CLEAR_EPHKEY message handler", () => {
     expect(mockZkProofs["sui:devnet"]).not.toBeNull();
     expect(mockZkProofs["sui:testnet"]).not.toBeNull();
     expect(mockZkProofs["sui:mainnet"]).not.toBeNull();
-    expect(mockZkProofs["sui:localnet"]).not.toBeNull();
 
     simulateClearEphKeyHandler({
       target: "KEEPER",
@@ -102,7 +100,6 @@ describe("Keeper CLEAR_EPHKEY message handler", () => {
     expect(mockZkProofs["sui:devnet"]).not.toBeNull();
     expect(mockZkProofs["sui:testnet"]).not.toBeNull();
     expect(mockZkProofs["sui:mainnet"]).not.toBeNull();
-    expect(mockZkProofs["sui:localnet"]).not.toBeNull();
   });
 
   it("sends { ok: true } response when CLEAR_EPHKEY succeeds", () => {

--- a/apps/extension/entrypoints/keeper/keeper.ts
+++ b/apps/extension/entrypoints/keeper/keeper.ts
@@ -14,6 +14,12 @@ import type { IntentScope } from "@mysten/sui/cryptography";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import type { SuiChain } from "@mysten/wallet-standard";
 import type { BackgroundMessage } from "../../src/lib/background/types";
+import {
+  type LocalnetState,
+  localnetGetAddress,
+  localnetSetKeypair,
+  localnetSign,
+} from "./local";
 
 /**
  * Keeper - Holds the ephemeral key in RAM-only memory
@@ -23,6 +29,9 @@ import type { BackgroundMessage } from "../../src/lib/background/types";
 
 // RAM-only storage for the ephemeral key
 let ephemeralKey: Ed25519Keypair | null = null;
+
+// RAM-only storage for the localnet dev keypair
+const localnetState: LocalnetState = { localnetKey: null };
 
 // Rotation re-encrypts the new ephemeral secret key without requiring the user
 // to re-enter their PIN. We derive a non-extractable CryptoKey at unlock time.
@@ -34,10 +43,9 @@ let sessionSalt: string | null = null; // base64 PBKDF2 salt from the stored Has
 let _vaultUnlocked = false;
 let _vaultUnlockExpiry: number | null = null;
 // RAM-only storage for zkProofs (chain-specific)
-let zkProofs: Record<SuiChain, ZkProofResponse | null> = {
+let zkProofs: Partial<Record<SuiChain, ZkProofResponse | null>> = {
   "sui:devnet": null,
   "sui:testnet": null,
-  "sui:localnet": null,
   "sui:mainnet": null,
 };
 
@@ -343,11 +351,26 @@ chrome.runtime.onMessage.addListener(
       zkProofs = {
         "sui:devnet": null,
         "sui:testnet": null,
-        "sui:localnet": null,
         "sui:mainnet": null,
       };
       sendResponse({ ok: true });
       return false;
+    }
+
+    // Localnet dev methods
+    if (message.type === KeeperMessageTypes.LOCALNET_SET_KEYPAIR) {
+      localnetSetKeypair(localnetState, message, sendResponse);
+      return true;
+    }
+
+    if (message.type === KeeperMessageTypes.LOCALNET_GET_ADDRESS) {
+      localnetGetAddress(localnetState, sendResponse);
+      return false;
+    }
+
+    if (message.type === KeeperMessageTypes.LOCALNET_SIGN) {
+      localnetSign(localnetState, message, sendResponse);
+      return true;
     }
 
     // Unknown message type

--- a/apps/extension/entrypoints/keeper/local.ts
+++ b/apps/extension/entrypoints/keeper/local.ts
@@ -1,0 +1,107 @@
+import { ephSign } from "@evevault/shared";
+import type { IntentScope } from "@mysten/sui/cryptography";
+import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
+import type { BackgroundMessage } from "../../src/lib/background/types";
+
+type LocalnetState = {
+  localnetKey: Ed25519Keypair | null;
+};
+
+const localnetSetKeypair = async (
+  state: LocalnetState,
+  message: BackgroundMessage,
+  sendResponse: (response: {
+    ok: boolean;
+    address?: string;
+    error?: string;
+  }) => void,
+) => {
+  try {
+    const { privateKey } = message as { privateKey?: string };
+
+    if (!privateKey) {
+      sendResponse({ ok: false, error: "privateKey required" });
+      return;
+    }
+
+    // suiprivkey1... (Bech32): SDK handles this directly
+    if (privateKey.startsWith("suiprivkey")) {
+      state.localnetKey = Ed25519Keypair.fromSecretKey(privateKey);
+    } else {
+      throw new Error("Invalid private key");
+    }
+
+    sendResponse({
+      ok: true,
+      address: state.localnetKey.getPublicKey().toSuiAddress(),
+    });
+  } catch (error) {
+    sendResponse({
+      ok: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+};
+
+const localnetGetAddress = (
+  state: LocalnetState,
+  sendResponse: (response: {
+    ok: boolean;
+    address?: string | null;
+    error?: string;
+  }) => void,
+) => {
+  if (!state.localnetKey) {
+    sendResponse({ ok: true, address: null });
+  } else {
+    sendResponse({
+      ok: true,
+      address: state.localnetKey.getPublicKey().toSuiAddress(),
+    });
+  }
+};
+
+const localnetSign = async (
+  state: LocalnetState,
+  message: BackgroundMessage,
+  sendResponse: (response: {
+    ok: boolean;
+    bytes?: string;
+    signature?: string;
+    error?: string;
+  }) => void,
+) => {
+  const key = state.localnetKey;
+  if (!key) {
+    sendResponse({ ok: false, error: "No localnet keypair loaded" });
+    return;
+  }
+
+  try {
+    const { msgBytes, scope, suiAddress } = message as {
+      msgBytes: number[];
+      scope: IntentScope;
+      suiAddress: string;
+    };
+
+    const messageBytes = new Uint8Array(msgBytes);
+    const result = await ephSign(messageBytes, scope, {
+      sui_address: suiAddress,
+      ephemeralKeyPair: key,
+    });
+
+    sendResponse({
+      ok: true,
+      bytes: result.bytes,
+      signature: result.userSignature,
+    });
+  } catch (error) {
+    sendResponse({
+      ok: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+};
+
+export type { LocalnetState };
+export { localnetSetKeypair, localnetGetAddress, localnetSign };

--- a/apps/extension/src/lib/background/handlers/__tests__/localVaultHandlers.test.ts
+++ b/apps/extension/src/lib/background/handlers/__tests__/localVaultHandlers.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { VaultMessage } from "../../types";
+import {
+  _handleLocalnetGetAddress,
+  _handleLocalnetSetKeypair,
+  _handleLocalnetSignBytes,
+} from "../localVaultHandlers";
+
+const { mockSendToKeeper } = vi.hoisted(() => ({
+  mockSendToKeeper: vi.fn(),
+}));
+
+vi.mock("../vaultHandlers", () => ({
+  sendToKeeper: mockSendToKeeper,
+}));
+
+vi.mock("@evevault/shared", () => ({
+  LOCALNET_STORAGE_KEY: "evevault:localnet-key",
+}));
+
+vi.mock("@evevault/shared/types", () => ({
+  KeeperMessageTypes: {
+    LOCALNET_SET_KEYPAIR: "LOCALNET_SET_KEYPAIR",
+    LOCALNET_GET_ADDRESS: "LOCALNET_GET_ADDRESS",
+    LOCALNET_SIGN: "LOCALNET_SIGN",
+  },
+}));
+
+const mockSender = {} as chrome.runtime.MessageSender;
+
+function makeMessage(overrides: Partial<VaultMessage> = {}): VaultMessage {
+  return {
+    type: "LOCALNET_SET_KEYPAIR",
+    ...overrides,
+  } as unknown as VaultMessage;
+}
+
+function installChromeMock() {
+  globalThis.chrome = {
+    storage: {
+      local: {
+        set: vi.fn(),
+        remove: vi.fn(),
+      },
+    },
+  } as unknown as typeof chrome;
+}
+
+describe("_handleLocalnetSetKeypair", () => {
+  beforeEach(() => {
+    installChromeMock();
+    mockSendToKeeper.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("persists key and calls sendResponse when keeper returns ok", async () => {
+    mockSendToKeeper.mockResolvedValue({ ok: true, address: "0xabc" });
+    const sendResponse = vi.fn();
+    const message = makeMessage({
+      privateKey: "suiprivkey1abc",
+    } as Partial<VaultMessage>);
+
+    _handleLocalnetSetKeypair(message, mockSender, sendResponse);
+
+    // Wait for async IIFE
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockSendToKeeper).toHaveBeenCalledWith({
+      type: "LOCALNET_SET_KEYPAIR",
+      privateKey: "suiprivkey1abc",
+    });
+    expect(chrome.storage.local.set).toHaveBeenCalledWith({
+      "evevault:localnet-key": "suiprivkey1abc",
+    });
+    expect(sendResponse).toHaveBeenCalledWith({ ok: true, address: "0xabc" });
+  });
+
+  it("does not persist key when keeper returns an error", async () => {
+    mockSendToKeeper.mockResolvedValue({ ok: false, error: "Invalid key" });
+    const sendResponse = vi.fn();
+    const message = makeMessage({
+      privateKey: "badkey",
+    } as Partial<VaultMessage>);
+
+    _handleLocalnetSetKeypair(message, mockSender, sendResponse);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+    expect(sendResponse).toHaveBeenCalledWith({
+      ok: false,
+      error: "Invalid key",
+    });
+  });
+
+  it("calls sendResponse with error when sendToKeeper throws", async () => {
+    mockSendToKeeper.mockRejectedValue(new Error("Keeper unavailable"));
+    const sendResponse = vi.fn();
+    const message = makeMessage({
+      privateKey: "suiprivkey1abc",
+    } as Partial<VaultMessage>);
+
+    _handleLocalnetSetKeypair(message, mockSender, sendResponse);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+    expect(sendResponse).toHaveBeenCalledWith({
+      ok: false,
+      error: "Keeper unavailable",
+    });
+  });
+
+  it("returns true (async channel indicator)", () => {
+    mockSendToKeeper.mockResolvedValue({ ok: true, address: "0xabc" });
+    const result = _handleLocalnetSetKeypair(
+      makeMessage(),
+      mockSender,
+      vi.fn(),
+    );
+    expect(result).toBe(true);
+  });
+});
+
+describe("_handleLocalnetGetAddress", () => {
+  beforeEach(() => {
+    installChromeMock();
+    mockSendToKeeper.mockReset();
+  });
+
+  it("calls sendResponse with keeper address on success", async () => {
+    mockSendToKeeper.mockResolvedValue({ ok: true, address: "0xdef" });
+    const sendResponse = vi.fn();
+
+    await _handleLocalnetGetAddress(makeMessage(), mockSender, sendResponse);
+
+    expect(sendResponse).toHaveBeenCalledWith({ ok: true, address: "0xdef" });
+  });
+
+  it("calls sendResponse with null address when no keypair loaded", async () => {
+    mockSendToKeeper.mockResolvedValue({ ok: true, address: null });
+    const sendResponse = vi.fn();
+
+    await _handleLocalnetGetAddress(makeMessage(), mockSender, sendResponse);
+
+    expect(sendResponse).toHaveBeenCalledWith({ ok: true, address: null });
+  });
+
+  it("calls sendResponse with error shape when sendToKeeper throws", async () => {
+    mockSendToKeeper.mockRejectedValue(new Error("Keeper error"));
+    const sendResponse = vi.fn();
+
+    await _handleLocalnetGetAddress(makeMessage(), mockSender, sendResponse);
+
+    expect(sendResponse).toHaveBeenCalledWith({ ok: false, address: null });
+  });
+});
+
+describe("_handleLocalnetSignBytes", () => {
+  beforeEach(() => {
+    installChromeMock();
+    mockSendToKeeper.mockReset();
+  });
+
+  it("calls sendResponse with bytes and signature on success", async () => {
+    mockSendToKeeper.mockResolvedValue({
+      ok: true,
+      bytes: "base64bytes",
+      signature: "base64sig",
+    });
+    const sendResponse = vi.fn();
+    const message = makeMessage({
+      msgBytes: [1, 2, 3],
+      scope: "TransactionData",
+      suiAddress: "0xabc",
+    } as Partial<VaultMessage>);
+
+    await _handleLocalnetSignBytes(message, mockSender, sendResponse);
+
+    expect(sendResponse).toHaveBeenCalledWith({
+      ok: true,
+      bytes: "base64bytes",
+      signature: "base64sig",
+    });
+  });
+
+  it("converts Uint8Array msgBytes to plain array before sending to keeper", async () => {
+    mockSendToKeeper.mockResolvedValue({
+      ok: true,
+      bytes: "b",
+      signature: "s",
+    });
+    const message = makeMessage({
+      msgBytes: new Uint8Array([10, 20, 30]) as unknown as number[],
+      scope: "TransactionData",
+      suiAddress: "0xabc",
+    } as Partial<VaultMessage>);
+
+    await _handleLocalnetSignBytes(message, mockSender, vi.fn());
+
+    const calledWith = mockSendToKeeper.mock.calls[0][0];
+    expect(calledWith.msgBytes).toEqual([10, 20, 30]);
+  });
+
+  it("calls sendResponse with error when keeper returns ok: false", async () => {
+    mockSendToKeeper.mockResolvedValue({
+      ok: false,
+      error: "No keypair loaded",
+    });
+    const sendResponse = vi.fn();
+    const message = makeMessage({
+      msgBytes: [1, 2, 3],
+      scope: "TransactionData",
+      suiAddress: "0xabc",
+    } as Partial<VaultMessage>);
+
+    await _handleLocalnetSignBytes(message, mockSender, sendResponse);
+
+    expect(sendResponse).toHaveBeenCalledWith({
+      ok: false,
+      error: "No keypair loaded",
+    });
+  });
+
+  it("calls sendResponse with error when sendToKeeper throws", async () => {
+    mockSendToKeeper.mockRejectedValue(new Error("Keeper crashed"));
+    const sendResponse = vi.fn();
+    const message = makeMessage({
+      msgBytes: [1, 2, 3],
+      scope: "TransactionData",
+      suiAddress: "0xabc",
+    } as Partial<VaultMessage>);
+
+    await _handleLocalnetSignBytes(message, mockSender, sendResponse);
+
+    expect(sendResponse).toHaveBeenCalledWith({
+      ok: false,
+      error: "Keeper crashed",
+    });
+  });
+});

--- a/apps/extension/src/lib/background/handlers/localVaultHandlers.ts
+++ b/apps/extension/src/lib/background/handlers/localVaultHandlers.ts
@@ -1,0 +1,93 @@
+import { LOCALNET_KEY_STORAGE_KEY } from "@evevault/shared";
+import { KeeperMessageTypes } from "@evevault/shared/types";
+
+import type { VaultMessage } from "../types";
+import { sendToKeeper } from "./vaultHandlers";
+
+// ─── Localnet dev signing ────────────────────────────────────────────────────
+
+export function _handleLocalnetSetKeypair(
+  message: VaultMessage,
+  _sender: chrome.runtime.MessageSender,
+  sendResponse: (response?: unknown) => void,
+): boolean {
+  (async () => {
+    try {
+      const response = await sendToKeeper({
+        type: KeeperMessageTypes.LOCALNET_SET_KEYPAIR,
+        privateKey: message.privateKey,
+      });
+      if (response?.ok) {
+        // Persist raw key in background storage so it survives keeper restarts
+        chrome.storage.local.set({
+          [LOCALNET_KEY_STORAGE_KEY]: message.privateKey ?? "",
+        });
+      }
+      sendResponse(response);
+    } catch (error) {
+      sendResponse({
+        ok: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
+  })();
+  return true;
+}
+
+export async function _handleLocalnetGetAddress(
+  _message: VaultMessage,
+  _sender: chrome.runtime.MessageSender,
+  sendResponse: (response?: unknown) => void,
+): Promise<boolean> {
+  try {
+    const response = await sendToKeeper({
+      type: KeeperMessageTypes.LOCALNET_GET_ADDRESS,
+    });
+    sendResponse(response);
+  } catch {
+    sendResponse({ ok: false, address: null });
+  }
+  return true;
+}
+
+export async function _handleLocalnetSignBytes(
+  message: VaultMessage,
+  _sender: chrome.runtime.MessageSender,
+  sendResponse: (response?: unknown) => void,
+): Promise<boolean> {
+  const { msgBytes, scope, suiAddress } = message;
+
+  try {
+    const response = await sendToKeeper({
+      type: KeeperMessageTypes.LOCALNET_SIGN,
+      msgBytes: Array.isArray(msgBytes)
+        ? msgBytes
+        : Array.from(
+            msgBytes instanceof Uint8Array
+              ? msgBytes
+              : Object.values(msgBytes as Record<number, number>),
+          ),
+      scope,
+      suiAddress,
+    });
+
+    if (response?.ok && response?.bytes && response?.signature) {
+      sendResponse({
+        ok: true,
+        bytes: response.bytes,
+        signature: response.signature,
+      });
+    } else {
+      sendResponse({
+        ok: false,
+        error: response?.error ?? "localnet sign failed",
+      });
+    }
+  } catch (error) {
+    sendResponse({
+      ok: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+  return true;
+}

--- a/apps/extension/src/lib/background/handlers/localVaultHandlers.ts
+++ b/apps/extension/src/lib/background/handlers/localVaultHandlers.ts
@@ -1,4 +1,4 @@
-import { LOCALNET_KEY_STORAGE_KEY } from "@evevault/shared";
+import { LOCALNET_STORAGE_KEY } from "@evevault/shared";
 import { KeeperMessageTypes } from "@evevault/shared/types";
 
 import type { VaultMessage } from "../types";
@@ -20,7 +20,7 @@ export function _handleLocalnetSetKeypair(
       if (response?.ok) {
         // Persist raw key in background storage so it survives keeper restarts
         chrome.storage.local.set({
-          [LOCALNET_KEY_STORAGE_KEY]: message.privateKey ?? "",
+          [LOCALNET_STORAGE_KEY]: message.privateKey ?? "",
         });
       }
       sendResponse(response);

--- a/apps/extension/src/lib/background/handlers/messageHandler.ts
+++ b/apps/extension/src/lib/background/handlers/messageHandler.ts
@@ -20,6 +20,9 @@ import {
   _handleCreateKeypair,
   _handleGetPublicKey,
   _handleGetZkProof,
+  _handleLocalnetGetAddress,
+  _handleLocalnetSetKeypair,
+  _handleLocalnetSignBytes,
   _handleRotateKeypair,
   _handleSetZkProof,
   _handleZkEphSignBytes,
@@ -130,6 +133,22 @@ export function handleMessage(
 
   if (message.type === VaultMessageTypes.CLEAR_ZKPROOF) {
     _handleClearZkProof(message, sender, sendResponse);
+    return true;
+  }
+
+  // Localnet dev signing
+  if (message.type === VaultMessageTypes.LOCALNET_SET_KEYPAIR) {
+    _handleLocalnetSetKeypair(message, sender, sendResponse);
+    return true;
+  }
+
+  if (message.type === VaultMessageTypes.LOCALNET_GET_ADDRESS) {
+    void _handleLocalnetGetAddress(message, sender, sendResponse);
+    return true;
+  }
+
+  if (message.type === VaultMessageTypes.LOCALNET_SIGN_BYTES) {
+    void _handleLocalnetSignBytes(message, sender, sendResponse);
     return true;
   }
 

--- a/apps/extension/src/lib/background/handlers/vaultHandlers.ts
+++ b/apps/extension/src/lib/background/handlers/vaultHandlers.ts
@@ -3,6 +3,12 @@ import { ensureOffscreen } from "../services/offscreenService";
 import type { VaultMessage } from "../types";
 import { checkPendingAuthAfterUnlock } from "./authHandlers";
 
+export {
+  _handleLocalnetGetAddress,
+  _handleLocalnetSetKeypair,
+  _handleLocalnetSignBytes,
+} from "./localVaultHandlers";
+
 const log = createLogger();
 
 /**
@@ -10,7 +16,7 @@ const log = createLogger();
  * Retries if the keeper isn't ready yet
  */
 // biome-ignore lint/suspicious/noExplicitAny: Keeper messages have dynamic types
-async function sendToKeeper(message: any, retries = 3): Promise<any> {
+export async function sendToKeeper(message: any, retries = 3): Promise<any> {
   await ensureOffscreen(true);
 
   return new Promise((resolve, reject) => {

--- a/apps/extension/src/lib/background/services/offscreenService.ts
+++ b/apps/extension/src/lib/background/services/offscreenService.ts
@@ -1,13 +1,13 @@
 /// <reference types="chrome"/>
 
-import { KeeperMessageTypes, LOCALNET_KEY_STORAGE_KEY } from "@evevault/shared";
+import { KeeperMessageTypes, LOCALNET_STORAGE_KEY } from "@evevault/shared";
 import { createLogger } from "@evevault/shared/utils";
 
 const log = createLogger();
 
 function restoreLocalnetKeyToKeeper(): void {
-  chrome.storage.local.get(LOCALNET_KEY_STORAGE_KEY, (result) => {
-    const raw = result[LOCALNET_KEY_STORAGE_KEY] as string | undefined;
+  chrome.storage.local.get(LOCALNET_STORAGE_KEY, (result) => {
+    const raw = result[LOCALNET_STORAGE_KEY] as string | undefined;
     if (!raw) return;
     const msg = {
       type: KeeperMessageTypes.LOCALNET_SET_KEYPAIR,

--- a/apps/extension/src/lib/background/services/offscreenService.ts
+++ b/apps/extension/src/lib/background/services/offscreenService.ts
@@ -24,7 +24,26 @@ function restoreLocalnetKeyToKeeper(): void {
       }
       if (response?.ok) {
         log.info("Keeper: restored localnet keypair", response.address);
+        return;
       }
+
+      const restoreError =
+        typeof response?.error === "string"
+          ? response.error
+          : "Keeper rejected stored localnet key";
+
+      log.warn("Failed to restore localnet key to keeper", restoreError);
+
+      chrome.storage.local.remove(LOCALNET_STORAGE_KEY, () => {
+        if (chrome.runtime.lastError) {
+          log.warn(
+            "Failed to remove invalid localnet key from storage",
+            chrome.runtime.lastError.message,
+          );
+          return;
+        }
+        log.info("Removed invalid localnet key from storage");
+      });
     });
   });
 }

--- a/apps/extension/src/lib/background/services/offscreenService.ts
+++ b/apps/extension/src/lib/background/services/offscreenService.ts
@@ -1,14 +1,40 @@
 /// <reference types="chrome"/>
 
+import { KeeperMessageTypes, LOCALNET_KEY_STORAGE_KEY } from "@evevault/shared";
 import { createLogger } from "@evevault/shared/utils";
 
 const log = createLogger();
+
+function restoreLocalnetKeyToKeeper(): void {
+  chrome.storage.local.get(LOCALNET_KEY_STORAGE_KEY, (result) => {
+    const raw = result[LOCALNET_KEY_STORAGE_KEY] as string | undefined;
+    if (!raw) return;
+    const msg = {
+      type: KeeperMessageTypes.LOCALNET_SET_KEYPAIR,
+      privateKey: raw,
+      target: "KEEPER",
+    };
+    chrome.runtime.sendMessage(msg, (response) => {
+      if (chrome.runtime.lastError) {
+        log.warn(
+          "Failed to restore localnet key to keeper",
+          chrome.runtime.lastError.message,
+        );
+        return;
+      }
+      if (response?.ok) {
+        log.info("Keeper: restored localnet keypair", response.address);
+      }
+    });
+  });
+}
 
 let keeperReady = false;
 const keeperReadyPromise = new Promise<void>((resolve) => {
   chrome.runtime.onMessage.addListener((message) => {
     if (message.type === "KEEPER_READY") {
       keeperReady = true;
+      restoreLocalnetKeyToKeeper();
       resolve();
     }
     return false;

--- a/packages/shared/src/services/keeperService.ts
+++ b/packages/shared/src/services/keeperService.ts
@@ -209,3 +209,36 @@ export const zkProofService = {
     }
   },
 };
+
+/**
+ * Extension-only: manages a persistent dev keypair for localnet signing.
+ * The keypair lives in keeper RAM; the encrypted secret is stored in chrome.storage.local.
+ * Only available in extension context — never used on the web app path.
+ */
+export const localnetKeyService = {
+  /**
+   * Loads a keypair into the keeper from a raw private key (suiprivkey1..., hex, or base64).
+   */
+  async setKeypairFromPrivateKey(
+    privateKey: string,
+  ): Promise<{ address: string }> {
+    const res = (await chrome.runtime?.sendMessage?.({
+      type: VaultMessageTypes.LOCALNET_SET_KEYPAIR,
+      privateKey,
+    })) as { ok?: boolean; address?: string; error?: string } | undefined;
+
+    if (!res?.ok || !res.address) {
+      throw new Error(res?.error ?? "Failed to set localnet keypair");
+    }
+    return { address: res.address };
+  },
+
+  /** Returns the Sui address for the currently loaded localnet keypair, or null if none set. */
+  async getAddress(): Promise<string | null> {
+    const res = (await chrome.runtime?.sendMessage?.({
+      type: VaultMessageTypes.LOCALNET_GET_ADDRESS,
+    })) as { ok?: boolean; address?: string } | undefined;
+
+    return res?.address ?? null;
+  },
+};

--- a/packages/shared/src/services/keeperService.ts
+++ b/packages/shared/src/services/keeperService.ts
@@ -210,14 +210,14 @@ export const zkProofService = {
   },
 };
 
-/**
- * Extension-only: manages a persistent dev keypair for localnet signing.
- * The keypair lives in keeper RAM; the encrypted secret is stored in chrome.storage.local.
- * Only available in extension context — never used on the web app path.
+/** Extension-only: manages a persistent dev keypair for localnet signing.
+ * The keypair lives in keeper RAM; the raw (unencrypted) private key is stored in
+ * chrome.storage.local for dev convenience across restarts. This is acceptable for
+ * localnet-dev use only — do not use for mainnet/testnet keys.
  */
 export const localnetKeyService = {
   /**
-   * Loads a keypair into the keeper from a raw private key (suiprivkey1..., hex, or base64).
+   * Loads a keypair into the keeper from a Bech32 private key (suiprivkey1...).
    */
   async setKeypairFromPrivateKey(
     privateKey: string,

--- a/packages/shared/src/services/vaultService.test.ts
+++ b/packages/shared/src/services/vaultService.test.ts
@@ -320,7 +320,9 @@ describe("zkProofService routing", () => {
       expect(webVaultService.clearZkProof).toHaveBeenCalledWith("sui:devnet");
       expect(webVaultService.clearZkProof).toHaveBeenCalledWith("sui:testnet");
       expect(webVaultService.clearZkProof).toHaveBeenCalledWith("sui:mainnet");
-      expect(webVaultService.clearZkProof).toHaveBeenCalledWith("sui:localnet");
+      expect(webVaultService.clearZkProof).not.toHaveBeenCalledWith(
+        "sui:localnet",
+      );
     });
   });
 

--- a/packages/shared/src/services/vaultService.ts
+++ b/packages/shared/src/services/vaultService.ts
@@ -6,6 +6,7 @@ import { createWebCryptoPlaceholder } from "../types/wallet";
 import { isWeb } from "../utils/environment";
 import {
   ephKeyService as keeperEphKeyService,
+  localnetKeyService as keeperLocalnetKeyService,
   zkProofService as keeperZkProofService,
 } from "./keeperService";
 import { webVaultService } from "./webVaultService";
@@ -219,11 +220,28 @@ export const zkProofService = {
       await webVaultService.clearZkProof("sui:devnet" as SuiChain);
       await webVaultService.clearZkProof("sui:testnet" as SuiChain);
       await webVaultService.clearZkProof("sui:mainnet" as SuiChain);
-      await webVaultService.clearZkProof("sui:localnet" as SuiChain);
       return;
     }
 
     // Extension: delegate to keeperService
     return keeperZkProofService.clear();
+  },
+};
+
+/**
+ * Extension-only: localnet dev keypair management.
+ * Throws at runtime if called from the web app (localnet is extension-only).
+ */
+export const localnetKeyService = {
+  async setKeypairFromPrivateKey(
+    privateKey: string,
+  ): Promise<{ address: string }> {
+    if (isWeb()) throw new Error("localnetKeyService is extension-only");
+    return keeperLocalnetKeyService.setKeypairFromPrivateKey(privateKey);
+  },
+
+  async getAddress(): Promise<string | null> {
+    if (isWeb()) throw new Error("localnetKeyService is extension-only");
+    return keeperLocalnetKeyService.getAddress();
   },
 };

--- a/packages/shared/src/stores/deviceStore/actions/initActions.ts
+++ b/packages/shared/src/stores/deviceStore/actions/initActions.ts
@@ -3,12 +3,15 @@ import type { SuiChain } from "@mysten/wallet-standard";
 import { clearAllZkLoginJwts } from "../../../auth/storageService";
 import { ephKeyService, zkProofService } from "../../../services/vaultService";
 import { getCurrentEpochFromGraphQL } from "../../../sui/graphqlEpoch";
+import { getCurrentEpochFromRpc } from "../../../sui/rpcEpoch";
 import type {
   DeviceState,
+  NetworkDataEntry,
   PersistedDeviceStore,
   PersistedDeviceStoreState,
   StoredSecretKey,
 } from "../../../types";
+import { isLocalnetChain } from "../../../types/networks";
 import { createWebCryptoPlaceholder } from "../../../types/wallet";
 import { isWeb } from "../../../utils/environment";
 import { createLogger } from "../../../utils/logger";
@@ -20,7 +23,72 @@ import type { GetDeviceState, SetDeviceState } from "./types";
 
 const log = createLogger();
 
+const emptyChainData = (): NetworkDataEntry => ({
+  maxEpoch: null,
+  maxEpochTimestampMs: null,
+  nonce: null,
+  jwtRandomness: null,
+});
+
 export function createInitActions(set: SetDeviceState, get: GetDeviceState) {
+  const setChainData = (chain: SuiChain, data: NetworkDataEntry) => {
+    set({
+      networkData: {
+        ...get().networkData,
+        [chain]: data,
+      },
+      error: null,
+    });
+  };
+
+  const initializeLocalnetChainData = async (chain: SuiChain) => {
+    const localnetUrl = useNetworkStore.getState().localnetUrl;
+    if (!localnetUrl) {
+      log.warn("Localnet URL not configured, skipping epoch fetch");
+      setChainData(chain, emptyChainData());
+      return;
+    }
+
+    try {
+      const { numericMaxEpoch, maxEpochTimestampMs } =
+        await getCurrentEpochFromRpc(localnetUrl);
+      setChainData(chain, {
+        maxEpoch: numericMaxEpoch.toString(),
+        maxEpochTimestampMs,
+        nonce: null,
+        jwtRandomness: null,
+      });
+    } catch (err) {
+      log.error("Failed to fetch localnet epoch", err);
+      // Non-fatal: store empty entry so we don't retry on every render
+      setChainData(chain, emptyChainData());
+    }
+  };
+
+  const initializeZkLoginChainData = async (chain: SuiChain) => {
+    const ephemeralPubkey = get().ephemeralPublicKey;
+    if (!ephemeralPubkey) {
+      throw new Error("Ephemeral public key not found");
+    }
+
+    const jwtRandomness = generateRandomness().toString();
+    const { numericMaxEpoch, maxEpochTimestampMs } =
+      await getCurrentEpochFromGraphQL(chain);
+
+    const nonce = generateNonce(
+      ephemeralPubkey,
+      numericMaxEpoch,
+      jwtRandomness,
+    );
+
+    setChainData(chain, {
+      maxEpoch: numericMaxEpoch.toString(),
+      maxEpochTimestampMs,
+      nonce,
+      jwtRandomness,
+    });
+  };
+
   return {
     initialize: async (pin: string) => {
       set({ loading: true });
@@ -246,33 +314,12 @@ export function createInitActions(set: SetDeviceState, get: GetDeviceState) {
     initializeForChain: async (chain: SuiChain) => {
       log.info("Generating device data for chain", { chain });
 
-      const ephemeralPubkey = get().ephemeralPublicKey;
-      if (!ephemeralPubkey) {
-        throw new Error("Ephemeral public key not found");
+      if (isLocalnetChain(chain)) {
+        await initializeLocalnetChainData(chain);
+        return;
       }
 
-      const jwtRandomness = generateRandomness().toString();
-      const { numericMaxEpoch, maxEpochTimestampMs } =
-        await getCurrentEpochFromGraphQL(chain);
-
-      const nonce = generateNonce(
-        ephemeralPubkey,
-        numericMaxEpoch,
-        jwtRandomness,
-      );
-
-      set({
-        networkData: {
-          ...get().networkData,
-          [chain]: {
-            maxEpoch: numericMaxEpoch.toString(),
-            maxEpochTimestampMs: maxEpochTimestampMs,
-            nonce: nonce,
-            jwtRandomness: jwtRandomness,
-          },
-        },
-        error: null,
-      });
+      await initializeZkLoginChainData(chain);
     },
 
     rotateEphemeralKey: async () => {

--- a/packages/shared/src/stores/deviceStore/actions/proofActions.ts
+++ b/packages/shared/src/stores/deviceStore/actions/proofActions.ts
@@ -3,6 +3,7 @@ import { getJwt } from "../../../auth/storageService";
 import { zkProofService } from "../../../services/vaultService";
 import type { DeviceState, ZkProofResponse } from "../../../types";
 import type { JwtResponse } from "../../../types/authTypes";
+import { isLocalnetChain } from "../../../types/networks";
 import { createLogger } from "../../../utils/logger";
 import { fetchZkProof } from "../../../wallet/zkProof";
 import { useNetworkStore } from "../../networkStore";
@@ -15,6 +16,10 @@ export function createProofActions(set: SetDeviceState, get: GetDeviceState) {
   return {
     getZkProof: async () => {
       const currentChain = useNetworkStore.getState().chain;
+      if (isLocalnetChain(currentChain)) {
+        return { error: "zkLogin proofs are not available on localnet" };
+      }
+
       const maxEpochExpiry = get().getMaxEpochTimestampMs(currentChain);
 
       if (maxEpochExpiry && Date.now().valueOf() < maxEpochExpiry) {

--- a/packages/shared/src/stores/networkStore.ts
+++ b/packages/shared/src/stores/networkStore.ts
@@ -90,7 +90,16 @@ export const useNetworkStore = create<NetworkState>()(
         const switchToLocalnetChain = (): NetworkSwitchResult => {
           // Localnet: no JWT or zkLogin needed — direct Ed25519 signing.
           // Don't fetch epoch here: the RPC URL may not be configured yet.
-          set({ chain });
+          set({ chain, loading: false });
+
+          if (isExtension()) {
+            chrome.runtime?.sendMessage?.({
+              __from: "Eve Vault",
+              event: "change",
+              payload: { chains: [chain] },
+            });
+          }
+
           log.info("Switched to localnet");
           return { success: true, requiresReauth: false };
         };

--- a/packages/shared/src/stores/networkStore.ts
+++ b/packages/shared/src/stores/networkStore.ts
@@ -4,6 +4,7 @@ import { createJSONStorage, persist } from "zustand/middleware";
 import { chromeStorageAdapter, localStorageAdapter } from "../adapters";
 import { hasJwt, useAuthStore } from "../auth";
 import type { NetworkState, NetworkSwitchResult } from "../types";
+import { isLocalnetChain } from "../types/networks";
 import { createLogger, isExtension, isWeb } from "../utils";
 import { NETWORK_STORAGE_KEY } from "../utils/storageKeys";
 import { useDeviceStore } from "./deviceStore";
@@ -38,6 +39,8 @@ export const useNetworkStore = create<NetworkState>()(
     (set, get) => ({
       chain: getInitialChain(),
       loading: false,
+      localnetUrl: "http://127.0.0.1:9000",
+      setLocalnetUrl: (url: string) => set({ localnetUrl: url }),
 
       initialize: async () => {
         // Note: persist middleware already hydrates state from storage
@@ -54,6 +57,10 @@ export const useNetworkStore = create<NetworkState>()(
 
         // Same chain - no switch needed
         if (currentChain === chain) {
+          return { requiresReauth: false };
+        }
+
+        if (isLocalnetChain(chain)) {
           return { requiresReauth: false };
         }
 
@@ -80,6 +87,82 @@ export const useNetworkStore = create<NetworkState>()(
       setChain: async (chain: SuiChain): Promise<NetworkSwitchResult> => {
         const currentChain = get().chain;
 
+        const switchToLocalnetChain = (): NetworkSwitchResult => {
+          // Localnet: no JWT or zkLogin needed — direct Ed25519 signing.
+          // Don't fetch epoch here: the RPC URL may not be configured yet.
+          set({ chain });
+          log.info("Switched to localnet");
+          return { success: true, requiresReauth: false };
+        };
+
+        const switchToZkLoginChain = async (): Promise<NetworkSwitchResult> => {
+          const jwtExists = await hasJwt();
+
+          // Switch network state immediately (even if no JWT)
+          set({ chain, loading: true });
+
+          if (!jwtExists) {
+            // No JWT for target network - requires re-authentication
+            try {
+              await useAuthStore.getState().initialize();
+            } catch (error) {
+              log.error(
+                "Failed to initialize auth store after network switch",
+                error,
+              );
+            }
+
+            // Pre-initialize zkLogin device data for vendJwt after login.
+            try {
+              await useDeviceStore.getState().initializeForChain(chain);
+            } catch (error) {
+              // May fail if ephemeral key is not yet loaded (e.g. vault locked); login flow will retry.
+              log.warn(
+                "Could not pre-initialize device data for chain during network switch",
+                { chain, error },
+              );
+            }
+
+            set({ loading: false });
+            log.info("Switched to zkLogin chain (re-authentication required)", {
+              chain,
+            });
+            return { success: true, requiresReauth: true };
+          }
+
+          try {
+            // Notify extension about network change
+            if (isExtension()) {
+              chrome.runtime?.sendMessage?.({
+                __from: "Eve Vault",
+                event: "change",
+                payload: { chains: [chain] },
+              });
+            }
+
+            // Ensure zkLogin device data is present and valid for the new chain.
+            const deviceStore = useDeviceStore.getState();
+            const networkData = deviceStore.networkData[chain];
+            const isExpired =
+              networkData?.maxEpochTimestampMs != null &&
+              Date.now() >= networkData.maxEpochTimestampMs;
+            const needsInit =
+              !networkData?.maxEpoch || isExpired || !networkData?.nonce;
+            if (needsInit) {
+              await deviceStore.initializeForChain(chain);
+            }
+
+            set({ loading: false });
+            log.info("Successfully switched to zkLogin chain", { chain });
+            return { success: true, requiresReauth: false };
+          } catch (error) {
+            log.error("Failed to complete network switch", error);
+            set({ loading: false });
+            set({ chain: currentChain });
+            return { success: false, requiresReauth: false };
+          }
+        };
+
         // Same chain - no switch needed
         if (currentChain === chain) {
           return { success: true, requiresReauth: false };
@@ -87,75 +170,11 @@ export const useNetworkStore = create<NetworkState>()(
 
         log.info("Setting chain", { from: currentChain, to: chain });
 
-        // Check if we have a JWT
-        const jwtExists = await hasJwt();
-
-        // Switch network state immediately (even if no JWT)
-        set({ chain, loading: true });
-
-        if (!jwtExists) {
-          // No JWT for target network - requires re-authentication
-          // Re-initialize auth store to check JWT for new network
-          // This will automatically set user to null if no JWT exists
-          try {
-            await useAuthStore.getState().initialize();
-          } catch (error) {
-            log.error(
-              "Failed to initialize auth store after network switch",
-              error,
-            );
-          }
-
-          // Pre-initialize device data for the new chain so it's ready for vendJwt after login.
-          try {
-            await useDeviceStore.getState().initializeForChain(chain);
-          } catch (error) {
-            // May fail if ephemeral key is not yet loaded (e.g. vault locked); login flow will retry.
-            log.warn(
-              "Could not pre-initialize device data for chain during network switch",
-              { chain, error },
-            );
-          }
-
-          set({ loading: false });
-          log.info("Switched to chain (no JWT, re-authentication required)", {
-            chain,
-          });
-          return { success: true, requiresReauth: true };
+        if (isLocalnetChain(chain)) {
+          return switchToLocalnetChain();
         }
 
-        // We have a JWT - proceed with seamless switch
-
-        try {
-          // Notify extension about network change
-          if (isExtension()) {
-            chrome.runtime?.sendMessage?.({
-              __from: "Eve Vault",
-              event: "change",
-              payload: { chains: [chain] },
-            });
-          }
-
-          // Ensure device data is present and valid for the new chain.
-          const deviceStore = useDeviceStore.getState();
-          const networkData = deviceStore.networkData[chain];
-          const isExpired =
-            networkData?.maxEpochTimestampMs != null &&
-            Date.now() >= networkData.maxEpochTimestampMs;
-          if (!networkData?.nonce || !networkData?.maxEpoch || isExpired) {
-            await deviceStore.initializeForChain(chain);
-          }
-
-          set({ loading: false });
-          log.info("Successfully switched to chain", { chain });
-          return { success: true, requiresReauth: false };
-        } catch (error) {
-          log.error("Failed to complete network switch", error);
-          set({ loading: false });
-          // Revert to previous chain on error
-          set({ chain: currentChain });
-          return { success: false, requiresReauth: false };
-        }
+        return switchToZkLoginChain();
       },
     }),
     {
@@ -163,7 +182,10 @@ export const useNetworkStore = create<NetworkState>()(
       storage: createJSONStorage(() =>
         isWeb() ? localStorageAdapter : chromeStorageAdapter,
       ),
-      partialize: (state) => ({ chain: state.chain }),
+      partialize: (state) => ({
+        chain: state.chain,
+        localnetUrl: state.localnetUrl,
+      }),
     },
   ),
 );

--- a/packages/shared/src/sui/index.ts
+++ b/packages/shared/src/sui/index.ts
@@ -1,4 +1,5 @@
 export * from "./graphqlClient";
 export { getCurrentEpochFromGraphQL } from "./graphqlEpoch";
 export * from "./networks";
+export { getCurrentEpochFromRpc } from "./rpcEpoch";
 export * from "./suiClient";

--- a/packages/shared/src/sui/rpcEpoch.ts
+++ b/packages/shared/src/sui/rpcEpoch.ts
@@ -1,0 +1,33 @@
+import { SUI_LOCALNET_CHAIN } from "@mysten/wallet-standard";
+import { DEFAULT_EPOCH_DURATION_MS } from "../utils/constants";
+import { createLogger } from "../utils/logger";
+import { createSuiClient } from "./suiClient";
+
+const log = createLogger();
+
+/**
+ * Fetches current epoch via GRPC for localnet.
+ * Returns the same shape as getCurrentEpochFromGraphQL so callers are interchangeable.
+ */
+export async function getCurrentEpochFromRpc(fullnodeUrl: string): Promise<{
+  numericMaxEpoch: number;
+  maxEpochTimestampMs: number;
+}> {
+  const client = createSuiClient(SUI_LOCALNET_CHAIN, fullnodeUrl);
+
+  const epochResponse = await client.ledgerService
+    .getEpoch({})
+    .response.then((response) => response.epoch);
+
+  const epoch = Number(epochResponse?.epoch ?? 0);
+
+  const startMs = Number(epochResponse?.start ?? 0);
+  const durationMs = Number(DEFAULT_EPOCH_DURATION_MS);
+
+  log.debug("Fetched epoch via gRPC", { epoch, startMs, durationMs });
+
+  return {
+    numericMaxEpoch: epoch,
+    maxEpochTimestampMs: startMs + durationMs,
+  };
+}

--- a/packages/shared/src/sui/suiClient.ts
+++ b/packages/shared/src/sui/suiClient.ts
@@ -1,10 +1,19 @@
 import { SuiGrpcClient } from "@mysten/sui/grpc";
-import { SUI_TESTNET_CHAIN, type SuiChain } from "@mysten/wallet-standard";
+import {
+  SUI_LOCALNET_CHAIN,
+  SUI_TESTNET_CHAIN,
+  type SuiChain,
+} from "@mysten/wallet-standard";
 import { NETWORKS } from "./networks";
 
-/** Creates a Sui gRPC client for the specified network. Default matches useNetworkStore.getInitialChain(). */
+/**
+ * Creates a Sui gRPC client for the specified network.
+ * For localnet, pass localnetUrl explicitly (stored in network store); the static
+ * NETWORKS.localnet entry has no URL since it is user-configured.
+ */
 export const createSuiClient = (
   network: SuiChain = SUI_TESTNET_CHAIN,
+  localnetUrl?: string,
 ): SuiGrpcClient => {
   const chainName = network.replace("sui:", "") as
     | "mainnet"
@@ -12,10 +21,13 @@ export const createSuiClient = (
     | "devnet"
     | "localnet";
 
-  const networkInfo = NETWORKS[chainName];
+  const baseUrl =
+    network === SUI_LOCALNET_CHAIN
+      ? (localnetUrl ?? NETWORKS.localnet.fullnodeUrl)
+      : NETWORKS[chainName].fullnodeUrl;
 
   return new SuiGrpcClient({
     network: chainName,
-    baseUrl: networkInfo.fullnodeUrl,
+    baseUrl,
   });
 };

--- a/packages/shared/src/sui/suiClient.ts
+++ b/packages/shared/src/sui/suiClient.ts
@@ -23,7 +23,15 @@ export const createSuiClient = (
 
   const baseUrl =
     network === SUI_LOCALNET_CHAIN
-      ? (localnetUrl ?? NETWORKS.localnet.fullnodeUrl)
+      ? (() => {
+          const configuredUrl = localnetUrl?.trim();
+          if (!configuredUrl) {
+            throw new Error(
+              "createSuiClient requires a non-empty localnetUrl when using SUI_LOCALNET_CHAIN.",
+            );
+          }
+          return configuredUrl;
+        })()
       : NETWORKS[chainName].fullnodeUrl;
 
   return new SuiGrpcClient({

--- a/packages/shared/src/types/messages.ts
+++ b/packages/shared/src/types/messages.ts
@@ -27,6 +27,10 @@ export enum VaultMessageTypes {
   SET_ZKPROOF = "SET_ZKPROOF",
   GET_ZKPROOF = "GET_ZKPROOF",
   CLEAR_ZKPROOF = "CLEAR_ZKPROOF",
+  // Localnet dev-only: persistent keypair management and direct signing
+  LOCALNET_SET_KEYPAIR = "LOCALNET_SET_KEYPAIR",
+  LOCALNET_GET_ADDRESS = "LOCALNET_GET_ADDRESS",
+  LOCALNET_SIGN_BYTES = "LOCALNET_SIGN_BYTES",
 }
 
 export enum WalletStandardMessageTypes {
@@ -47,6 +51,10 @@ export enum KeeperMessageTypes {
   SET_ZKPROOF = "KEEPER_SET_ZKPROOF",
   GET_ZKPROOF = "KEEPER_GET_ZKPROOF",
   CLEAR_ZKPROOF = "KEEPER_CLEAR_ZKPROOF",
+  // Localnet dev-only
+  LOCALNET_SET_KEYPAIR = "KEEPER_LOCALNET_SET_KEYPAIR",
+  LOCALNET_GET_ADDRESS = "KEEPER_LOCALNET_GET_ADDRESS",
+  LOCALNET_SIGN = "KEEPER_LOCALNET_SIGN",
 }
 
 // Response type for vault/keeper message handlers

--- a/packages/shared/src/types/networks.ts
+++ b/packages/shared/src/types/networks.ts
@@ -8,8 +8,6 @@ import {
 import { SUI_COIN_TYPE } from "../utils/constants";
 import { getEveCoinType } from "../wallet/eveToken";
 
-export { SUI_LOCALNET_CHAIN };
-
 export function isLocalnetChain(chain: SuiChain | string | null | undefined) {
   return chain === SUI_LOCALNET_CHAIN;
 }

--- a/packages/shared/src/types/networks.ts
+++ b/packages/shared/src/types/networks.ts
@@ -1,11 +1,22 @@
 import { TenantId } from "@evefrontier/dapp-kit/utils";
 import {
   SUI_DEVNET_CHAIN,
+  SUI_LOCALNET_CHAIN,
   SUI_TESTNET_CHAIN,
   type SuiChain,
 } from "@mysten/wallet-standard";
 import { SUI_COIN_TYPE } from "../utils/constants";
 import { getEveCoinType } from "../wallet/eveToken";
+
+export { SUI_LOCALNET_CHAIN };
+
+export function isLocalnetChain(chain: SuiChain | string | null | undefined) {
+  return chain === SUI_LOCALNET_CHAIN;
+}
+
+export function isZkLoginChain(chain: SuiChain | string | null | undefined) {
+  return !!chain && !isLocalnetChain(chain);
+}
 
 export interface NetworkOption {
   chain: SuiChain;
@@ -18,6 +29,24 @@ export const AVAILABLE_NETWORKS: NetworkOption[] = [
   { chain: SUI_DEVNET_CHAIN, label: "Devnet", shortLabel: "DEV" },
   // Mainnet will be added later as a feature flag
 ];
+
+/**
+ * Returns the network list for the selector.
+ * Localnet is appended only when dev mode is enabled AND running in extension context,
+ * since localnet signing bypasses zkLogin and is not appropriate for the web app.
+ */
+export function getAvailableNetworks(
+  devMode: boolean,
+  isExt: boolean,
+): NetworkOption[] {
+  if (devMode && isExt) {
+    return [
+      ...AVAILABLE_NETWORKS,
+      { chain: SUI_LOCALNET_CHAIN, label: "Localnet", shortLabel: "LOCAL" },
+    ];
+  }
+  return AVAILABLE_NETWORKS;
+}
 
 /**
  * Get the display label for a given SuiChain

--- a/packages/shared/src/types/stores.ts
+++ b/packages/shared/src/types/stores.ts
@@ -72,6 +72,9 @@ export interface NetworkSwitchResult {
 export interface NetworkState {
   chain: SuiChain;
   loading: boolean;
+  /** Custom fullnode URL for localnet (extension dev mode only). */
+  localnetUrl: string;
+  setLocalnetUrl: (url: string) => void;
   initialize: () => Promise<void>;
   setChain: (chain: SuiChain) => Promise<NetworkSwitchResult>;
   /** Force set chain without JWT check - for logout-based network switching */

--- a/packages/shared/src/utils/routes.ts
+++ b/packages/shared/src/utils/routes.ts
@@ -24,6 +24,7 @@ export const EXTENSION_ROUTES = {
   ADD_TOKEN: "/add-token",
   SEND_TOKEN: "/send-token",
   TRANSACTIONS: "/transactions",
+  LOCALNET_SETTINGS: "/localnet-settings",
 } as const;
 
 /**

--- a/packages/shared/src/utils/storageKeys.ts
+++ b/packages/shared/src/utils/storageKeys.ts
@@ -5,7 +5,7 @@ export const NETWORK_STORAGE_KEY = "evevault:network";
 export const TOKENLIST_STORAGE_KEY = "evevault:tokenlist";
 export const JWT_STORAGE_KEY = "evevault:jwt";
 export const TENANT_STORAGE_KEY = "evevault:tenant";
-/** Extension-only: encrypted localnet keypair for dev/localnet signing. */
+/** Extension-only: raw localnet keypair for dev/localnet signing (extension-dev use only, not encrypted at rest). */
 export const LOCALNET_STORAGE_KEY = "evevault:localnet-key";
 
 /** Persist keys used by Zustand and auth (localStorage / chrome.storage.local). Cleared on reset. */

--- a/packages/shared/src/utils/storageKeys.ts
+++ b/packages/shared/src/utils/storageKeys.ts
@@ -6,7 +6,7 @@ export const TOKENLIST_STORAGE_KEY = "evevault:tokenlist";
 export const JWT_STORAGE_KEY = "evevault:jwt";
 export const TENANT_STORAGE_KEY = "evevault:tenant";
 /** Extension-only: encrypted localnet keypair for dev/localnet signing. */
-export const LOCALNET_KEY_STORAGE_KEY = "evevault:localnet-key";
+export const LOCALNET_STORAGE_KEY = "evevault:localnet-key";
 
 /** Persist keys used by Zustand and auth (localStorage / chrome.storage.local). Cleared on reset. */
 export const EVEVAULT_STORAGE_KEYS = [
@@ -16,7 +16,7 @@ export const EVEVAULT_STORAGE_KEYS = [
   TOKENLIST_STORAGE_KEY,
   JWT_STORAGE_KEY,
   TENANT_STORAGE_KEY,
-  LOCALNET_KEY_STORAGE_KEY,
+  LOCALNET_STORAGE_KEY,
 ] as const;
 
 /** Extension-only chrome.storage.local keys cleared on reset (not covered by cleanupExtensionStorage). */

--- a/packages/shared/src/utils/storageKeys.ts
+++ b/packages/shared/src/utils/storageKeys.ts
@@ -5,6 +5,8 @@ export const NETWORK_STORAGE_KEY = "evevault:network";
 export const TOKENLIST_STORAGE_KEY = "evevault:tokenlist";
 export const JWT_STORAGE_KEY = "evevault:jwt";
 export const TENANT_STORAGE_KEY = "evevault:tenant";
+/** Extension-only: encrypted localnet keypair for dev/localnet signing. */
+export const LOCALNET_KEY_STORAGE_KEY = "evevault:localnet-key";
 
 /** Persist keys used by Zustand and auth (localStorage / chrome.storage.local). Cleared on reset. */
 export const EVEVAULT_STORAGE_KEYS = [
@@ -14,6 +16,7 @@ export const EVEVAULT_STORAGE_KEYS = [
   TOKENLIST_STORAGE_KEY,
   JWT_STORAGE_KEY,
   TENANT_STORAGE_KEY,
+  LOCALNET_KEY_STORAGE_KEY,
 ] as const;
 
 /** Extension-only chrome.storage.local keys cleared on reset (not covered by cleanupExtensionStorage). */

--- a/packages/shared/src/wallet/index.ts
+++ b/packages/shared/src/wallet/index.ts
@@ -10,6 +10,7 @@ export { ephSign } from "./ephSign";
 export { useBalance } from "./hooks/useBalance";
 export { useSendToken } from "./hooks/useSendToken";
 export { useTransactionHistory } from "./hooks/useTransactionHistory";
+export { rawSign } from "./rawSign";
 export type {
   CoinMetadataQueryResponse,
   CoinMetadataResult,

--- a/packages/shared/src/wallet/rawSign.ts
+++ b/packages/shared/src/wallet/rawSign.ts
@@ -7,8 +7,7 @@ const log = createLogger();
 
 /**
  * Signs bytes directly with the localnet keypair held in the keeper.
- * Produces a plain Ed25519 signature — no ZK proof, no zkLogin wrapper.
- * Extension-only: localnet signing is not supported on the web app path.
+ * Extension-only: Produces a plain Ed25519 signature.
  */
 export async function rawSign(
   scope: IntentScope,

--- a/packages/shared/src/wallet/rawSign.ts
+++ b/packages/shared/src/wallet/rawSign.ts
@@ -1,0 +1,38 @@
+import type { IntentScope } from "@mysten/sui/cryptography";
+import { VaultMessageTypes } from "../types/messages";
+import { isWeb } from "../utils/environment";
+import { createLogger } from "../utils/logger";
+
+const log = createLogger();
+
+/**
+ * Signs bytes directly with the localnet keypair held in the keeper.
+ * Produces a plain Ed25519 signature — no ZK proof, no zkLogin wrapper.
+ * Extension-only: localnet signing is not supported on the web app path.
+ */
+export async function rawSign(
+  scope: IntentScope,
+  msgBytes: Uint8Array,
+  suiAddress: string,
+): Promise<{ bytes: string; signature: string }> {
+  if (isWeb()) {
+    throw new Error("rawSign is only available in the extension (localnet)");
+  }
+
+  log.info("rawSign: requesting direct signature from keeper", { scope });
+
+  const response = (await chrome.runtime?.sendMessage?.({
+    type: VaultMessageTypes.LOCALNET_SIGN_BYTES,
+    msgBytes: Array.from(msgBytes),
+    scope,
+    suiAddress,
+  })) as
+    | { ok?: boolean; bytes?: string; signature?: string; error?: string }
+    | undefined;
+
+  if (!response?.ok || !response.bytes || !response.signature) {
+    throw new Error(response?.error ?? "rawSign: no response from keeper");
+  }
+
+  return { bytes: response.bytes, signature: response.signature };
+}

--- a/packages/shared/src/wallet/rawSign.ts
+++ b/packages/shared/src/wallet/rawSign.ts
@@ -14,7 +14,11 @@ export async function rawSign(
   msgBytes: Uint8Array,
   suiAddress: string,
 ): Promise<{ bytes: string; signature: string }> {
-  if (isWeb()) {
+  if (
+    isWeb() ||
+    typeof chrome === "undefined" ||
+    !chrome.runtime?.sendMessage
+  ) {
     throw new Error("rawSign is only available in the extension (localnet)");
   }
 


### PR DESCRIPTION
keypair pipeline, network store, signing primitive

   - Add localnet network type, isLocalnetChain helper, message/storage key constants
   - Extend SUI client to accept URL override; add gRPC epoch fetching for localnet
   - Implement Ed25519 keypair load/persist/restore pipeline:
     keeper (local.ts) → localVaultHandlers → chrome.storage → offscreenService restore on READY
   - Add rawSign: plain Ed25519 signing via keeper, returns { bytes, signature }
   - Extend networkStore with localnetUrl and localnet-aware setChain
   - Skip zkLogin vault init on localnet in deviceStore initActions/proofActions