### PR TITLE
fix(keeper): persist ephemeral key to chrome.storage.session to survive offscreen teardown

### DIFF
--- a/apps/extension/entrypoints/keeper/__tests__/sessionPersistence.test.ts
+++ b/apps/extension/entrypoints/keeper/__tests__/sessionPersistence.test.ts
@@ -1,0 +1,113 @@
+/// <reference types="chrome"/>
+
+import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  clearPersistedKeeperState,
+  persistKeeperState,
+  restoreKeeperState,
+} from "../sessionPersistence";
+
+// Minimal in-memory mock of chrome.storage.session for vitest.
+function makeSessionStorageMock() {
+  const store = new Map<string, unknown>();
+  return {
+    async get(key?: string | string[]) {
+      if (typeof key === "string") {
+        return store.has(key) ? { [key]: store.get(key) } : {};
+      }
+      const result: Record<string, unknown> = {};
+      for (const [k, v] of store.entries()) result[k] = v;
+      return result;
+    },
+    async set(items: Record<string, unknown>) {
+      for (const [k, v] of Object.entries(items)) store.set(k, v);
+    },
+    async remove(key: string | string[]) {
+      const keys = Array.isArray(key) ? key : [key];
+      for (const k of keys) store.delete(k);
+    },
+    _store: store,
+  };
+}
+
+describe("keeper sessionPersistence", () => {
+  let mockSession: ReturnType<typeof makeSessionStorageMock>;
+
+  beforeEach(() => {
+    mockSession = makeSessionStorageMock();
+    (globalThis as unknown as { chrome: unknown }).chrome = {
+      storage: { session: mockSession },
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("round-trips an ephemeral keypair through persist + restore", async () => {
+    const original = Ed25519Keypair.generate();
+    const expiry = Date.now() + 5 * 60 * 1000;
+
+    await persistKeeperState(original, expiry);
+    const restored = await restoreKeeperState();
+
+    expect(restored).not.toBeNull();
+    expect(restored?.unlockExpiry).toBe(expiry);
+    expect(restored?.ephemeralKey.getPublicKey().toRawBytes()).toEqual(
+      original.getPublicKey().toRawBytes(),
+    );
+  });
+
+  it("returns null when no state has been persisted", async () => {
+    const restored = await restoreKeeperState();
+    expect(restored).toBeNull();
+  });
+
+  it("returns null and clears storage when persisted state has expired", async () => {
+    const original = Ed25519Keypair.generate();
+    const expiredAt = Date.now() - 1000;
+
+    await persistKeeperState(original, expiredAt);
+    const restored = await restoreKeeperState();
+
+    expect(restored).toBeNull();
+    // Storage should now be empty
+    const remaining = await mockSession.get();
+    expect(remaining).toEqual({});
+  });
+
+  it("clearPersistedKeeperState removes the entry", async () => {
+    const original = Ed25519Keypair.generate();
+    await persistKeeperState(original, Date.now() + 60_000);
+
+    expect((await mockSession.get())["keeper.session.v1"]).toBeDefined();
+
+    await clearPersistedKeeperState();
+
+    expect((await mockSession.get())["keeper.session.v1"]).toBeUndefined();
+  });
+
+  it("returns null gracefully when chrome.storage.session is unavailable", async () => {
+    (globalThis as unknown as { chrome: unknown }).chrome = {};
+    const restored = await restoreKeeperState();
+    expect(restored).toBeNull();
+  });
+
+  it("persistKeeperState swallows errors (best-effort)", async () => {
+    (globalThis as unknown as { chrome: unknown }).chrome = {
+      storage: {
+        session: {
+          set: () => Promise.reject(new Error("quota exceeded")),
+          get: () => Promise.resolve({}),
+          remove: () => Promise.resolve(),
+        },
+      },
+    };
+    // Should not throw
+    await expect(
+      persistKeeperState(Ed25519Keypair.generate(), Date.now() + 60_000),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/extension/entrypoints/keeper/keeper.ts
+++ b/apps/extension/entrypoints/keeper/keeper.ts
@@ -20,6 +20,11 @@ import {
   localnetSetKeypair,
   localnetSign,
 } from "./local";
+import {
+  clearPersistedKeeperState,
+  persistKeeperState,
+  restoreKeeperState,
+} from "./sessionPersistence";
 
 /**
  * Keeper - Holds the ephemeral key in RAM-only memory
@@ -65,11 +70,36 @@ function checkAndEnforceExpiry(): boolean {
     sessionSalt = null;
     _vaultUnlocked = false;
     _vaultUnlockExpiry = null;
+    void clearPersistedKeeperState();
     return true; // Now locked
   }
 
   return false; // Still unlocked
 }
+
+/**
+ * Attempt to restore the ephemeral key and unlock state from
+ * `chrome.storage.session`. This survives offscreen-document teardown
+ * caused by Chromium MV3 service-worker eviction, so the user does not
+ * have to re-enter their PIN every ~30 seconds of inactivity.
+ *
+ * Note: WebCrypto `sessionDerivedKey` is intentionally NOT restored —
+ * key rotation will simply require a fresh unlock if the offscreen has
+ * been torn down. This preserves the existing security boundary for
+ * rotation while fixing the much more common signing-flow regression.
+ */
+async function restoreSessionStateIfAny(): Promise<void> {
+  const restored = await restoreKeeperState();
+  if (!restored) return;
+  ephemeralKey = restored.ephemeralKey;
+  _vaultUnlocked = true;
+  _vaultUnlockExpiry = restored.unlockExpiry;
+}
+
+// Kick off restore as early as possible. Message handlers below await this
+// promise before reading ephemeralKey, so signing requests that arrive
+// during a cold-start race do not falsely fail with LOCKED.
+const restorePromise: Promise<void> = restoreSessionStateIfAny();
 
 /**
  * Message handler for keeper operations
@@ -92,6 +122,10 @@ chrome.runtime.onMessage.addListener(
       ephemeralKey = Ed25519Keypair.generate();
       _vaultUnlocked = true;
       _vaultUnlockExpiry = Date.now() + 10 * 60 * 1000; // 10 minutes default
+
+      // Persist to chrome.storage.session so we survive offscreen-document
+      // teardown without forcing the user to re-unlock.
+      void persistKeeperState(ephemeralKey, _vaultUnlockExpiry);
 
       // Keep sendResponse reference and handle async operation
       (async () => {
@@ -159,6 +193,10 @@ chrome.runtime.onMessage.addListener(
             _vaultUnlocked = true;
             _vaultUnlockExpiry = Date.now() + 10 * 60 * 1000; // 10 minutes default
 
+            // Persist to chrome.storage.session so we survive offscreen
+            // document teardown.
+            void persistKeeperState(ephemeralKey, _vaultUnlockExpiry);
+
             // At subsequent unlock attempts, derive and cache the session key
             // from the stored salt.
             const salt = Uint8Array.from(
@@ -192,18 +230,21 @@ chrome.runtime.onMessage.addListener(
     }
 
     if (message.type === KeeperMessageTypes.GET_PUBLIC_KEY) {
-      // Check if vault is locked or expired
-      if (checkAndEnforceExpiry()) {
-        sendResponse({ error: "LOCKED" });
-        return false;
-      }
-
-      const publicKey = ephemeralKey?.getPublicKey();
-      sendResponse({
-        ok: true,
-        publicKeyBytes: Array.from(publicKey?.toRawBytes() ?? []),
-      });
-      return false;
+      // Wait for any in-flight session restore so a cold-start signing
+      // race does not falsely report LOCKED.
+      (async () => {
+        await restorePromise;
+        if (checkAndEnforceExpiry()) {
+          sendResponse({ error: "LOCKED" });
+          return;
+        }
+        const publicKey = ephemeralKey?.getPublicKey();
+        sendResponse({
+          ok: true,
+          publicKeyBytes: Array.from(publicKey?.toRawBytes() ?? []),
+        });
+      })();
+      return true; // async response
     }
 
     if (message.type === KeeperMessageTypes.ROTATE_KEYPAIR) {
@@ -229,6 +270,10 @@ chrome.runtime.onMessage.addListener(
           _vaultUnlocked = true;
           _vaultUnlockExpiry = Date.now() + 10 * 60 * 1000;
 
+          // Persist rotated keypair so the next offscreen revival sees
+          // the new key, not the old one.
+          void persistKeeperState(ephemeralKey, _vaultUnlockExpiry);
+
           sendResponse({
             ok: true,
             hashedSecretKey,
@@ -248,20 +293,22 @@ chrome.runtime.onMessage.addListener(
     }
 
     if (message.type === KeeperMessageTypes.EPH_SIGN) {
-      // Check if vault is locked or expired
-      if (checkAndEnforceExpiry()) {
-        sendResponse({ error: "[KEEPER_EPH_SIGN] LOCKED" });
-        return false;
-      }
-
-      const key = ephemeralKey;
-      if (!key) {
-        sendResponse({ error: "[KEEPER_EPH_SIGN] LOCKED" });
-        return false;
-      }
-
-      // Handle async signing
+      // Handle async signing — wait for session restore first so a
+      // cold-start race does not falsely report LOCKED.
       (async () => {
+        await restorePromise;
+
+        if (checkAndEnforceExpiry()) {
+          sendResponse({ error: "[KEEPER_EPH_SIGN] LOCKED" });
+          return;
+        }
+
+        const key = ephemeralKey;
+        if (!key) {
+          sendResponse({ error: "[KEEPER_EPH_SIGN] LOCKED" });
+          return;
+        }
+
         try {
           const { msgBytes, scope, sui_address } = message;
           // msgBytes comes as an array from chrome.runtime.sendMessage
@@ -293,46 +340,45 @@ chrome.runtime.onMessage.addListener(
     }
 
     if (message.type === KeeperMessageTypes.SET_ZKPROOF) {
-      // Store zkProof for a specific chain
+      // Store zkProof for a specific chain (await session restore to avoid
+      // cold-start race).
       const { chain, zkProof } = message;
-
-      if (!ephemeralKey) {
-        sendResponse({
-          error: "[KEEPER_SET_ZKPROOF] No ephemeral key found, vault LOCKED",
-        });
-        return false;
-      }
-
-      if (!chain) {
-        sendResponse({ error: "Chain is required" });
-        return false;
-      }
-
-      zkProofs[chain as SuiChain] = zkProof as ZkProofResponse;
-      sendResponse({ ok: true });
-      return false;
+      (async () => {
+        await restorePromise;
+        if (!ephemeralKey) {
+          sendResponse({
+            error: "[KEEPER_SET_ZKPROOF] No ephemeral key found, vault LOCKED",
+          });
+          return;
+        }
+        if (!chain) {
+          sendResponse({ error: "Chain is required" });
+          return;
+        }
+        zkProofs[chain as SuiChain] = zkProof as ZkProofResponse;
+        sendResponse({ ok: true });
+      })();
+      return true;
     }
 
     if (message.type === KeeperMessageTypes.GET_ZKPROOF) {
-      // Retrieve zkProof for a specific chain
+      // Retrieve zkProof for a specific chain (await session restore to
+      // avoid cold-start race).
       const { chain } = message;
-
-      if (!ephemeralKey) {
-        sendResponse({ error: "LOCKED" });
-        return false;
-      }
-
-      if (!chain) {
-        sendResponse({ error: "Chain is required" });
-        return false;
-      }
-
-      const zkProof = zkProofs[chain as SuiChain] ?? null;
-      sendResponse({
-        ok: true,
-        zkProof,
-      });
-      return false;
+      (async () => {
+        await restorePromise;
+        if (!ephemeralKey) {
+          sendResponse({ error: "LOCKED" });
+          return;
+        }
+        if (!chain) {
+          sendResponse({ error: "Chain is required" });
+          return;
+        }
+        const zkProof = zkProofs[chain as SuiChain] ?? null;
+        sendResponse({ ok: true, zkProof });
+      })();
+      return true;
     }
 
     if (message.type === KeeperMessageTypes.CLEAR_EPHKEY) {
@@ -342,6 +388,7 @@ chrome.runtime.onMessage.addListener(
       sessionSalt = null;
       _vaultUnlocked = false;
       _vaultUnlockExpiry = null;
+      void clearPersistedKeeperState();
       sendResponse({ ok: true });
       return false;
     }

--- a/apps/extension/entrypoints/keeper/sessionPersistence.ts
+++ b/apps/extension/entrypoints/keeper/sessionPersistence.ts
@@ -1,0 +1,118 @@
+/// <reference types="chrome"/>
+
+import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
+
+/**
+ * Session-storage persistence for the keeper offscreen document.
+ *
+ * Why this exists:
+ *   The keeper's RAM-only `ephemeralKey` and unlock state survive only
+ *   as long as the offscreen document does. Chromium MV3 closes the
+ *   offscreen document when the service worker is torn down (after
+ *   ~30 seconds of idle), which loses all module-level state and
+ *   surfaces as `[KEEPER_EPH_SIGN] LOCKED` even though the user's
+ *   10-minute unlock window has not actually expired.
+ *
+ * What we use:
+ *   `chrome.storage.session` — in-memory only, isolated per-extension,
+ *   cleared on browser-process exit. Critically, it is NOT written to
+ *   disk and does not survive a browser restart, which is the right
+ *   security boundary for an "ephemeral" key.
+ *
+ * What we persist:
+ *   - The encoded secret key for the ephemeral keypair (Ed25519)
+ *   - The unlock-expiry timestamp
+ *
+ * What we do NOT persist:
+ *   - The user PIN (never stored anywhere by the keeper)
+ *   - The decrypted master keypair (only ephemeral keys are session-scoped)
+ *   - WebCrypto-derived `CryptoKey` instances (those are non-extractable)
+ *
+ * If the user runs CLEAR_EPHKEY (explicit lock), we clear session storage
+ * too. If the unlock expires naturally, we clear it. If the offscreen
+ * document is re-created and the session entry is missing, we stay locked.
+ */
+
+const STORAGE_KEY = "keeper.session.v1";
+
+interface PersistedKeeperState {
+  /** Ed25519 keypair encoded as a Sui-format secret key string. */
+  secretKey: string;
+  /** ms-since-epoch when the unlock window expires. */
+  unlockExpiry: number;
+}
+
+/**
+ * Serialize and persist current keeper state to chrome.storage.session.
+ * Safe to call repeatedly; failures are non-fatal (we just stay in
+ * RAM-only mode like before this patch).
+ */
+export async function persistKeeperState(
+  ephemeralKey: Ed25519Keypair,
+  unlockExpiry: number,
+): Promise<void> {
+  try {
+    const state: PersistedKeeperState = {
+      secretKey: ephemeralKey.getSecretKey(),
+      unlockExpiry,
+    };
+    await chrome.storage.session.set({ [STORAGE_KEY]: state });
+  } catch {
+    // chrome.storage.session may be unavailable in some test environments
+    // or older Chromium builds; treat as best-effort.
+  }
+}
+
+/**
+ * Clear all persisted keeper state from session storage.
+ * Called on explicit lock (CLEAR_EPHKEY) and on natural expiry.
+ */
+export async function clearPersistedKeeperState(): Promise<void> {
+  try {
+    await chrome.storage.session.remove(STORAGE_KEY);
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * Result of attempting to restore keeper state on offscreen document load.
+ */
+export interface RestoredKeeperState {
+  ephemeralKey: Ed25519Keypair;
+  unlockExpiry: number;
+}
+
+/**
+ * Attempt to restore keeper state from session storage. Returns null if:
+ *   - No persisted state exists
+ *   - Persisted state has expired (we also clear it in that case)
+ *   - The persisted secret key fails to decode
+ *   - chrome.storage.session is unavailable
+ */
+export async function restoreKeeperState(): Promise<RestoredKeeperState | null> {
+  try {
+    if (!chrome.storage?.session) return null;
+
+    const raw = await chrome.storage.session.get(STORAGE_KEY);
+    const state = raw?.[STORAGE_KEY] as PersistedKeeperState | undefined;
+    if (
+      !state ||
+      typeof state.secretKey !== "string" ||
+      typeof state.unlockExpiry !== "number"
+    ) {
+      return null;
+    }
+
+    if (Date.now() > state.unlockExpiry) {
+      // Expired — clean up and stay locked.
+      await clearPersistedKeeperState();
+      return null;
+    }
+
+    const ephemeralKey = Ed25519Keypair.fromSecretKey(state.secretKey);
+    return { ephemeralKey, unlockExpiry: state.unlockExpiry };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Problem

The keeper offscreen document at `apps/extension/entrypoints/keeper/keeper.ts` holds the unlocked ephemeral key (`ephemeralKey`, `_vaultUnlocked`, `_vaultUnlockExpiry`) in module-level RAM.

In Chromium MV3, the offscreen document is closed when the service worker is torn down — which happens after ~30 seconds of service-worker idle. When the offscreen is reconstructed, all module-level state is lost. The next signing request from a dApp falls into the `if (!ephemeralKey)` branch and returns `[KEEPER_EPH_SIGN] LOCKED`, even though the user's 10-minute unlock timer never expired.

End users perceive this as the vault "locking itself" between transactions and have to re-enter their PIN repeatedly. We see this in the wild on the CradleOS dApp (sui-testnet/Stillness) — a transaction submitted ~30 s after the previous one consistently fails with `LOCKED`.

## Fix

Persist `(ephemeralKey, unlockExpiry)` to `chrome.storage.session` whenever state changes, restore at offscreen module load, and have read paths await the in-flight restore so a cold-start race does not falsely report `LOCKED`.

### Why `chrome.storage.session`?

`chrome.storage.session` is **in-memory only, never written to disk**, and **isolated per extension**. It matches the existing "ephemeral key" security model exactly:

| Property | Module-level RAM (today) | `chrome.storage.session` (this PR) |
|---|---|---|
| Cleared on browser exit | ✅ | ✅ |
| Cleared on extension reload | ✅ | ✅ |
| Written to disk | ❌ | ❌ |
| Survives offscreen teardown | ❌ | ✅ |
| Visible to other extensions | ❌ | ❌ |

The user PIN is **never** persisted. WebCrypto-derived `sessionDerivedKey` / `sessionSalt` are intentionally **not** restored; key rotation will simply require a fresh unlock if the offscreen has been torn down. This preserves the existing security boundary for the rotation flow while fixing the much more common signing flow.

### Code changes

1. **New module `sessionPersistence.ts`** with three exported helpers:
   - `persistKeeperState(keypair, expiry)` — best-effort write
   - `restoreKeeperState()` — best-effort read with built-in expiry check
   - `clearPersistedKeeperState()` — best-effort delete
2. **`keeper.ts`**:
   - On module load, kicks off `restoreSessionStateIfAny()` and stores the promise.
   - Persists state in `CREATE_KEYPAIR`, `UNLOCK_VAULT`, and `ROTATE_KEYPAIR`.
   - Clears persisted state in `CLEAR_EPHKEY` and `checkAndEnforceExpiry`.
   - Read handlers (`GET_PUBLIC_KEY`, `EPH_SIGN`, `SET_ZKPROOF`, `GET_ZKPROOF`) now `await restorePromise` before checking the lock, so a cold-start signing race does not falsely return `LOCKED`.

### Manifest

The `storage` permission is **already declared** in `apps/extension/wxt.config.ts`. No manifest changes required.

## Tests

- 6 new vitest cases in `apps/extension/entrypoints/keeper/__tests__/sessionPersistence.test.ts` covering:
  - round-trip persist + restore
  - returns null when no state has been persisted
  - returns null and clears storage when persisted state has expired
  - explicit clear removes the entry
  - returns null gracefully when `chrome.storage.session` is unavailable
  - `persistKeeperState` swallows errors (best-effort)
- All 13 keeper tests pass (`bun run test:run entrypoints/keeper/__tests__/`):

```
 ✓ entrypoints/keeper/__tests__/sessionPersistence.test.ts (6 tests) 31ms
 ✓ entrypoints/keeper/__tests__/keeper.lock.test.ts (7 tests) 49ms

 Test Files  2 passed (2)
      Tests  13 passed (13)
```

- `bunx biome check` clean on all three touched files.

## Reproduction (before this PR)

1. Unlock EVE Vault.
2. Sign a transaction in any dApp. ✅
3. Wait 30+ seconds without interacting with the extension.
4. Sign another transaction. → `Error: [KEEPER_EPH_SIGN] LOCKED`

After this PR, step 4 succeeds without re-prompting for PIN, until the 10-minute unlock window expires naturally.

## Risks / non-goals

- **Browser compatibility**: `chrome.storage.session` is supported in Chromium 102+ (May 2022) and Firefox MV3. The extension already requires MV3.
- **Storage quota**: `chrome.storage.session` allows ~10 MB per extension; we store one ~80 byte entry. No quota concern.
- **Multiple offscreen instances**: Chrome enforces a single offscreen document per extension, so there is no concurrency hazard.
- **Out of scope for this PR**: persisting `zkProofs` or rotation-derived WebCrypto state. Both can be added incrementally if desired.

## Discord context

Reported by users in the EVE Frontier dev community. Happy to provide repro logs or tweak any of this — just leave a review comment.