### PR TITLE
fix: signing request flow, scripting permission

### DIFF
--- a/apps/extension/entrypoints/__tests__/content.test.ts
+++ b/apps/extension/entrypoints/__tests__/content.test.ts
@@ -293,13 +293,36 @@ describe('content bridge message validation', () => {
     ).toBe(false)
   })
 
-  it('rejects a personal message request without an account', () => {
+  it('allows a personal message request with an empty account object (ReadonlyWalletAccount loses prototype getters over postMessage; address is not validated at the content-script boundary)', () => {
     expect(
       content.isAllowedPageMessage({
         __to: 'Eve Vault',
         id: 'pm-id',
         action: WalletStandardMessageTypes.SIGN_PERSONAL_MESSAGE,
         message: [104, 101, 108, 108, 111],
+        account: {},
+      }),
+    ).toBe(true)
+  })
+
+  it('rejects a personal message request with no account field (popup would crash dereferencing account.address)', () => {
+    expect(
+      content.isAllowedPageMessage({
+        __to: 'Eve Vault',
+        id: 'pm-id',
+        action: WalletStandardMessageTypes.SIGN_PERSONAL_MESSAGE,
+        message: [104, 101, 108, 108, 111],
+      }),
+    ).toBe(false)
+  })
+
+  it('rejects a transaction request with no account field', () => {
+    expect(
+      content.isAllowedPageMessage({
+        __to: 'Eve Vault',
+        id: 'tx-id',
+        action: WalletStandardMessageTypes.SIGN_TRANSACTION,
+        transaction: 'tx-json',
       }),
     ).toBe(false)
   })

--- a/apps/extension/entrypoints/content.ts
+++ b/apps/extension/entrypoints/content.ts
@@ -38,13 +38,12 @@ function isTrustedPageEvent(event: MessageEvent): boolean {
   return event.source === window && !!origin && event.origin === origin
 }
 
-function hasObjectAccount(data: Record<string, unknown>): boolean {
-  const account = data.account
-  return (
-    isRecord(account) &&
-    typeof account.address === 'string' &&
-    account.address.length > 0
-  )
+// Crash guard: the popup dereferences account.address without optional chaining, so
+// account must be present and non-null.  The field always arrives as {} after
+// window.postMessage's structured clone strips ReadonlyWalletAccount's prototype
+// getters — isRecord({}) is true, so valid dapp requests still pass.
+function hasNonNullAccount(data: Record<string, unknown>): boolean {
+  return isRecord(data.account)
 }
 
 function hasStringFields(
@@ -89,7 +88,7 @@ function isPersonalMessageRequest(data: Record<string, unknown>): boolean {
   return (
     isValidRequestId(data.id) &&
     isMessageBytes(data.message) &&
-    hasObjectAccount(data)
+    hasNonNullAccount(data)
   )
 }
 
@@ -97,7 +96,7 @@ function isTransactionRequest(data: Record<string, unknown>): boolean {
   return (
     isValidRequestId(data.id) &&
     typeof data.transaction === 'string' &&
-    hasObjectAccount(data)
+    hasNonNullAccount(data)
   )
 }
 

--- a/apps/extension/src/features/wallet/components/UnauthenticatedView.tsx
+++ b/apps/extension/src/features/wallet/components/UnauthenticatedView.tsx
@@ -57,7 +57,7 @@ export function UnauthenticatedView({
         <header className="flex flex-col items-center gap-4 text-center">
           <Heading level={2}>Sign in</Heading>
         </header>
-        <div className="w-full max-w-[300px]">
+        <div className="w-full max-w-75">
           <Button size="fill" onClick={onLoginClick} disabled={authLoading}>
             {authLoading ? 'Loading...' : 'Login'}
           </Button>

--- a/apps/extension/src/lib/background/services/popupWindow.ts
+++ b/apps/extension/src/lib/background/services/popupWindow.ts
@@ -17,7 +17,7 @@ export async function openPopupWindow(
       url: popupUrl,
       type: 'popup',
       width: 500,
-      height: 650,
+      height: 800,
       focused: true,
     })
 

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -144,10 +144,15 @@ export default defineConfig(() => {
       },
     },
     hooks: {
+      // WXT adds `scripting` in dev for HMR content-script registration but
+      // uses a static content_scripts entry in production. Strip it from
+      // release builds only so the Web Store doesn't flag it as unused.
       'build:manifestGenerated'(_wxt, manifest) {
-        manifest.permissions = manifest.permissions?.filter(
-          (p) => p !== 'scripting',
-        )
+        if (process.env.NODE_ENV !== 'development') {
+          manifest.permissions = manifest.permissions?.filter(
+            (p) => p !== 'scripting',
+          )
+        }
       },
     },
   }

--- a/packages/shared/src/auth/__tests__/userJwtSync.test.ts
+++ b/packages/shared/src/auth/__tests__/userJwtSync.test.ts
@@ -50,8 +50,28 @@ describe('enrichUserWithZkLoginIfNeeded', () => {
     expect(mockGetZkLoginAddress).not.toHaveBeenCalled()
   })
 
-  it('returns the same user when profile.sui_address is already set', async () => {
+  it('returns the same user when profile has both sui_address and salt', async () => {
     const { enrichUserWithZkLoginIfNeeded } = await import('#/auth/userJwtSync')
+    const user = baseUser({
+      profile: {
+        sub: 'user-1',
+        sui_address: '0xsui',
+        salt: 'salt-abc',
+      } as unknown as User['profile'],
+    })
+
+    const out = await enrichUserWithZkLoginIfNeeded(user, () => 'enoki-key')
+
+    expect(out).toBe(user)
+    expect(mockGetZkLoginAddress).not.toHaveBeenCalled()
+  })
+
+  it('calls Enoki to re-derive salt when sui_address is present but salt is missing (stripped from sessionStorage)', async () => {
+    const { enrichUserWithZkLoginIfNeeded } = await import('#/auth/userJwtSync')
+    mockGetZkLoginAddress.mockResolvedValue({
+      data: { address: '0xsui', salt: 'salt-re-derived' },
+      error: undefined,
+    })
     const user = baseUser({
       profile: {
         sub: 'user-1',
@@ -61,8 +81,8 @@ describe('enrichUserWithZkLoginIfNeeded', () => {
 
     const out = await enrichUserWithZkLoginIfNeeded(user, () => 'enoki-key')
 
-    expect(out).toBe(user)
-    expect(mockGetZkLoginAddress).not.toHaveBeenCalled()
+    expect(mockGetZkLoginAddress).toHaveBeenCalledOnce()
+    expect(out.profile?.salt).toBe('salt-re-derived')
   })
 
   it('calls Enoki and merges sui_address and salt when sui_address is missing', async () => {

--- a/packages/shared/src/auth/stores/__tests__/authStore.initialize.web.browser.test.ts
+++ b/packages/shared/src/auth/stores/__tests__/authStore.initialize.web.browser.test.ts
@@ -87,8 +87,14 @@ describe('authStore.initialize() (web path)', () => {
     vi.clearAllMocks()
   })
 
-  it('sets user to webUser when the token is still valid', async () => {
-    const user = makeUser()
+  it('sets user to webUser directly when the token is valid and salt is present', async () => {
+    const user = makeUser({
+      profile: {
+        sub: 'user-1',
+        sui_address: '0xsui',
+        salt: 'abc',
+      } as User['profile'],
+    })
     h.mockGetUser.mockResolvedValue(user)
     h.mockUserToJwtResponse.mockReturnValue(makeStoredJwt())
     h.mockResolveExpiresAt.mockReturnValue(FUTURE)
@@ -96,6 +102,24 @@ describe('authStore.initialize() (web path)', () => {
     await useAuthStore.getState().initialize()
 
     expect(useAuthStore.getState().user).toBe(user)
+    expect(useAuthStore.getState().loading).toBe(false)
+    expect(h.mockSigninSilent).not.toHaveBeenCalled()
+    expect(h.mockEnrichUser).not.toHaveBeenCalled()
+  })
+
+  it('re-enriches via Enoki when the token is valid but salt was stripped from sessionStorage', async () => {
+    const user = makeUser({
+      profile: { sub: 'user-1', sui_address: '0xsui' } as User['profile'],
+    })
+    h.mockGetUser.mockResolvedValue(user)
+    h.mockUserToJwtResponse.mockReturnValue(makeStoredJwt())
+    h.mockResolveExpiresAt.mockReturnValue(FUTURE)
+
+    await useAuthStore.getState().initialize()
+
+    expect(h.mockEnrichUser).toHaveBeenCalledOnce()
+    expect(h.mockStoreUser).toHaveBeenCalledOnce()
+    expect(h.mockSyncPrimaryJwt).toHaveBeenCalledOnce()
     expect(useAuthStore.getState().loading).toBe(false)
     expect(h.mockSigninSilent).not.toHaveBeenCalled()
   })

--- a/packages/shared/src/auth/stores/authWebWorkflows.ts
+++ b/packages/shared/src/auth/stores/authWebWorkflows.ts
@@ -32,7 +32,14 @@ export async function initializeWebSession(
   const isExpired = !webJwt || now >= resolveExpiresAt(webJwt)
 
   if (!isExpired) {
-    return webUser ?? null
+    if (!webUser) return null
+    // Salt is stripped from sessionStorage for security. The user is loaded
+    // from storage without salt, so it is re-derived via Enoki before returning
+    // so the in-memory auth store is always fully enriched for signing.
+    const hasSalt =
+      typeof (webUser.profile as Record<string, unknown>)?.salt === 'string'
+    if (!hasSalt) return persistEnrichedUser(new User(webUser), webUserManager)
+    return webUser
   }
 
   if (!webUser?.refresh_token?.trim()) {

--- a/packages/shared/src/auth/userJwtSync.ts
+++ b/packages/shared/src/auth/userJwtSync.ts
@@ -22,7 +22,16 @@ export async function enrichUserWithZkLoginIfNeeded(
   }
 
   const sui = user.profile?.sui_address
-  if (typeof sui === 'string' && sui.trim()) {
+  const existingSalt = (user.profile as Record<string, unknown> | undefined)
+    ?.salt
+  // Require both address and salt — salt is stripped from sessionStorage
+  // so a user loaded from storage may have sui_address but no salt.
+  if (
+    typeof sui === 'string' &&
+    sui.trim() &&
+    typeof existingSalt === 'string' &&
+    existingSalt.trim()
+  ) {
     return user
   }
 

--- a/packages/shared/src/screens/Lockscreen/Lockscreen.tsx
+++ b/packages/shared/src/screens/Lockscreen/Lockscreen.tsx
@@ -73,7 +73,7 @@ export default function LockScreen({
 
   return (
     <div className="flex flex-col items-center justify-between gap-4 w-full h-full">
-      <section className="flex flex-col items-center gap-10 w-full flex-1">
+      <section className="flex flex-col items-center gap-10 w-full flex-1 justify-between">
         <img
           src="/images/logo.png"
           alt="Evevault Logo"


### PR DESCRIPTION
**`scripting` permission stripped unconditionally**

The `build:manifestGenerated` hook removed `scripting` from every build, including dev. WXT needs `scripting` in dev for HMR content-script registration; stripping it caused the wallet to stop being announced to dapps. The hook now guards on `NODE_ENV !== 'development'`, so production and webstore builds still drop the permission (avoiding Chrome Web Store rejection) while dev builds keep it.

**`hasObjectAccount` blocked every sign request**

`isPersonalMessageRequest` and `isTransactionRequest` required a non-empty `account.address` string. `ReadonlyWalletAccount` (from `@wallet-standard/wallet`) exposes `address` and `publicKey` as prototype getters backed by private class fields. Chrome's structured-clone algorithm — used by `window.postMessage` — only copies own enumerable properties, so the account always arrived at the content-script boundary as `{}`. Every signing request was silently dropped before reaching the background. `hasObjectAccount` is removed; the validators now only check that the request has a valid id and well-formed payload. Dapp-level authorization is enforced by `requireSigningPermission` in the background.

**Salt missing after OAuth callback page reload (web vault)**

The security fix that stripped the zkLogin salt from sessionStorage (TB8-1) left signing broken after SSO. Two places failed together: `enrichUserWithZkLoginIfNeeded` short-circuited whenever `sui_address` was present, silently skipping the missing salt; and `initializeWebSession` returned the sessionStorage user directly on the non-expired path without re-enriching. Together these meant the in-memory auth store held a saltless user after every page reload. Fixed by requiring both `sui_address` and `salt` in the early-return condition, and by calling `persistEnrichedUser` in `initializeWebSession` when salt is absent — which re-derives it from Enoki and leaves the in-memory user fully enriched for signing.