### PR TITLE
feat(security): Argon2id vault KDF and web/extension CSP

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -37,12 +37,20 @@ applications:
 # The CSP is shipped as Report-Only first (per rollout plan): it reports
 # violations without breaking the app. Once the reports are clean, rename the
 # key to `Content-Security-Policy` to enforce it.
+# TODO(tracking issue): file an issue to own the Report-Only -> enforce flip so
+# this doesn't silently live in Report-Only forever. Link it here.
 #
 # Notes:
 # - 'wasm-unsafe-eval' is required for Argon2id (hash-wasm) WebAssembly.
+# - This is the WEB CSP. The extension has its own CSP in
+#   apps/extension/wxt.config.ts (manifest content_security_policy). The two are
+#   separate surfaces in different formats, but share the same allowed-host list
+#   and 'wasm-unsafe-eval' grant — change both together.
 # - connect-src is scoped to the EVE, Sui and Mysten (Enoki/prover) orgs the
 #   app talks to. Keep this list in sync with deployed environments; once the
 #   Enoki call moves behind a server-side proxy, add that host here.
+#   TODO(tracking issue): link the Enoki-proxy work item so this connect-src
+#   entry is revisited when the proxy lands.
 # - require-trusted-types-for 'script' enables Trusted Types enforcement.
 customHeaders:
   - pattern: "**"

--- a/amplify.yml
+++ b/amplify.yml
@@ -25,43 +25,50 @@ applications:
         baseDirectory: apps/web/dist
         files:
           - "**/*"
-    # Security response headers applied to all served paths.
-    #
-    # The CSP is shipped as Report-Only first (per rollout plan): it reports
-    # violations without breaking the app. Once the violation reports are clean,
-    # rename the key to `Content-Security-Policy` to enforce it.
-    #
-    # Notes:
-    # - 'wasm-unsafe-eval' is required for Argon2id (hash-wasm) WebAssembly.
-    # - connect-src is scoped to the EVE, Sui and Mysten (Enoki/prover) orgs the
-    #   app talks to. Keep this list in sync with deployed environments; once the
-    #   Enoki call moves behind a server-side proxy, add that host here.
-    # - require-trusted-types-for 'script' enables Trusted Types enforcement.
-    customHeaders:
-      - pattern: "**"
-        headers:
-          - key: "Content-Security-Policy-Report-Only"
-            value: >-
-              default-src 'self';
-              script-src 'self' 'wasm-unsafe-eval';
-              style-src 'self' 'unsafe-inline';
-              img-src 'self' data: blob:;
-              font-src 'self' data:;
-              connect-src 'self' https://*.sui.io https://*.evefrontier.com https://*.mystenlabs.com;
-              worker-src 'self';
-              manifest-src 'self';
-              object-src 'none';
-              base-uri 'self';
-              form-action 'self';
-              frame-ancestors 'none';
-              require-trusted-types-for 'script'
-          - key: "X-Content-Type-Options"
-            value: "nosniff"
-          - key: "X-Frame-Options"
-            value: "DENY"
-          - key: "Referrer-Policy"
-            value: "strict-origin-when-cross-origin"
-          - key: "Strict-Transport-Security"
-            value: "max-age=63072000; includeSubDomains; preload"
-          - key: "Permissions-Policy"
-            value: "camera=(), microphone=(), geolocation=(), payment=()"
+
+# Security response headers applied to all served paths.
+# customHeaders is a ROOT-level key (sibling of `version`/`applications`) — this
+# is the location AWS Amplify documents for the build spec; nesting it under an
+# application or under `frontend` causes Amplify to silently ignore it.
+# NOTE: monorepo build specs fail silently if this is misplaced — verify after
+# deploy with `curl -sI https://<app-url> | grep -i content-security-policy`,
+# and fall back to the Amplify Console custom-headers UI if they don't appear.
+#
+# The CSP is shipped as Report-Only first (per rollout plan): it reports
+# violations without breaking the app. Once the reports are clean, rename the
+# key to `Content-Security-Policy` to enforce it.
+#
+# Notes:
+# - 'wasm-unsafe-eval' is required for Argon2id (hash-wasm) WebAssembly.
+# - connect-src is scoped to the EVE, Sui and Mysten (Enoki/prover) orgs the
+#   app talks to. Keep this list in sync with deployed environments; once the
+#   Enoki call moves behind a server-side proxy, add that host here.
+# - require-trusted-types-for 'script' enables Trusted Types enforcement.
+customHeaders:
+  - pattern: "**"
+    headers:
+      - key: "Content-Security-Policy-Report-Only"
+        value: >-
+          default-src 'self';
+          script-src 'self' 'wasm-unsafe-eval';
+          style-src 'self' 'unsafe-inline';
+          img-src 'self' data: blob:;
+          font-src 'self' data:;
+          connect-src 'self' https://*.sui.io https://*.evefrontier.com https://*.mystenlabs.com;
+          worker-src 'self';
+          manifest-src 'self';
+          object-src 'none';
+          base-uri 'self';
+          form-action 'self';
+          frame-ancestors 'none';
+          require-trusted-types-for 'script'
+      - key: "X-Content-Type-Options"
+        value: "nosniff"
+      - key: "X-Frame-Options"
+        value: "DENY"
+      - key: "Referrer-Policy"
+        value: "strict-origin-when-cross-origin"
+      - key: "Strict-Transport-Security"
+        value: "max-age=63072000; includeSubDomains; preload"
+      - key: "Permissions-Policy"
+        value: "camera=(), microphone=(), geolocation=(), payment=()"

--- a/amplify.yml
+++ b/amplify.yml
@@ -25,3 +25,43 @@ applications:
         baseDirectory: apps/web/dist
         files:
           - "**/*"
+    # Security response headers applied to all served paths.
+    #
+    # The CSP is shipped as Report-Only first (per rollout plan): it reports
+    # violations without breaking the app. Once the violation reports are clean,
+    # rename the key to `Content-Security-Policy` to enforce it.
+    #
+    # Notes:
+    # - 'wasm-unsafe-eval' is required for Argon2id (hash-wasm) WebAssembly.
+    # - connect-src is scoped to the EVE, Sui and Mysten (Enoki/prover) orgs the
+    #   app talks to. Keep this list in sync with deployed environments; once the
+    #   Enoki call moves behind a server-side proxy, add that host here.
+    # - require-trusted-types-for 'script' enables Trusted Types enforcement.
+    customHeaders:
+      - pattern: "**"
+        headers:
+          - key: "Content-Security-Policy-Report-Only"
+            value: >-
+              default-src 'self';
+              script-src 'self' 'wasm-unsafe-eval';
+              style-src 'self' 'unsafe-inline';
+              img-src 'self' data: blob:;
+              font-src 'self' data:;
+              connect-src 'self' https://*.sui.io https://*.evefrontier.com https://*.mystenlabs.com;
+              worker-src 'self';
+              manifest-src 'self';
+              object-src 'none';
+              base-uri 'self';
+              form-action 'self';
+              frame-ancestors 'none';
+              require-trusted-types-for 'script'
+          - key: "X-Content-Type-Options"
+            value: "nosniff"
+          - key: "X-Frame-Options"
+            value: "DENY"
+          - key: "Referrer-Policy"
+            value: "strict-origin-when-cross-origin"
+          - key: "Strict-Transport-Security"
+            value: "max-age=63072000; includeSubDomains; preload"
+          - key: "Permissions-Policy"
+            value: "camera=(), microphone=(), geolocation=(), payment=()"

