### PR TITLE
fix(security): keeper sender guard, gated logger, OAuth state

### DIFF
--- a/apps/extension/entrypoints/keeper/__tests__/keeperTestUtils.ts
+++ b/apps/extension/entrypoints/keeper/__tests__/keeperTestUtils.ts
@@ -50,8 +50,10 @@ export function createKeeperTestContext(): {
     msg: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     return new Promise((resolve) => {
-      handler({ target: 'KEEPER', ...msg }, {}, (resp) =>
-        resolve((resp ?? {}) as Record<string, unknown>),
+      handler(
+        { target: 'KEEPER', ...msg },
+        { url: 'chrome-extension://test-extension-id/offscreen.html' },
+        (resp) => resolve((resp ?? {}) as Record<string, unknown>),
       )
     })
   }
@@ -102,6 +104,7 @@ export function setupKeeperSuite(
     // chrome.runtime.onMessage.addListener() at module scope.
     vi.stubGlobal('chrome', {
       runtime: {
+        id: 'test-extension-id',
         onMessage: { addListener: ctx.captureHandler },
         sendMessage: vi.fn().mockResolvedValue(undefined),
       },

--- a/apps/extension/entrypoints/keeper/keeper.ts
+++ b/apps/extension/entrypoints/keeper/keeper.ts
@@ -13,9 +13,9 @@ import { handleKeeperMessage, type KeeperSendResponse } from './keeperHandlers'
 chrome.runtime.onMessage.addListener(
   (
     message: BackgroundMessage,
-    _sender: chrome.runtime.MessageSender,
+    sender: chrome.runtime.MessageSender,
     sendResponse: KeeperSendResponse,
-  ) => handleKeeperMessage(message, sendResponse),
+  ) => handleKeeperMessage(message, sender, sendResponse),
 )
 
 console.log('Keeper offscreen document initialized')

--- a/apps/extension/entrypoints/keeper/keeperHandlers.ts
+++ b/apps/extension/entrypoints/keeper/keeperHandlers.ts
@@ -1,6 +1,10 @@
 import { KeeperMessageTypes } from '@evevault/shared'
+import { isExtensionSender } from '@/lib/background/senderGuard'
 import type { BackgroundMessage } from '@/lib/background/types'
 import type { KeeperHandler, KeeperSendResponse } from './keeperTypes'
+
+type MsgSender = chrome.runtime.MessageSender
+
 import {
   handleLocalnetGetAddress,
   handleLocalnetSetKeypair,
@@ -41,8 +45,12 @@ const keeperHandlers: Partial<Record<KeeperMessageTypes, KeeperHandler>> = {
  */
 export function handleKeeperMessage(
   message: BackgroundMessage,
+  sender: MsgSender,
   sendResponse: KeeperSendResponse,
 ): boolean {
+  if (!isExtensionSender(sender)) {
+    return false
+  }
   if (message.target !== 'KEEPER') {
     return false
   }

--- a/apps/extension/entrypoints/keeper/vaultHandlers.ts
+++ b/apps/extension/entrypoints/keeper/vaultHandlers.ts
@@ -1,6 +1,7 @@
 import { ZKEd25519Keypair } from '@evefrontier/wallet-core/crypto'
 import type { ZKProofData } from '@evefrontier/wallet-core/types'
 import { encrypt, encryptWithKey, type HashedData } from '@evevault/shared'
+import { createLogger } from '@evevault/shared/utils'
 import type { BackgroundMessage } from '@/lib/background/types'
 import {
   cacheSessionKey,
@@ -18,6 +19,8 @@ import {
   unlockVaultWithKeypair,
 } from './keeperState'
 import type { KeeperSendResponse } from './keeperTypes'
+
+const log = createLogger()
 
 export function handleCreateKeypair(
   message: BackgroundMessage,
@@ -59,7 +62,7 @@ export function handleUnlockVault(
     try {
       secretKey = await decryptVaultSecret(hashedSecretKey, pin)
     } catch (error) {
-      console.error('[Keeper] Decryption failed:', error)
+      log.error('[Keeper] Decryption failed', { error: getErrorMessage(error) })
       lockVault()
       sendResponse({
         ok: false,
@@ -72,7 +75,9 @@ export function handleUnlockVault(
       await restoreUnlockedVault(message, secretKey, hashedSecretKey, pin)
       sendResponse({ ok: true })
     } catch (error) {
-      console.error('[Keeper] Keypair creation failed:', error)
+      log.error('[Keeper] Keypair creation failed', {
+        error: getErrorMessage(error),
+      })
       lockVault()
       sendResponse({
         ok: false,

--- a/apps/extension/src/lib/background/handlers/auth/__tests__/extLogin.test.ts
+++ b/apps/extension/src/lib/background/handlers/auth/__tests__/extLogin.test.ts
@@ -91,6 +91,7 @@ vi.mock('@/lib/background/services/popupWindow', () => ({
 vi.mock('../authHelpers', () => ({
   ensureMessageId: mocks.ensureMessageId,
   extractAuthCode: mocks.extractAuthCode,
+  extractState: (url: string) => new URL(url).searchParams.get('state'),
   getCurrentChain: mocks.getCurrentChain,
   getCurrentChainFromStorage: mocks.getCurrentChainFromStorage,
   sendAuthError: mocks.sendAuthError,
@@ -157,12 +158,13 @@ describe('handleExtLogin', () => {
     mockGetAuthRequest.mockResolvedValue({
       authUrl: new URL('https://auth.example/login'),
       codeVerifier: 'verifier',
+      state: 'test-state',
     })
     mocks.extractAuthCode.mockReturnValue('auth-code')
     mockExchangeCodeForToken.mockResolvedValue({ id_token: 'id-token' })
     mockStoreJwt.mockResolvedValue(undefined)
     installChromeIdentityMock(
-      'https://extension.example/callback?code=auth-code',
+      'https://extension.example/callback?code=auth-code&state=test-state',
     )
   })
 

--- a/apps/extension/src/lib/background/handlers/auth/authHelpers.ts
+++ b/apps/extension/src/lib/background/handlers/auth/authHelpers.ts
@@ -82,6 +82,10 @@ export function extractAuthCode(responseUrl: string): string | null {
   return new URL(responseUrl).searchParams.get('code')
 }
 
+export function extractState(responseUrl: string): string | null {
+  return new URL(responseUrl).searchParams.get('state')
+}
+
 export function sendExtensionAuthSuccess(id: string, jwt: JwtResponse): void {
   const token = buildExtensionAuthSuccessToken(jwt)
   const message: ExtensionAuthSuccessMessage = {

--- a/apps/extension/src/lib/background/handlers/auth/dappLogin.ts
+++ b/apps/extension/src/lib/background/handlers/auth/dappLogin.ts
@@ -25,6 +25,7 @@ import { sendToKeeper } from '../vaultHandlers'
 import {
   ensureMessageId,
   extractAuthCode,
+  extractState,
   getCurrentChain,
   sendDappConnectSuccessToTab,
 } from './authHelpers'
@@ -88,6 +89,7 @@ type OAuthCallbackContext = {
   chromeRedirectUri: string
   tenant: string
   codeVerifier: string
+  state: string
   tabId: number | undefined
   dappContext: DappRequestContext
 }
@@ -423,6 +425,7 @@ async function handleOAuthCallback(
     chromeRedirectUri,
     tenant,
     codeVerifier,
+    state,
     tabId,
     dappContext,
   } = ctx
@@ -438,6 +441,11 @@ async function handleOAuthCallback(
       chrome.runtime.lastError?.message ??
         'Sign-in did not complete. Please try again.',
     )
+    return
+  }
+
+  if (extractState(responseUrl) !== state) {
+    sendAuthErrorToTabIds(tabId, ids, 'Invalid OAuth response (state mismatch)')
     return
   }
 
@@ -533,7 +541,7 @@ export async function handleDappLogin(
   if (!nonce) return
 
   const chromeRedirectUri = chrome.identity.getRedirectURL()
-  const { authUrl, codeVerifier } = await getAuthRequest({
+  const { authUrl, codeVerifier, state } = await getAuthRequest({
     tenantId: tenant,
     nonce,
   })
@@ -547,6 +555,7 @@ export async function handleDappLogin(
         chromeRedirectUri,
         tenant,
         codeVerifier,
+        state,
         tabId,
         dappContext,
       }),

--- a/apps/extension/src/lib/background/handlers/auth/extLogin.ts
+++ b/apps/extension/src/lib/background/handlers/auth/extLogin.ts
@@ -13,6 +13,7 @@ import type { MessageWithId } from '@/lib/background/types'
 import {
   ensureMessageId,
   extractAuthCode,
+  extractState,
   getCurrentChain,
   getCurrentChainFromStorage,
   sendAuthError,
@@ -70,8 +71,11 @@ export async function handleExtLogin(
   const nonce = await getNonceForChain(id, currentChain)
   if (!nonce) return
 
-  const { authUrl, codeVerifier } = await getAuthRequest({ tenantId, nonce })
-  launchOAuthLogin({ id, authUrl, codeVerifier, currentChain, tenantId })
+  const { authUrl, codeVerifier, state } = await getAuthRequest({
+    tenantId,
+    nonce,
+  })
+  launchOAuthLogin({ id, authUrl, codeVerifier, state, currentChain, tenantId })
 }
 
 /**
@@ -255,12 +259,14 @@ async function handleOAuthResponse({
   id,
   responseUrl,
   codeVerifier,
+  state,
   currentChain,
   tenantId,
 }: {
   id: string
   responseUrl: string | undefined
   codeVerifier: string
+  state: string
   currentChain: StoredChain
   tenantId: TenantId
 }) {
@@ -271,6 +277,11 @@ async function handleOAuthResponse({
 
   if (!responseUrl) {
     sendAuthError(id, { message: 'No response URL received' })
+    return
+  }
+
+  if (extractState(responseUrl) !== state) {
+    sendAuthError(id, { message: 'Invalid OAuth response (state mismatch)' })
     return
   }
 
@@ -320,12 +331,14 @@ function launchOAuthLogin({
   id,
   authUrl,
   codeVerifier,
+  state,
   currentChain,
   tenantId,
 }: {
   id: string
   authUrl: URL
   codeVerifier: string
+  state: string
   currentChain: StoredChain
   tenantId: TenantId
 }) {
@@ -336,6 +349,7 @@ function launchOAuthLogin({
         id,
         responseUrl,
         codeVerifier,
+        state,
         currentChain,
         tenantId,
       })

--- a/apps/extension/src/lib/background/handlers/messageHandler.ts
+++ b/apps/extension/src/lib/background/handlers/messageHandler.ts
@@ -1,6 +1,7 @@
 import { VaultMessageTypes, WalletStandardMessageTypes } from '@evevault/shared'
 import { createLogger, redactSensitive } from '@evevault/shared/utils'
 import { sendToTab } from '@/lib/background/messaging/tabMessaging'
+import { isDappSender, isExtensionSender } from '@/lib/background/senderGuard'
 import { revokeDappPermission } from '@/lib/background/services/dappPermissions'
 import type {
   BackgroundMessage,
@@ -258,33 +259,6 @@ function findRoute(message: BackgroundMessage): MessageRoute | undefined {
   }
 
   return undefined
-}
-
-/**
- * Identifies messages that originate from this extension rather than a web
- * page. Fails closed: a sender is trusted only when it carries a URL under this
- * extension's own origin. Senders with no identifying metadata are NOT trusted,
- * so the privileged extension-only routes can't be reached without provenance.
- */
-function isExtensionSender(sender: MsgSender): boolean {
-  const senderUrls = [sender.origin, sender.url, sender.tab?.url]
-  const extensionId = chrome.runtime?.id
-  const isOwnExtensionUrl = (url: string | undefined) => {
-    if (!url) return false
-    if (!extensionId) return url.startsWith('chrome-extension://')
-
-    return url.startsWith(`chrome-extension://${extensionId}/`)
-  }
-
-  return senderUrls.some(isOwnExtensionUrl)
-}
-
-/**
- * Identifies messages sent by a page tab, excluding extension UI tabs so
- * extension pages cannot exercise dApp-only routes.
- */
-function isDappSender(sender: MsgSender): boolean {
-  return typeof sender.tab?.id === 'number' && !isExtensionSender(sender)
 }
 
 /**

--- a/apps/extension/src/lib/background/senderGuard.ts
+++ b/apps/extension/src/lib/background/senderGuard.ts
@@ -1,0 +1,28 @@
+type MsgSender = chrome.runtime.MessageSender
+
+/**
+ * Identifies messages that originate from this extension rather than a web
+ * page. Fails closed: a sender is trusted only when it carries a URL under this
+ * extension's own origin. Senders with no identifying metadata are NOT trusted,
+ * so the privileged extension-only routes can't be reached without provenance.
+ */
+export function isExtensionSender(sender: MsgSender): boolean {
+  const senderUrls = [sender.origin, sender.url, sender.tab?.url]
+  const extensionId = chrome.runtime?.id
+  const isOwnExtensionUrl = (url: string | undefined) => {
+    if (!url) return false
+    if (!extensionId) return url.startsWith('chrome-extension://')
+
+    return url.startsWith(`chrome-extension://${extensionId}/`)
+  }
+
+  return senderUrls.some(isOwnExtensionUrl)
+}
+
+/**
+ * Identifies messages sent by a page tab, excluding extension UI tabs so
+ * extension pages cannot exercise dApp-only routes.
+ */
+export function isDappSender(sender: MsgSender): boolean {
+  return typeof sender.tab?.id === 'number' && !isExtensionSender(sender)
+}

--- a/apps/extension/src/lib/background/services/__tests__/oauthService.test.ts
+++ b/apps/extension/src/lib/background/services/__tests__/oauthService.test.ts
@@ -32,8 +32,8 @@ describe('getAuthRequest', () => {
     vi.clearAllMocks()
   })
 
-  it('builds a well-formed auth URL with nonce and PKCE', async () => {
-    const { authUrl, codeVerifier } = await getAuthRequest({
+  it('builds a well-formed auth URL with nonce, PKCE, and state', async () => {
+    const { authUrl, codeVerifier, state } = await getAuthRequest({
       tenantId: TenantId.STILLNESS,
       nonce: 'test-nonce',
     })
@@ -51,5 +51,7 @@ describe('getAuthRequest', () => {
     expect(codeVerifier).toMatch(BASE64URL)
     expect(authUrl.searchParams.get('code_challenge')).toMatch(BASE64URL)
     expect(authUrl.searchParams.get('code_challenge_method')).toBe('S256')
+    expect(state).toMatch(BASE64URL)
+    expect(authUrl.searchParams.get('state')).toBe(state)
   })
 })

--- a/apps/extension/src/lib/background/services/oauthService.ts
+++ b/apps/extension/src/lib/background/services/oauthService.ts
@@ -6,15 +6,19 @@ import { base64UrlEncode } from '@/lib/util/b64UrlEncode'
 async function createPkcePair(): Promise<{
   codeVerifier: string
   codeChallenge: string
+  state: string
 }> {
-  const randomBytes = new Uint8Array(32)
-  crypto.getRandomValues(randomBytes)
-  const codeVerifier = base64UrlEncode(randomBytes)
+  const verifierBytes = new Uint8Array(32)
+  const stateBytes = new Uint8Array(16)
+  crypto.getRandomValues(verifierBytes)
+  crypto.getRandomValues(stateBytes)
+  const codeVerifier = base64UrlEncode(verifierBytes)
   const challengeBytes = await sha256(codeVerifier)
 
   return {
     codeVerifier,
     codeChallenge: base64UrlEncode(challengeBytes),
+    state: base64UrlEncode(stateBytes),
   }
 }
 
@@ -22,6 +26,7 @@ function getAuthUrl(params: {
   tenantId: TenantId
   nonce: string
   codeChallenge?: string
+  state?: string
 }) {
   const tenantConfig = getTenantConfig(params.tenantId)
 
@@ -44,15 +49,19 @@ function getAuthUrl(params: {
     url.searchParams.set('code_challenge', params.codeChallenge)
     url.searchParams.set('code_challenge_method', 'S256')
   }
+  if (params.state) {
+    url.searchParams.set('state', params.state)
+  }
 
   return url
 }
 
 async function getAuthRequest(params: { tenantId: TenantId; nonce: string }) {
-  const { codeVerifier, codeChallenge } = await createPkcePair()
+  const { codeVerifier, codeChallenge, state } = await createPkcePair()
   return {
-    authUrl: getAuthUrl({ ...params, codeChallenge }),
+    authUrl: getAuthUrl({ ...params, codeChallenge, state }),
     codeVerifier,
+    state,
   }
 }
 

--- a/apps/web/src/features/auth/components/CallbackScreen.tsx
+++ b/apps/web/src/features/auth/components/CallbackScreen.tsx
@@ -66,17 +66,24 @@ const completeOAuthCallback = async (): Promise<RoutePath> => {
 
   const { salt, address } = zkLoginResponse.data
 
-  // Update user profile with zkLogin address
+  // Update user profile with zkLogin address.
+  // salt is kept in-memory (Zustand) for signing but stripped from sessionStorage
+  // so it never sits in browser-accessible storage.
   const updatedUser = new User({
     ...user,
-    profile: {
-      ...user.profile,
-      sui_address: address,
-      salt,
-    },
+    profile: { ...user.profile, sui_address: address, salt },
   })
 
-  await userManager.storeUser(updatedUser)
+  const { salt: _s, ...profileWithoutSalt } = updatedUser.profile as Record<
+    string,
+    unknown
+  >
+  await userManager.storeUser(
+    new User({
+      ...updatedUser,
+      profile: profileWithoutSalt as User['profile'],
+    }),
+  )
   useAuthStore.getState().setUser(updatedUser)
 
   log.info('FusionAuth callback successful')

--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,7 @@
     },
     "apps/extension": {
       "name": "@evevault/extension",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "dependencies": {
         "@evevault/shared": "workspace:*",
         "@mysten/sui": "^2.17.0",
@@ -57,7 +57,7 @@
     },
     "apps/web": {
       "name": "@evevault/web",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "dependencies": {
         "@evevault/shared": "workspace:*",
         "@tanstack/react-query": "^5.100.9",
@@ -82,7 +82,7 @@
     },
     "packages/shared": {
       "name": "@evevault/shared",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "dependencies": {
         "@mysten/signers": "^1.0.5",
       },

--- a/packages/shared/src/auth/stores/__tests__/authStore.initialize.browser.test.ts
+++ b/packages/shared/src/auth/stores/__tests__/authStore.initialize.browser.test.ts
@@ -211,8 +211,11 @@ describe('authStore.initialize() (extension path)', () => {
       expect((h.mockStoreUser.mock.calls[0][0] as User).refresh_token).toBe(
         'rt',
       )
-      // Second storeUser persisted the refreshed user
-      expect(h.mockStoreUser.mock.calls[1][0]).toBe(refreshedUser)
+      // Second storeUser persisted the refreshed user (salt stripped from profile)
+      expect(h.mockStoreUser.mock.calls[1][0]).toBeInstanceOf(User)
+      expect((h.mockStoreUser.mock.calls[1][0] as User).access_token).toBe(
+        refreshedUser.access_token,
+      )
       expect(h.mockEnrichUser).toHaveBeenCalledWith(
         expect.any(User),
         expect.any(Function),

--- a/packages/shared/src/auth/stores/__tests__/authUserSession.test.ts
+++ b/packages/shared/src/auth/stores/__tests__/authUserSession.test.ts
@@ -131,7 +131,16 @@ describe('Build user from JWT', () => {
       )
 
       expect(result).toBe(enrichedUser)
-      expect(h.mockStoreUser).toHaveBeenCalledWith(enrichedUser)
+      // Salt must be stripped from the stored user — it must not sit in sessionStorage.
+      const storedUser = h.mockStoreUser.mock.calls[0]?.[0] as User
+      expect(storedUser).toBeDefined()
+      expect(
+        (storedUser.profile as Record<string, unknown>).salt,
+      ).toBeUndefined()
+      expect((storedUser.profile as Record<string, unknown>).sui_address).toBe(
+        '0xenriched',
+      )
+      // The full enriched user (with salt) is returned and used for JWT sync.
       expect(h.mockSyncPrimaryJwt).toHaveBeenCalledWith(enrichedUser)
     })
   })

--- a/packages/shared/src/auth/stores/authUserSession.ts
+++ b/packages/shared/src/auth/stores/authUserSession.ts
@@ -64,9 +64,19 @@ export async function persistEnrichedUser(
    * Enrichment may add zkLogin address/salt claims. Persist the enriched user in
    * OIDC storage and mirror its primary JWT so extension and web call sites read
    * the same session snapshot.
+   *
+   * Salt is stripped before storage: on web the userStore is sessionStorage, and
+   * salt must not sit in browser-accessible storage. Signing always re-derives
+   * salt on demand via getUserForNetwork so nothing breaks at runtime.
    */
   const enrichedUser = await enrichUserWithZkLoginIfNeeded(user, getEnokiApiKey)
-  await userManager.storeUser(enrichedUser)
+  const { salt: _stripped, ...profileWithoutSalt } = (enrichedUser.profile ??
+    {}) as Record<string, unknown>
+  const userToStore = new User({
+    ...enrichedUser,
+    profile: profileWithoutSalt as User['profile'],
+  })
+  await userManager.storeUser(userToStore)
   await syncPrimaryJwtFromUser(enrichedUser)
   return enrichedUser
 }


### PR DESCRIPTION
- Route keeper messages only from extension-origin senders (`isExtensionSender`, extracted to `senderGuard.ts` and shared with messageHandler)
- Replace bare console.error in keeper vaultHandlers with the gated logger
- Add a random state param to the OAuth authorize URL; verify the echoed value in both extLogin and dappLogin callbacks before exchanging the code
- Strip zkLogin salt from the User profile before writing to sessionStorage in both CallbackScreen (initial login) and persistEnrichedUser (silent renew); salt is kept in the in-memory Zustand store for signing and re-derived on demand via getUserForNetwork