--- a/apps/extension/entrypoints/keeper/keeperState.ts
+++ b/apps/extension/entrypoints/keeper/keeperState.ts
@@ -19,8 +19,10 @@ export const localnetState: LocalnetState = { localnetKey: null }
 
 /*
  * Rotation re-encrypts a new ephemeral secret key without asking for the PIN
- * again. We cache only a non-extractable CryptoKey plus the original salt; the
- * raw PIN-derived key bytes stay inside WebCrypto.
+ * again. We cache only a non-extractable CryptoKey plus the original salt — the
+ * PIN itself is never cached. Argon2id derivation briefly materialises the
+ * derived key bytes in JS before importKey(); those bytes are zeroed right
+ * after import (see deriveAesKey).
  */
 let sessionDerivedKey: CryptoKey | null = null
 let sessionSalt: string | null = null // base64 Argon2id salt from the stored HashedData

--- a/apps/extension/entrypoints/keeper/keeperState.ts
+++ b/apps/extension/entrypoints/keeper/keeperState.ts
@@ -1,9 +1,7 @@
 import type { ZKEd25519Keypair } from '@evefrontier/wallet-core/crypto'
-import type { ZkProofResponse } from '@evevault/shared'
+import { VAULT_UNLOCK_MS, type ZkProofResponse } from '@evevault/shared'
 import type { SuiChain } from '@mysten/wallet-standard'
 import type { LocalnetState } from './local'
-
-const VAULT_UNLOCK_MS = 10 * 60 * 1000
 
 /*
  * This module is loaded by the offscreen keeper document and is intentionally

--- a/apps/extension/entrypoints/keeper/keeperState.ts
+++ b/apps/extension/entrypoints/keeper/keeperState.ts
@@ -23,7 +23,7 @@ export const localnetState: LocalnetState = { localnetKey: null }
  * raw PIN-derived key bytes stay inside WebCrypto.
  */
 let sessionDerivedKey: CryptoKey | null = null
-let sessionSalt: string | null = null // base64 PBKDF2 salt from the stored HashedData
+let sessionSalt: string | null = null // base64 Argon2id salt from the stored HashedData
 
 let _vaultUnlocked = false
 let _vaultUnlockExpiry: number | null = null

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -139,8 +139,10 @@ export default defineConfig(() => {
         },
       ],
       content_security_policy: {
+        // 'wasm-unsafe-eval' is required for the keeper's Argon2id (hash-wasm)
+        // to instantiate its inline WebAssembly in the MV3 service worker.
         extension_pages:
-          "script-src 'self'; object-src 'self'; img-src 'self' data: http://localhost:3000",
+          "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; img-src 'self' data: http://localhost:3000",
       },
     },
     hooks: {

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -34,7 +34,8 @@ export default defineConfig(() => {
   const includeExtensionKey =
     process.env.WXT_WEBSTORE_BUILD !== 'true' && !!envVars.EXTENSION_ID
 
-  // Debug: Log to verify env loading (remove in production)
+  // Debug: log loaded env vars to aid local setup. Gated to non-production so
+  // it never runs in release builds.
   if (process.env.NODE_ENV !== 'production') {
     logger.info('Env vars loaded', {
       hasFusionAuthRedirectUri: !!envVars.VITE_FUSIONAUTH_REDIRECT_URI,
@@ -141,6 +142,10 @@ export default defineConfig(() => {
       content_security_policy: {
         // 'wasm-unsafe-eval' is required for the keeper's Argon2id (hash-wasm)
         // to instantiate its inline WebAssembly in the MV3 service worker.
+        // This is the EXTENSION CSP. The web app has its own CSP in
+        // amplify.yml (customHeaders). The two are separate surfaces in
+        // different formats but share the same allowed-host list and
+        // 'wasm-unsafe-eval' grant — change both together.
         extension_pages:
           "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; img-src 'self' data: http://localhost:3000",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,7 @@
     },
     "apps/extension": {
       "name": "@evevault/extension",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "dependencies": {
         "@evevault/shared": "workspace:*",
         "@mysten/sui": "^2.17.0",
@@ -57,7 +57,7 @@
     },
     "apps/web": {
       "name": "@evevault/web",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "dependencies": {
         "@evevault/shared": "workspace:*",
         "@tanstack/react-query": "^5.100.9",
@@ -82,9 +82,10 @@
     },
     "packages/shared": {
       "name": "@evevault/shared",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "dependencies": {
         "@mysten/signers": "^1.0.5",
+        "hash-wasm": "4.12.0",
       },
       "devDependencies": {
         "@testing-library/react": "^16.3.2",
@@ -1333,6 +1334,8 @@
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
     "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hash-wasm": ["hash-wasm@4.12.0", "", {}, "sha512-+/2B2rYLb48I/evdOIhP+K/DD2ca2fgBjp6O+GBEnCDk2e4rpeXIK8GvIyRPjTezgmWn9gmKwkQjjx6BtqDHVQ=="],
 
     "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -97,7 +97,8 @@
     "test:coverage": "vitest run --config ./vitest.config.mts --coverage"
   },
   "dependencies": {
-    "@mysten/signers": "^1.0.5"
+    "@mysten/signers": "^1.0.5",
+    "hash-wasm": "4.12.0"
   },
   "peerDependencies": {
     "@mysten/sui": "^2.17.0",

--- a/packages/shared/src/hooks/useDevice.helpers.ts
+++ b/packages/shared/src/hooks/useDevice.helpers.ts
@@ -5,19 +5,24 @@ import type { SuiChain } from '@mysten/wallet-standard'
 import type { DeviceState, NetworkDataMap, StoredSecretKey } from '#/types'
 import { isLocalnetChain, isZkLoginSuiChain } from '#/types/networks'
 import { KEY_FLAG_SECP256R1 } from '#/types/stores'
+import { isWebCryptoMarker } from '#/types/wallet'
 import { createLogger } from '#/utils/logger'
 
 type LocalnetData = DeviceState['localnet']
 
 const log = createLogger()
 
-/** A configured PIN produces an encrypted key object with `{ iv, data }`; a raw/null key means no PIN was set. */
+/**
+ * A configured PIN is signalled either by an encrypted key object with
+ * `{ iv, data }` (extension) or by the inert web-crypto marker (web, where the
+ * real key lives non-extractably in IndexedDB). A raw/null key means no PIN.
+ */
 export const isPinConfigured = (secretKey: StoredSecretKey): boolean => {
   return Boolean(
     secretKey &&
       typeof secretKey === 'object' &&
-      'iv' in secretKey &&
-      'data' in secretKey,
+      (isWebCryptoMarker(secretKey) ||
+        ('iv' in secretKey && 'data' in secretKey)),
   )
 }
 

--- a/packages/shared/src/services/__tests__/vaultService.test.ts
+++ b/packages/shared/src/services/__tests__/vaultService.test.ts
@@ -65,8 +65,7 @@ vi.mock('#/services/keeperService', () => ({
 // Mock wallet types
 vi.mock('#/types/wallet', () => ({
   createWebCryptoPlaceholder: vi.fn(() => ({
-    iv: 'web-placeholder',
-    data: 'web-placeholder',
+    webCryptoNonExtractable: true,
   })),
 }))
 
@@ -130,10 +129,9 @@ describe('ephKeyService routing', () => {
       )
       expect(result).toHaveProperty('hashedSecretKey')
       expect(result).toHaveProperty('publicKey')
-      // Web uses placeholder for hashedSecretKey
+      // Web uses an inert marker for hashedSecretKey
       expect(result.hashedSecretKey).toEqual({
-        iv: 'web-placeholder',
-        data: 'web-placeholder',
+        webCryptoNonExtractable: true,
       })
     })
 

--- a/packages/shared/src/services/__tests__/webVaultService.test.ts
+++ b/packages/shared/src/services/__tests__/webVaultService.test.ts
@@ -184,16 +184,16 @@ describe('WebVaultService', () => {
 
       // Verify PIN verifier was stored
       expect(mockSetFn).toHaveBeenCalledWith(
-        'evevault:web-pin-hash',
+        'evevault:web-pin-verifier',
         expect.any(String),
       )
 
       // Verify the stored value is an Argon2id encoded verifier (salt + params
       // embedded).
-      const pinHashCall = mockSetFn.mock.calls.find(
-        (call) => call[0] === 'evevault:web-pin-hash',
+      const pinVerifierCall = mockSetFn.mock.calls.find(
+        (call) => call[0] === 'evevault:web-pin-verifier',
       )
-      expect(pinHashCall?.[1]).toMatch(/^\$argon2id\$/)
+      expect(pinVerifierCall?.[1]).toMatch(/^\$argon2id\$/)
     })
 
     it('throws if PIN is empty', async () => {
@@ -225,7 +225,7 @@ describe('WebVaultService', () => {
       webVaultService.lock()
     })
 
-    it('verifies PIN hash and recovers keypair', async () => {
+    it('verifies PIN verifier and recovers keypair', async () => {
       const result = await webVaultService.unlock(testPin)
 
       expect(result).toBe(true)
@@ -255,9 +255,9 @@ describe('WebVaultService', () => {
       )
     })
 
-    it('returns false if no PIN hash exists', async () => {
-      // Clear the store to simulate no PIN hash
-      mockStore.delete('evevault:web-pin-hash')
+    it('returns false if no PIN verifier exists', async () => {
+      // Clear the store to simulate no PIN verifier
+      mockStore.delete('evevault:web-pin-verifier')
 
       const result = await webVaultService.unlock(testPin)
       expect(result).toBe(false)
@@ -364,7 +364,7 @@ describe('WebVaultService', () => {
 
       // Verify IndexedDB items were deleted
       expect(mockStore.has('evevault:web-ephemeral-keypair')).toBe(false)
-      expect(mockStore.has('evevault:web-pin-hash')).toBe(false)
+      expect(mockStore.has('evevault:web-pin-verifier')).toBe(false)
     })
   })
 

--- a/packages/shared/src/services/__tests__/webVaultService.test.ts
+++ b/packages/shared/src/services/__tests__/webVaultService.test.ts
@@ -178,21 +178,22 @@ describe('WebVaultService', () => {
       expect(publicKey.toRawBytes()).toBeInstanceOf(Uint8Array)
     })
 
-    it('stores PIN hash for verification', async () => {
+    it('stores an Argon2id PIN verifier for verification', async () => {
       const pin = '123456'
       await webVaultService.createEphemeralKeyPair(pin)
 
-      // Verify PIN hash was stored
+      // Verify PIN verifier was stored
       expect(mockSetFn).toHaveBeenCalledWith(
         'evevault:web-pin-hash',
         expect.any(String),
       )
 
-      // Verify the stored hash is 64 chars (SHA-256 hex)
+      // Verify the stored value is an Argon2id encoded verifier (salt + params
+      // embedded).
       const pinHashCall = mockSetFn.mock.calls.find(
         (call) => call[0] === 'evevault:web-pin-hash',
       )
-      expect(pinHashCall?.[1]).toHaveLength(64)
+      expect(pinHashCall?.[1]).toMatch(/^\$argon2id\$/)
     })
 
     it('throws if PIN is empty', async () => {

--- a/packages/shared/src/services/keeperService.ts
+++ b/packages/shared/src/services/keeperService.ts
@@ -3,6 +3,7 @@ import type { SuiChain } from '@mysten/wallet-standard'
 import type { ZkProofResponse } from '#/types/enoki'
 import { VaultMessageTypes, type VaultResponse } from '#/types/messages'
 import type { StoredSecretKey } from '#/types/stores'
+import { VAULT_UNLOCK_MS } from '#/utils/constants'
 import { createLogger } from '#/utils/logger'
 
 const log = createLogger()
@@ -49,7 +50,7 @@ export const ephKeyService = {
       type: VaultMessageTypes.UNLOCK_VAULT,
       hashedSecretKey: hashedSecretKey,
       pin: pin,
-      unlockDurationMs: 10 * 60 * 1000, // 10 minutes
+      unlockDurationMs: VAULT_UNLOCK_MS,
     })) as VaultResponse | undefined
 
     if (res?.ok) {

--- a/packages/shared/src/services/webVaultService.ts
+++ b/packages/shared/src/services/webVaultService.ts
@@ -2,6 +2,7 @@ import { ZKWebCryptoSigner } from '@evefrontier/wallet-core/crypto'
 import type { PublicKey } from '@mysten/sui/cryptography'
 import type { SuiChain } from '@mysten/wallet-standard'
 import type { ZkProofResponse } from '#/types/enoki'
+import { VAULT_UNLOCK_MS } from '#/utils/constants'
 import { del, get, set } from '#/utils/indexedDbKeyval'
 import { createPinVerifier, verifyPin } from '#/utils/keys/pinVerifier'
 import { createLogger } from '#/utils/logger'
@@ -9,7 +10,7 @@ import { createLogger } from '#/utils/logger'
 const log = createLogger()
 
 const KEYPAIR_STORAGE_KEY = 'evevault:web-ephemeral-keypair'
-const PIN_HASH_STORAGE_KEY = 'evevault:web-pin-hash'
+const PIN_VERIFIER_STORAGE_KEY = 'evevault:web-pin-verifier'
 const ZKPROOF_STORAGE_PREFIX = 'evevault:web-zkproof:'
 
 /**
@@ -36,7 +37,7 @@ class WebVaultService {
   }
 
   /**
-   * Creates a new Secp256r1 ephemeral keypair and stores it with a PIN hash.
+   * Creates a new Secp256r1 ephemeral keypair and stores it with a PIN verifier.
    */
   async createEphemeralKeyPair(pin: string): Promise<PublicKey> {
     if (!pin || pin.trim().length === 0) {
@@ -52,9 +53,9 @@ class WebVaultService {
 
     // Store an Argon2id PIN verifier (salt + params embedded) for unlock checks
     const pinVerifier = await createPinVerifier(pin)
-    await set(PIN_HASH_STORAGE_KEY, pinVerifier)
+    await set(PIN_VERIFIER_STORAGE_KEY, pinVerifier)
 
-    this.unlockExpiry = Date.now() + 10 * 60 * 1000
+    this.unlockExpiry = Date.now() + VAULT_UNLOCK_MS
 
     log.info(
       '[web-vault] Created new Secp256r1 ephemeral keypair (PIN verifier stored)',
@@ -65,7 +66,7 @@ class WebVaultService {
   /**
    * Unlocks the vault by verifying the PIN and recovering the keypair.
    */
-  async unlock(pin: string, durationMs = 10 * 60 * 1000): Promise<boolean> {
+  async unlock(pin: string, durationMs = VAULT_UNLOCK_MS): Promise<boolean> {
     if (!pin || pin.trim().length === 0) {
       throw new Error('PIN is required to unlock')
     }
@@ -78,7 +79,7 @@ class WebVaultService {
     }
 
     // Verify PIN against the stored Argon2id verifier
-    const storedPinVerifier = await get<string>(PIN_HASH_STORAGE_KEY)
+    const storedPinVerifier = await get<string>(PIN_VERIFIER_STORAGE_KEY)
     if (!storedPinVerifier) {
       log.error('[web-vault] No PIN verifier found')
       return false
@@ -160,8 +161,8 @@ class WebVaultService {
     this.signer = null
     this.unlockExpiry = null
     await del(KEYPAIR_STORAGE_KEY)
-    await del(PIN_HASH_STORAGE_KEY)
-    log.info('[web-vault] Cleared keypair and PIN hash')
+    await del(PIN_VERIFIER_STORAGE_KEY)
+    log.info('[web-vault] Cleared keypair and PIN verifier')
   }
 
   async rotateEphemeralKeyPair(): Promise<PublicKey> {
@@ -169,7 +170,7 @@ class WebVaultService {
       throw new Error('Vault must be unlocked again before rotating keypair')
     }
 
-    // Generate a new keypair. The PIN hash in IndexedDB is unchanged — the
+    // Generate a new keypair. The PIN verifier in IndexedDB is unchanged — the
     // user's PIN hasn't changed, only the ephemeral key has been rotated.
     const newSigner = await ZKWebCryptoSigner.generate()
     const exported = newSigner.export()

--- a/packages/shared/src/services/webVaultService.ts
+++ b/packages/shared/src/services/webVaultService.ts
@@ -57,7 +57,7 @@ class WebVaultService {
     this.unlockExpiry = Date.now() + 10 * 60 * 1000
 
     log.info(
-      '[web-vault] Created new Secp256r1 ephemeral keypair (PIN hash stored)',
+      '[web-vault] Created new Secp256r1 ephemeral keypair (PIN verifier stored)',
     )
     return this.signer.getPublicKey()
   }

--- a/packages/shared/src/services/webVaultService.ts
+++ b/packages/shared/src/services/webVaultService.ts
@@ -3,7 +3,7 @@ import type { PublicKey } from '@mysten/sui/cryptography'
 import type { SuiChain } from '@mysten/wallet-standard'
 import type { ZkProofResponse } from '#/types/enoki'
 import { del, get, set } from '#/utils/indexedDbKeyval'
-import { sha256Hex } from '#/utils/keys/sha256'
+import { createPinVerifier, verifyPin } from '#/utils/keys/pinVerifier'
 import { createLogger } from '#/utils/logger'
 
 const log = createLogger()
@@ -18,7 +18,7 @@ const ZKPROOF_STORAGE_PREFIX = 'evevault:web-zkproof:'
  * Security model:
  * - Keys are non-extractable CryptoKeys (hardware-backed security)
  * - The exported keypair handle is stored directly in IndexedDB (required by WebCryptoSigner)
- * - PIN hash is stored separately for UX-level lock/unlock verification
+ * - An Argon2id PIN verifier is stored separately for UX-level lock/unlock verification
  * - True security comes from the non-extractable nature of the CryptoKey
  */
 class WebVaultService {
@@ -50,9 +50,9 @@ class WebVaultService {
     const exported = this.signer.export()
     await set(KEYPAIR_STORAGE_KEY, exported)
 
-    // Store the PIN hash for verification
-    const pinHash = await sha256Hex(pin)
-    await set(PIN_HASH_STORAGE_KEY, pinHash)
+    // Store an Argon2id PIN verifier (salt + params embedded) for unlock checks
+    const pinVerifier = await createPinVerifier(pin)
+    await set(PIN_HASH_STORAGE_KEY, pinVerifier)
 
     this.unlockExpiry = Date.now() + 10 * 60 * 1000
 
@@ -77,15 +77,15 @@ class WebVaultService {
       return true
     }
 
-    // Verify PIN hash
-    const storedPinHash = await get(PIN_HASH_STORAGE_KEY)
-    if (!storedPinHash) {
-      log.error('[web-vault] No PIN hash found')
+    // Verify PIN against the stored Argon2id verifier
+    const storedPinVerifier = await get<string>(PIN_HASH_STORAGE_KEY)
+    if (!storedPinVerifier) {
+      log.error('[web-vault] No PIN verifier found')
       return false
     }
 
-    const providedPinHash = await sha256Hex(pin)
-    if (providedPinHash !== storedPinHash) {
+    const pinValid = await verifyPin(pin, storedPinVerifier)
+    if (!pinValid) {
       log.error('[web-vault] Invalid PIN')
       throw new Error('Invalid PIN')
     }

--- a/packages/shared/src/stores/__tests__/deviceStore.initActions.test.ts
+++ b/packages/shared/src/stores/__tests__/deviceStore.initActions.test.ts
@@ -211,9 +211,7 @@ describe('createInitActions', () => {
       expect(clearAllZkLoginJwtsMock).toHaveBeenCalledOnce()
       expect(clearZkProofsMock).toHaveBeenCalledOnce()
       expect(state.ephemeralKeyPairSecretKey).toEqual({
-        iv: 'web-crypto-signer',
-        data: 'non-extractable-key',
-        salt: 'web-crypto-salt',
+        webCryptoNonExtractable: true,
       })
       expect(state.networkData[SUI_DEVNET_CHAIN]?.maxEpoch).toBe('777')
       expect(state.networkData[SUI_DEVNET_CHAIN]?.nonce).toEqual(

--- a/packages/shared/src/stores/deviceStore/rehydrationHelpers.ts
+++ b/packages/shared/src/stores/deviceStore/rehydrationHelpers.ts
@@ -1,5 +1,6 @@
 import { ephKeyService } from '#/services/vaultService'
 import { type DeviceState, KEY_FLAG_SECP256R1 } from '#/types'
+import { isWebCryptoMarker } from '#/types/wallet'
 import { isWeb } from '#/utils/environment'
 import { createLogger } from '#/utils/logger'
 import { createEmptyLocalnetDeviceData } from './constants'
@@ -96,7 +97,7 @@ const updateWebLockState = (state: DeviceState | undefined) => {
 }
 
 const isValidStoredSecretKey = (key: object): boolean => {
-  return 'iv' in key && 'data' in key
+  return isWebCryptoMarker(key) || ('iv' in key && 'data' in key)
 }
 
 const clearPublicKeyState = (state: DeviceState) => {

--- a/packages/shared/src/types/stores.ts
+++ b/packages/shared/src/types/stores.ts
@@ -17,7 +17,14 @@ export interface StorageAdapter {
 
 export type HashedData = { iv: string; data: string; salt: string }
 
-export type StoredSecretKey = HashedData | null
+/**
+ * Sentinel stored in place of a secret key on web. The real signing key is a
+ * non-extractable WebCrypto handle held in IndexedDB and is never serialized,
+ * so this marker carries no key material — it only signals "a vault exists".
+ */
+export type WebCryptoKeyMarker = { webCryptoNonExtractable: true }
+
+export type StoredSecretKey = HashedData | WebCryptoKeyMarker | null
 
 export interface LocalnetDeviceData {
   encryptedKey: string | null

--- a/packages/shared/src/types/wallet.ts
+++ b/packages/shared/src/types/wallet.ts
@@ -3,19 +3,26 @@ import type { PublicKey, Signer } from '@mysten/sui/cryptography'
 import type { Ed25519PublicKey } from '@mysten/sui/keypairs/ed25519'
 import type { User } from 'oidc-client-ts'
 import type { ZkProofResponse } from './enoki'
-import type { StoredSecretKey } from './stores'
+import type { WebCryptoKeyMarker } from './stores'
 
-// Web crypto placeholder constants - used when the actual key is stored in IndexedDB
-// and managed by WebCryptoSigner (non-extractable)
-export const WEB_CRYPTO_PLACEHOLDER_IV = 'web-crypto-signer'
-export const WEB_CRYPTO_PLACEHOLDER_DATA = 'non-extractable-key'
-export const WEB_CRYPTO_PLACEHOLDER_SALT = 'web-crypto-salt'
-
-export const createWebCryptoPlaceholder = (): StoredSecretKey => ({
-  iv: WEB_CRYPTO_PLACEHOLDER_IV,
-  data: WEB_CRYPTO_PLACEHOLDER_DATA,
-  salt: WEB_CRYPTO_PLACEHOLDER_SALT,
+/**
+ * Inert marker stored as the web vault's "secret key". The real key is a
+ * non-extractable WebCrypto handle held in IndexedDB (managed by
+ * WebCryptoSigner), so nothing sensitive is serialized — this marker only
+ * signals that a vault exists.
+ */
+export const createWebCryptoPlaceholder = (): WebCryptoKeyMarker => ({
+  webCryptoNonExtractable: true,
 })
+
+/** Type guard for the web vault's inert non-extractable-key marker. */
+export const isWebCryptoMarker = (
+  value: unknown,
+): value is WebCryptoKeyMarker =>
+  typeof value === 'object' &&
+  value !== null &&
+  (value as { webCryptoNonExtractable?: unknown }).webCryptoNonExtractable ===
+    true
 
 export interface ZkSignAnyParams {
   user: User

--- a/packages/shared/src/utils/constants.ts
+++ b/packages/shared/src/utils/constants.ts
@@ -14,6 +14,13 @@ export const DEFAULT_LOCALNET_URL = 'http://127.0.0.1:9000'
 /** Default epoch duration (24h in ms) when endTimestamp is not yet set for current epoch */
 export const DEFAULT_EPOCH_DURATION_MS = 86_400_000
 
+/**
+ * How long the vault stays unlocked after a successful PIN entry (10 minutes).
+ * Shared by the extension keeper and the web vault so both honour the same
+ * session lifetime.
+ */
+export const VAULT_UNLOCK_MS = 10 * 60 * 1000
+
 /** Message shown on every transfer screen: network fee is paid in SUI. */
 export const GAS_FEE_WARNING_MESSAGE =
   'This transfer will incur a network fee (gas) paid in SUI.'

--- a/packages/shared/src/utils/keys/constants.test.ts
+++ b/packages/shared/src/utils/keys/constants.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ARGON2_HASH_LENGTH,
+  ARGON2_ITERATIONS,
+  ARGON2_MEMORY_KIB,
+  ARGON2_PARALLELISM,
+  ARGON2_PARAMS,
+  KDF_SALT_LENGTH,
+} from './constants'
+
+/**
+ * These constants are the entire offline-brute-force defense for a low-entropy
+ * PIN. A well-meaning "optimization" that lowers them silently weakens every
+ * encrypted vault, so pin the floor here — bumping cost is fine, but lowering
+ * it must be a deliberate, reviewed change to this test.
+ */
+describe('Argon2id KDF parameters', () => {
+  it('meets the minimum cost floor', () => {
+    expect(ARGON2_MEMORY_KIB).toBeGreaterThanOrEqual(65_536) // >= 64 MiB
+    expect(ARGON2_ITERATIONS).toBeGreaterThanOrEqual(3)
+    expect(ARGON2_HASH_LENGTH).toBe(32) // 256-bit AES key
+    expect(KDF_SALT_LENGTH).toBeGreaterThanOrEqual(16)
+  })
+
+  it('exposes a single shared param object matching the individual constants', () => {
+    expect(ARGON2_PARAMS).toEqual({
+      iterations: ARGON2_ITERATIONS,
+      parallelism: ARGON2_PARALLELISM,
+      memorySize: ARGON2_MEMORY_KIB,
+      hashLength: ARGON2_HASH_LENGTH,
+    })
+  })
+})

--- a/packages/shared/src/utils/keys/constants.ts
+++ b/packages/shared/src/utils/keys/constants.ts
@@ -11,6 +11,19 @@ export const ARGON2_ITERATIONS = 3
 export const ARGON2_PARALLELISM = 1
 export const ARGON2_HASH_LENGTH = 32 // bytes -> 256-bit AES key
 
+/**
+ * The Argon2id cost/output parameters, as a single object so every call site
+ * (deriveAesKey, createPinVerifier, ...) spreads the same values. Spread it and
+ * add the per-call `password`, `salt`, and `outputType`. Changing the cost here
+ * updates every consumer at once, which is the whole point of centralizing it.
+ */
+export const ARGON2_PARAMS = {
+  iterations: ARGON2_ITERATIONS,
+  parallelism: ARGON2_PARALLELISM,
+  memorySize: ARGON2_MEMORY_KIB,
+  hashLength: ARGON2_HASH_LENGTH,
+} as const
+
 export const KDF_SALT_LENGTH = 16 // bytes
 export const AES_KEY_LENGTH = 256 // bits
 export const AES_IV_LENGTH = 12 // bytes

--- a/packages/shared/src/utils/keys/constants.ts
+++ b/packages/shared/src/utils/keys/constants.ts
@@ -1,10 +1,16 @@
 /**
  * Cryptographic constants for key derivation and encryption.
  * Centralized to prevent parameter drift between encrypt() and decrypt().
+ *
+ * Key derivation uses Argon2id.
  */
 
-export const PBKDF2_ITERATIONS = 100_000
-export const PBKDF2_SALT_LENGTH = 16 // bytes
-export const PBKDF2_HASH_ALGORITHM = 'SHA-256'
+// Argon2id parameters. memorySize dominates the cost-per-guess against GPUs.
+export const ARGON2_MEMORY_KIB = 65_536 // 64 MiB
+export const ARGON2_ITERATIONS = 3
+export const ARGON2_PARALLELISM = 1
+export const ARGON2_HASH_LENGTH = 32 // bytes -> 256-bit AES key
+
+export const KDF_SALT_LENGTH = 16 // bytes
 export const AES_KEY_LENGTH = 256 // bits
 export const AES_IV_LENGTH = 12 // bytes

--- a/packages/shared/src/utils/keys/encrypt.browser.test.ts
+++ b/packages/shared/src/utils/keys/encrypt.browser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { AES_IV_LENGTH, PBKDF2_SALT_LENGTH } from './constants'
+import { AES_IV_LENGTH, KDF_SALT_LENGTH } from './constants'
 import { decrypt } from './decrypt'
 import { encrypt } from './encrypt'
 
@@ -32,7 +32,7 @@ describe('encrypt', () => {
   it('generates a 16-byte salt', async () => {
     const result = await encrypt('test', 'pin')
     const saltBytes = Uint8Array.from(atob(result.salt), (c) => c.charCodeAt(0))
-    expect(saltBytes.length).toBe(PBKDF2_SALT_LENGTH)
+    expect(saltBytes.length).toBe(KDF_SALT_LENGTH)
   })
 
   it('produces different ciphertext for same input (random iv/salt)', async () => {
@@ -45,7 +45,7 @@ describe('encrypt', () => {
   })
 })
 
-describe('decrypt with PBKDF2 (new format with salt)', () => {
+describe('decrypt with Argon2id (format with salt)', () => {
   it('round-trips plaintext through encrypt/decrypt', async () => {
     const plaintext = 'super secret key material'
     const pin = '123456'

--- a/packages/shared/src/utils/keys/encrypt.ts
+++ b/packages/shared/src/utils/keys/encrypt.ts
@@ -33,13 +33,22 @@ export async function deriveAesKey(
   })
   // Copy into a fresh ArrayBuffer-backed view so the type is BufferSource
   // (hash-wasm returns Uint8Array<ArrayBufferLike>).
-  return cryptoApi.subtle.importKey(
-    'raw',
-    new Uint8Array(rawKey),
-    'AES-GCM',
-    false,
-    usage,
-  )
+  const keyBytes = new Uint8Array(rawKey)
+  try {
+    // importKey copies the bytes into the opaque CryptoKey, so once it resolves
+    // we zero our copies to minimise how long raw key material lives in JS
+    // memory (best-effort defense-in-depth).
+    return await cryptoApi.subtle.importKey(
+      'raw',
+      keyBytes,
+      'AES-GCM',
+      false,
+      usage,
+    )
+  } finally {
+    keyBytes.fill(0)
+    rawKey.fill(0)
+  }
 }
 
 export async function encrypt(string: string, pin: string) {

--- a/packages/shared/src/utils/keys/encrypt.ts
+++ b/packages/shared/src/utils/keys/encrypt.ts
@@ -1,13 +1,6 @@
 import { argon2id } from 'hash-wasm'
 import { bytesToB64 } from '../base64'
-import {
-  AES_IV_LENGTH,
-  ARGON2_HASH_LENGTH,
-  ARGON2_ITERATIONS,
-  ARGON2_MEMORY_KIB,
-  ARGON2_PARALLELISM,
-  KDF_SALT_LENGTH,
-} from './constants'
+import { AES_IV_LENGTH, ARGON2_PARAMS, KDF_SALT_LENGTH } from './constants'
 
 const cryptoApi =
   typeof crypto !== 'undefined' ? crypto : (window as Window).crypto
@@ -25,10 +18,7 @@ export async function deriveAesKey(
   const rawKey = await argon2id({
     password: pin,
     salt,
-    iterations: ARGON2_ITERATIONS,
-    parallelism: ARGON2_PARALLELISM,
-    memorySize: ARGON2_MEMORY_KIB,
-    hashLength: ARGON2_HASH_LENGTH,
+    ...ARGON2_PARAMS,
     outputType: 'binary',
   })
   // Copy into a fresh ArrayBuffer-backed view so the type is BufferSource

--- a/packages/shared/src/utils/keys/encrypt.ts
+++ b/packages/shared/src/utils/keys/encrypt.ts
@@ -1,48 +1,50 @@
+import { argon2id } from 'hash-wasm'
 import { bytesToB64 } from '../base64'
 import {
   AES_IV_LENGTH,
-  AES_KEY_LENGTH,
-  PBKDF2_HASH_ALGORITHM,
-  PBKDF2_ITERATIONS,
-  PBKDF2_SALT_LENGTH,
+  ARGON2_HASH_LENGTH,
+  ARGON2_ITERATIONS,
+  ARGON2_MEMORY_KIB,
+  ARGON2_PARALLELISM,
+  KDF_SALT_LENGTH,
 } from './constants'
 
 const cryptoApi =
   typeof crypto !== 'undefined' ? crypto : (window as Window).crypto
 
 /**
- * Derives a non-extractable AES-GCM key from a PIN and salt using PBKDF2.
- * The returned CryptoKey is an opaque browser handle.
+ * Derives a non-extractable AES-GCM key from a PIN and salt using Argon2id.
+ * Argon2id is memory-hard, so each guess is expensive even on GPUs — the key
+ * defense for a low-entropy PIN. The returned CryptoKey is an opaque handle.
  */
 export async function deriveAesKey(
   pin: string,
   salt: Uint8Array<ArrayBuffer>,
   usage: KeyUsage[],
 ): Promise<CryptoKey> {
-  const keyMaterial = await cryptoApi.subtle.importKey(
+  const rawKey = await argon2id({
+    password: pin,
+    salt,
+    iterations: ARGON2_ITERATIONS,
+    parallelism: ARGON2_PARALLELISM,
+    memorySize: ARGON2_MEMORY_KIB,
+    hashLength: ARGON2_HASH_LENGTH,
+    outputType: 'binary',
+  })
+  // Copy into a fresh ArrayBuffer-backed view so the type is BufferSource
+  // (hash-wasm returns Uint8Array<ArrayBufferLike>).
+  return cryptoApi.subtle.importKey(
     'raw',
-    new TextEncoder().encode(pin),
-    { name: 'PBKDF2' },
-    false,
-    ['deriveKey'],
-  )
-  return cryptoApi.subtle.deriveKey(
-    {
-      name: 'PBKDF2',
-      salt,
-      iterations: PBKDF2_ITERATIONS,
-      hash: PBKDF2_HASH_ALGORITHM,
-    },
-    keyMaterial,
-    { name: 'AES-GCM', length: AES_KEY_LENGTH },
+    new Uint8Array(rawKey),
+    'AES-GCM',
     false,
     usage,
   )
 }
 
 export async function encrypt(string: string, pin: string) {
-  // Generate a random salt for PBKDF2 key derivation
-  const salt = cryptoApi.getRandomValues(new Uint8Array(PBKDF2_SALT_LENGTH))
+  // Generate a random salt for Argon2id key derivation
+  const salt = cryptoApi.getRandomValues(new Uint8Array(KDF_SALT_LENGTH))
   const aesKey = await deriveAesKey(pin, salt, ['encrypt'])
 
   const iv = cryptoApi.getRandomValues(new Uint8Array(AES_IV_LENGTH))
@@ -60,7 +62,7 @@ export async function encrypt(string: string, pin: string) {
 }
 
 /**
- * Encrypts using a pre-derived CryptoKey, skipping the PBKDF2 step.
+ * Encrypts using a pre-derived CryptoKey, skipping the Argon2id step.
  * The original salt is preserved in the output so that decrypt(result, pin)
  * can re-derive the same key on next unlock.
  */

--- a/packages/shared/src/utils/keys/index.ts
+++ b/packages/shared/src/utils/keys/index.ts
@@ -1,6 +1,15 @@
 import { decrypt } from './decrypt'
 import { deriveAesKey, encrypt, encryptWithKey } from './encrypt'
-import { sha256, sha256Hex } from './sha256'
+import { createPinVerifier, verifyPin } from './pinVerifier'
+import { sha256 } from './sha256'
 
 export * from './constants'
-export { decrypt, deriveAesKey, encrypt, encryptWithKey, sha256, sha256Hex }
+export {
+  createPinVerifier,
+  decrypt,
+  deriveAesKey,
+  encrypt,
+  encryptWithKey,
+  sha256,
+  verifyPin,
+}

--- a/packages/shared/src/utils/keys/pinVerifier.browser.test.ts
+++ b/packages/shared/src/utils/keys/pinVerifier.browser.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { createPinVerifier, verifyPin } from './pinVerifier'
+
+describe('createPinVerifier / verifyPin', () => {
+  it('produces an Argon2id encoded verifier string', async () => {
+    const verifier = await createPinVerifier('123456')
+    expect(verifier.startsWith('$argon2id$')).toBe(true)
+  })
+
+  it('verifies the correct PIN', async () => {
+    const verifier = await createPinVerifier('123456')
+    expect(await verifyPin('123456', verifier)).toBe(true)
+  })
+
+  it('rejects an incorrect PIN', async () => {
+    const verifier = await createPinVerifier('123456')
+    expect(await verifyPin('654321', verifier)).toBe(false)
+  })
+
+  it('uses a random salt so the same PIN yields different verifiers', async () => {
+    const a = await createPinVerifier('123456')
+    const b = await createPinVerifier('123456')
+    expect(a).not.toBe(b)
+    // ...yet both still verify the same PIN
+    expect(await verifyPin('123456', a)).toBe(true)
+    expect(await verifyPin('123456', b)).toBe(true)
+  })
+
+  it('returns false (does not throw) on a malformed verifier', async () => {
+    expect(await verifyPin('123456', 'not-a-valid-hash')).toBe(false)
+  })
+})

--- a/packages/shared/src/utils/keys/pinVerifier.ts
+++ b/packages/shared/src/utils/keys/pinVerifier.ts
@@ -1,11 +1,5 @@
 import { argon2id, argon2Verify } from 'hash-wasm'
-import {
-  ARGON2_HASH_LENGTH,
-  ARGON2_ITERATIONS,
-  ARGON2_MEMORY_KIB,
-  ARGON2_PARALLELISM,
-  KDF_SALT_LENGTH,
-} from './constants'
+import { ARGON2_PARAMS, KDF_SALT_LENGTH } from './constants'
 
 const cryptoApi =
   typeof crypto !== 'undefined' ? crypto : (window as Window).crypto
@@ -22,10 +16,7 @@ export async function createPinVerifier(pin: string): Promise<string> {
   return argon2id({
     password: pin,
     salt,
-    iterations: ARGON2_ITERATIONS,
-    parallelism: ARGON2_PARALLELISM,
-    memorySize: ARGON2_MEMORY_KIB,
-    hashLength: ARGON2_HASH_LENGTH,
+    ...ARGON2_PARAMS,
     outputType: 'encoded',
   })
 }

--- a/packages/shared/src/utils/keys/pinVerifier.ts
+++ b/packages/shared/src/utils/keys/pinVerifier.ts
@@ -1,0 +1,47 @@
+import { argon2id, argon2Verify } from 'hash-wasm'
+import {
+  ARGON2_HASH_LENGTH,
+  ARGON2_ITERATIONS,
+  ARGON2_MEMORY_KIB,
+  ARGON2_PARALLELISM,
+  KDF_SALT_LENGTH,
+} from './constants'
+
+const cryptoApi =
+  typeof crypto !== 'undefined' ? crypto : (window as Window).crypto
+
+/**
+ * Creates an Argon2id verifier for a PIN. The returned "encoded" string embeds
+ * a random per-user salt and the Argon2id parameters, so it is fully
+ * self-describing. This is a UX-level unlock gate — NOT key material — but
+ * Argon2id's memory-hardness means a stolen verifier cannot be reversed to the
+ * PIN by cheap offline brute-force.
+ */
+export async function createPinVerifier(pin: string): Promise<string> {
+  const salt = cryptoApi.getRandomValues(new Uint8Array(KDF_SALT_LENGTH))
+  return argon2id({
+    password: pin,
+    salt,
+    iterations: ARGON2_ITERATIONS,
+    parallelism: ARGON2_PARALLELISM,
+    memorySize: ARGON2_MEMORY_KIB,
+    hashLength: ARGON2_HASH_LENGTH,
+    outputType: 'encoded',
+  })
+}
+
+/**
+ * Verifies a PIN against a stored verifier created by createPinVerifier().
+ * argon2Verify performs a constant-time comparison internally. Returns false
+ * (rather than throwing) on malformed verifiers.
+ */
+export async function verifyPin(
+  pin: string,
+  verifier: string,
+): Promise<boolean> {
+  try {
+    return await argon2Verify({ password: pin, hash: verifier })
+  } catch {
+    return false
+  }
+}

--- a/packages/shared/src/utils/keys/sha256.browser.test.ts
+++ b/packages/shared/src/utils/keys/sha256.browser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { sha256, sha256Hex } from './sha256'
+import { sha256 } from './sha256'
 
 describe('sha256', () => {
   it('returns a real ArrayBuffer for string input', async () => {
@@ -30,53 +30,5 @@ describe('sha256', () => {
   it('produces 32-byte (256-bit) output', async () => {
     const result = await sha256('any input')
     expect(result.byteLength).toBe(32)
-  })
-})
-
-describe('sha256Hex', () => {
-  it('returns 64-character hex string', async () => {
-    const result = await sha256Hex('test')
-    expect(result).toHaveLength(64)
-    expect(result).toMatch(/^[0-9a-f]+$/)
-  })
-
-  it('produces known hash for test vector', async () => {
-    // SHA-256 of empty string is a well-known test vector
-    const emptyHash = await sha256Hex('')
-    expect(emptyHash).toBe(
-      'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
-    )
-
-    // SHA-256 of "hello" is another known test vector
-    const helloHash = await sha256Hex('hello')
-    expect(helloHash).toBe(
-      '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824',
-    )
-  })
-
-  it('is consistent with sha256 output', async () => {
-    const input = 'test input'
-    const arrayBuffer = await sha256(input)
-    const hexString = await sha256Hex(input)
-
-    // Convert ArrayBuffer to hex manually
-    const bytes = new Uint8Array(arrayBuffer)
-    const manualHex = Array.from(bytes)
-      .map((b) => b.toString(16).padStart(2, '0'))
-      .join('')
-
-    expect(hexString).toBe(manualHex)
-  })
-
-  it('produces consistent hashes for same input', async () => {
-    const hash1 = await sha256Hex('same input')
-    const hash2 = await sha256Hex('same input')
-    expect(hash1).toBe(hash2)
-  })
-
-  it('produces different hashes for different inputs', async () => {
-    const hash1 = await sha256Hex('input1')
-    const hash2 = await sha256Hex('input2')
-    expect(hash1).not.toBe(hash2)
   })
 })

--- a/packages/shared/src/utils/keys/sha256.ts
+++ b/packages/shared/src/utils/keys/sha256.ts
@@ -1,20 +1,12 @@
 /**
  * Computes SHA-256 hash of a string, returning raw bytes.
- * Use this when you need the hash as key material (e.g., for AES encryption).
+ * Used for fixed-purpose digests such as the OAuth PKCE code challenge.
+ * NOTE: do not use this to hash PINs/passwords — use Argon2id (see
+ * deriveAesKey / createPinVerifier) which is memory-hard.
  */
 export async function sha256(input: string): Promise<ArrayBuffer> {
   const cryptoApi = typeof crypto !== 'undefined' ? crypto : window.crypto
   const encoder = new TextEncoder()
   const data = encoder.encode(input)
   return cryptoApi.subtle.digest('SHA-256', data)
-}
-
-/**
- * Computes SHA-256 hash of a string, returning a hex string.
- * Use this when you need the hash for storage or comparison.
- */
-export async function sha256Hex(input: string): Promise<string> {
-  const hashBuffer = await sha256(input)
-  const hashArray = Array.from(new Uint8Array(hashBuffer))
-  return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
 }

--- a/packages/shared/src/wallet/index.ts
+++ b/packages/shared/src/wallet/index.ts
@@ -3,8 +3,7 @@
 
 export {
   createWebCryptoPlaceholder,
-  WEB_CRYPTO_PLACEHOLDER_DATA,
-  WEB_CRYPTO_PLACEHOLDER_IV,
+  isWebCryptoMarker,
 } from '../types/wallet'
 export { useActiveSuiAddress } from './hooks/useActiveSuiAddress'
 export { useBalance } from './hooks/useBalance'


### PR DESCRIPTION
Proactive hardening of the vault crypto and HTTP security posture.

### Changes
- **Argon2id key derivation** across the shared key utilities (`packages/shared/src/utils/keys`), replacing the prior derivation. Memory-hard parameters: 64 MiB, t=3, p=1, 256-bit key, random per-derivation salt. Adds `hash-wasm` (MIT, inline WASM).
- **Web vault PIN** now uses a salted Argon2id verifier instead of a plain hash. Removed an unused hashing helper (the SHA-256 used for the OAuth PKCE challenge is unchanged).
- **Extension** keeper inherits the Argon2id derivation; updated the MV3 CSP to permit the WASM module.
- **Web** now sends a Content-Security-Policy (with Trusted Types) and standard security headers (`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, HSTS, `Permissions-Policy`) via Amplify.

### Notes
- App is pre-release, so no data migration is included.