### PR TITLE
feat: remove enoki api from `getZkLoginAddress`

### DIFF
--- a/.envsample
+++ b/.envsample
@@ -1,4 +1,3 @@
 VITE_FUSIONAUTH_REDIRECT_URI=chrome-extension://lbmfdkobfnkfobfahpekbaaombpnafah/callback.html
 
 EXTENSION_ID=
-VITE_ENOKI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -55,9 +55,6 @@ Create a `.env` at the **repository root** (WXT loads env from the monorepo root
 # FusionAuth
 VITE_FUSIONAUTH_REDIRECT_URI=
 
-# Enoki
-VITE_ENOKI_API_KEY=
-
 # Extension (when required by your build / OAuth redirect)
 EXTENSION_ID=
 ```

--- a/apps/extension/src/lib/background/handlers/auth/__tests__/dappLogin.test.ts
+++ b/apps/extension/src/lib/background/handlers/auth/__tests__/dappLogin.test.ts
@@ -146,11 +146,9 @@ describe('handleDappLogin', () => {
       token_type: 'Bearer',
     })
     mockGetZkLoginAddress.mockResolvedValue({
-      data: {
-        address: '0xzk',
-        publicKey: 'AQID',
-      },
-      error: undefined,
+      address: '0xzk',
+      publicKey: 'AQID',
+      salt: '99',
     })
   })
 
@@ -172,7 +170,6 @@ describe('handleDappLogin', () => {
 
     expect(mockGetZkLoginAddress).toHaveBeenCalledWith({
       jwt: 'access-token',
-      enokiApiKey: '',
     })
     expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
       id: 'connect-id',
@@ -302,11 +299,10 @@ describe('handleDappLogin', () => {
     )
   })
 
-  it('sends auth_error when zkLogin address lookup fails', async () => {
-    mockGetZkLoginAddress.mockResolvedValue({
-      data: undefined,
-      error: { message: 'Enoki lookup failed' },
-    })
+  it('sends auth_error when the zkLogin address lookup throws', async () => {
+    mockGetZkLoginAddress.mockRejectedValue(
+      new Error('zkLogin address request failed (401): unauthorized'),
+    )
 
     await handleDappLogin(
       { id: 'zk-fail' },
@@ -318,18 +314,24 @@ describe('handleDappLogin', () => {
       42,
     )
 
-    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
-      id: 'zk-fail',
-      type: 'auth_error',
-      error: expect.objectContaining({ message: 'Enoki lookup failed' }),
-    })
+    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({
+        id: 'zk-fail',
+        type: 'auth_error',
+        error: expect.objectContaining({
+          message: expect.stringContaining('account metadata'),
+        }),
+      }),
+    )
   })
 
   it('sends auth_error when zkLogin address is missing from the response', async () => {
     mockGetZkLoginAddress.mockResolvedValue({
-      data: { address: undefined, publicKey: undefined },
-      error: undefined,
-    })
+      address: undefined,
+      publicKey: undefined,
+      salt: undefined,
+    } as unknown as Awaited<ReturnType<typeof getZkLoginAddress>>)
 
     await handleDappLogin(
       { id: 'zk-no-addr' },

--- a/apps/extension/src/lib/background/handlers/auth/dappLogin.ts
+++ b/apps/extension/src/lib/background/handlers/auth/dappLogin.ts
@@ -282,7 +282,6 @@ async function fetchDappZkLoginAddress(
 ): Promise<ZkLoginAddressResult | null> {
   return getZkLoginAddress({
     jwt: accessToken,
-    enokiApiKey: import.meta.env.VITE_ENOKI_API_KEY ?? '',
   }).catch((error) => {
     log.error('Failed to resolve dApp account metadata', error)
     return null
@@ -299,16 +298,7 @@ function parseDappZkLoginAccount(
     }
   }
 
-  const hasLookupError = !!zkLoginResponse.error
-  if (hasLookupError) {
-    return {
-      ok: false,
-      error: zkLoginResponse?.error?.message ?? 'Unknown authentication error',
-    }
-  }
-
-  const address = zkLoginResponse.data?.address
-  const publicKey = zkLoginResponse.data?.publicKey
+  const { address, publicKey } = zkLoginResponse
   const account = buildDappAccountMetadata(address, publicKey)
   if (!account) {
     return {

--- a/apps/web/src/features/auth/components/CallbackScreen.tsx
+++ b/apps/web/src/features/auth/components/CallbackScreen.tsx
@@ -51,20 +51,9 @@ const completeOAuthCallback = async (): Promise<RoutePath> => {
   }
 
   // Get zkLogin address
-  const zkLoginResponse = await getZkLoginAddress({
+  const { salt, address } = await getZkLoginAddress({
     jwt: user.id_token,
-    enokiApiKey: import.meta.env.VITE_ENOKI_API_KEY,
   })
-
-  if (zkLoginResponse.error) {
-    throw new Error(zkLoginResponse.error.message)
-  }
-
-  if (!zkLoginResponse.data) {
-    throw new Error('No zkLogin address data received')
-  }
-
-  const { salt, address } = zkLoginResponse.data
 
   // Update user profile with zkLogin address.
   // salt is kept in-memory (Zustand) for signing but stripped from sessionStorage

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -265,15 +265,13 @@ Common issues and solutions when working with the EVE Vault extension.
 **Symptoms:**
 
 - Address derivation fails
-- "Enoki API error" message
 
 **Solutions:**
 
-1. Verify `VITE_ENOKI_API_KEY` is set correctly
-2. Check API key is valid and not expired
-3. Verify Enoki API is accessible
+1. Verify JWT passed is set correctly
+2. Check JWT is valid and not expired
+3. Verify API Gateway is accessible
 4. Check rate limits
-5. Review Enoki API documentation
 
 ## Development Issues
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -260,7 +260,7 @@ Common issues and solutions when working with the EVE Vault extension.
 4. Verify network switching works
 5. Check for CORS issues
 
-### Enoki API errors
+### zkLogin address derivation errors
 
 **Symptoms:**
 
@@ -268,7 +268,7 @@ Common issues and solutions when working with the EVE Vault extension.
 
 **Solutions:**
 
-1. Verify JWT passed is set correctly
+1. Verify the JWT is present and passed correctly
 2. Check JWT is valid and not expired
 3. Verify API Gateway is accessible
 4. Check rate limits

--- a/packages/shared/src/auth/__tests__/getZkLoginAddress.test.ts
+++ b/packages/shared/src/auth/__tests__/getZkLoginAddress.test.ts
@@ -4,10 +4,29 @@ import {
   getZkLoginAddress,
 } from '#/auth/getZkLoginAddress'
 
-const ENOKI_URL = 'https://api.enoki.mystenlabs.com/v1/zklogin'
+// A minimally-valid JWT (unsigned) whose payload carries the tenant/tier the
+// URL is derived from. Default tenant + no tier => `test` tier host.
+const b64url = (obj: unknown) =>
+  Buffer.from(JSON.stringify(obj)).toString('base64url')
+const makeJwt = (payload: Record<string, unknown>) =>
+  `${b64url({ alg: 'none' })}.${b64url(payload)}.`
+
+const JWT = makeJwt({ tenant: 'nova', sub: 'user-1' })
+const ZKLOGIN_URL = 'https://api.test.pub.evefrontier.com/auth/zklogin'
 
 const okResponse = (data: unknown) =>
-  ({ json: () => Promise.resolve(data) }) as unknown as Response
+  ({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(data),
+  }) as unknown as Response
+
+const errorResponse = (status: number, body: string) =>
+  ({
+    ok: false,
+    status,
+    text: () => Promise.resolve(body),
+  }) as unknown as Response
 
 describe('getZkLoginAddress', () => {
   let fetchMock: ReturnType<typeof vi.fn>
@@ -22,72 +41,75 @@ describe('getZkLoginAddress', () => {
     vi.unstubAllGlobals()
   })
 
-  it('fetches with the API key and JWT headers and returns the response', async () => {
-    const body = { data: { address: '0xabc', salt: '1', publicKey: 'pk' } }
+  it('fetches the tenant-derived URL with bearer + tenant headers and returns the data', async () => {
+    const body = { address: '0xabc', salt: '1', publicKey: 'pk' }
     fetchMock.mockResolvedValue(okResponse(body))
 
-    const result = await getZkLoginAddress({
-      jwt: 'jwt-token',
-      enokiApiKey: 'enoki-key',
-    })
+    const result = await getZkLoginAddress({ jwt: JWT })
 
     expect(result).toEqual(body)
-    expect(fetchMock).toHaveBeenCalledWith(ENOKI_URL, {
+    expect(fetchMock).toHaveBeenCalledWith(ZKLOGIN_URL, {
       method: 'GET',
       headers: {
-        Authorization: 'enoki-key',
-        'zklogin-jwt': 'jwt-token',
+        'X-Tenant': 'nova',
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${JWT}`,
       },
     })
   })
 
   it('caches successful responses so a repeat call does not re-fetch', async () => {
-    const body = { data: { address: '0xabc', salt: '1', publicKey: 'pk' } }
+    const body = { address: '0xabc', salt: '1', publicKey: 'pk' }
     fetchMock.mockResolvedValue(okResponse(body))
 
-    const params = { jwt: 'jwt-token', enokiApiKey: 'enoki-key' }
-    const first = await getZkLoginAddress(params)
-    const second = await getZkLoginAddress(params)
+    const first = await getZkLoginAddress({ jwt: JWT })
+    const second = await getZkLoginAddress({ jwt: JWT })
 
     expect(first).toBe(second)
     expect(fetchMock).toHaveBeenCalledOnce()
   })
 
-  it('does not cache error responses, so a transient failure stays retryable on the next call', async () => {
-    fetchMock.mockResolvedValue(
-      okResponse({ data: undefined, error: { message: 'bad jwt' } }),
+  it('throws with the status and body on a non-ok response, and does not cache it', async () => {
+    fetchMock.mockResolvedValue(errorResponse(401, '{"title":"Unauthorized"}'))
+
+    await expect(getZkLoginAddress({ jwt: JWT })).rejects.toThrow(
+      /failed \(401\).*Unauthorized/,
     )
-
-    const params = { jwt: 'jwt-token', enokiApiKey: 'enoki-key' }
-    const first = await getZkLoginAddress(params)
-    const second = await getZkLoginAddress(params)
-
+    // Not cached — a retry re-fetches.
+    fetchMock.mockResolvedValue(
+      okResponse({ address: '0x1', salt: '1', publicKey: 'pk' }),
+    )
+    await getZkLoginAddress({ jwt: JWT })
     expect(fetchMock).toHaveBeenCalledTimes(2)
-    // The error payload is still returned to the caller on both calls.
-    expect(first.error?.message).toBe('bad jwt')
-    expect(second.error?.message).toBe('bad jwt')
   })
 
-  it('keys the cache by API key + JWT so different params re-fetch', async () => {
+  it('throws when a 200 response is missing salt/address', async () => {
+    fetchMock.mockResolvedValue(okResponse({ publicKey: 'pk' }))
+
+    await expect(getZkLoginAddress({ jwt: JWT })).rejects.toThrow(
+      /missing salt\/address/,
+    )
+  })
+
+  it('keys the cache by JWT so a different token re-fetches', async () => {
     fetchMock.mockResolvedValue(
-      okResponse({ data: { address: '0x1', salt: '1', publicKey: 'pk' } }),
+      okResponse({ address: '0x1', salt: '1', publicKey: 'pk' }),
     )
 
-    await getZkLoginAddress({ jwt: 'jwt-a', enokiApiKey: 'key' })
-    await getZkLoginAddress({ jwt: 'jwt-b', enokiApiKey: 'key' })
+    await getZkLoginAddress({ jwt: makeJwt({ tenant: 'nova', sub: 'a' }) })
+    await getZkLoginAddress({ jwt: makeJwt({ tenant: 'nova', sub: 'b' }) })
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
   it('clearZkLoginAddressCache forces the next call to re-fetch', async () => {
     fetchMock.mockResolvedValue(
-      okResponse({ data: { address: '0x1', salt: '1', publicKey: 'pk' } }),
+      okResponse({ address: '0x1', salt: '1', publicKey: 'pk' }),
     )
 
-    const params = { jwt: 'jwt-token', enokiApiKey: 'enoki-key' }
-    await getZkLoginAddress(params)
+    await getZkLoginAddress({ jwt: JWT })
     clearZkLoginAddressCache()
-    await getZkLoginAddress(params)
+    await getZkLoginAddress({ jwt: JWT })
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })

--- a/packages/shared/src/auth/__tests__/getZkLoginAddress.test.ts
+++ b/packages/shared/src/auth/__tests__/getZkLoginAddress.test.ts
@@ -87,7 +87,15 @@ describe('getZkLoginAddress', () => {
     fetchMock.mockResolvedValue(okResponse({ publicKey: 'pk' }))
 
     await expect(getZkLoginAddress({ jwt: JWT })).rejects.toThrow(
-      /missing salt\/address/,
+      /missing salt\/address\/publicKey/,
+    )
+  })
+
+  it('throws when a 200 response is missing publicKey', async () => {
+    fetchMock.mockResolvedValue(okResponse({ address: '0xabc', salt: '1' }))
+
+    await expect(getZkLoginAddress({ jwt: JWT })).rejects.toThrow(
+      /missing salt\/address\/publicKey/,
     )
   })
 

--- a/packages/shared/src/auth/__tests__/userJwtSync.test.ts
+++ b/packages/shared/src/auth/__tests__/userJwtSync.test.ts
@@ -44,7 +44,7 @@ describe('enrichUserWithZkLoginIfNeeded', () => {
     const { enrichUserWithZkLoginIfNeeded } = await import('#/auth/userJwtSync')
     const user = baseUser({ id_token: undefined })
 
-    const out = await enrichUserWithZkLoginIfNeeded(user, () => 'enoki-key')
+    const out = await enrichUserWithZkLoginIfNeeded(user)
 
     expect(out).toBe(user)
     expect(mockGetZkLoginAddress).not.toHaveBeenCalled()
@@ -60,17 +60,18 @@ describe('enrichUserWithZkLoginIfNeeded', () => {
       } as unknown as User['profile'],
     })
 
-    const out = await enrichUserWithZkLoginIfNeeded(user, () => 'enoki-key')
+    const out = await enrichUserWithZkLoginIfNeeded(user)
 
     expect(out).toBe(user)
     expect(mockGetZkLoginAddress).not.toHaveBeenCalled()
   })
 
-  it('calls Enoki to re-derive salt when sui_address is present but salt is missing (stripped from sessionStorage)', async () => {
+  it('re-derives salt when sui_address is present but salt is missing (stripped from sessionStorage)', async () => {
     const { enrichUserWithZkLoginIfNeeded } = await import('#/auth/userJwtSync')
     mockGetZkLoginAddress.mockResolvedValue({
-      data: { address: '0xsui', salt: 'salt-re-derived' },
-      error: undefined,
+      address: '0xsui',
+      salt: 'salt-re-derived',
+      publicKey: 'pk',
     })
     const user = baseUser({
       profile: {
@@ -79,46 +80,45 @@ describe('enrichUserWithZkLoginIfNeeded', () => {
       } as unknown as User['profile'],
     })
 
-    const out = await enrichUserWithZkLoginIfNeeded(user, () => 'enoki-key')
+    const out = await enrichUserWithZkLoginIfNeeded(user)
 
     expect(mockGetZkLoginAddress).toHaveBeenCalledOnce()
     expect(out.profile?.salt).toBe('salt-re-derived')
   })
 
-  it('calls Enoki and merges sui_address and salt when sui_address is missing', async () => {
+  it('fetches and merges sui_address and salt when sui_address is missing', async () => {
     const { enrichUserWithZkLoginIfNeeded } = await import('#/auth/userJwtSync')
     mockGetZkLoginAddress.mockResolvedValue({
-      data: { address: '0xenoki', salt: 'salt-99' },
-      error: undefined,
+      address: '0xenoki',
+      salt: 'salt-99',
+      publicKey: 'pk',
     })
 
     const user = baseUser({
       profile: { sub: 'user-1' } as User['profile'],
     })
 
-    const out = await enrichUserWithZkLoginIfNeeded(user, () => 'enoki-key')
+    const out = await enrichUserWithZkLoginIfNeeded(user)
 
     expect(mockGetZkLoginAddress).toHaveBeenCalledWith({
       jwt: user.id_token,
-      enokiApiKey: 'enoki-key',
     })
     expect(out).not.toBe(user)
     expect(out.profile?.sui_address).toBe('0xenoki')
     expect(out.profile?.salt).toBe('salt-99')
   })
 
-  it('throws when Enoki returns an error', async () => {
+  it('propagates the error when the zkLogin address request fails', async () => {
     const { enrichUserWithZkLoginIfNeeded } = await import('#/auth/userJwtSync')
-    mockGetZkLoginAddress.mockResolvedValue({
-      data: undefined,
-      error: { message: 'Enoki down' },
-    })
+    mockGetZkLoginAddress.mockRejectedValue(
+      new Error('zkLogin address request failed (401): unauthorized'),
+    )
 
     const user = baseUser({})
 
-    await expect(
-      enrichUserWithZkLoginIfNeeded(user, () => 'k'),
-    ).rejects.toThrow('Enoki down')
+    await expect(enrichUserWithZkLoginIfNeeded(user)).rejects.toThrow(
+      /failed \(401\)/,
+    )
   })
 })
 

--- a/packages/shared/src/auth/getZkLoginAddress.ts
+++ b/packages/shared/src/auth/getZkLoginAddress.ts
@@ -2,11 +2,9 @@ import type { ZkLoginAddressData } from '#/types/enoki'
 import { getApiContext } from './getApiContext'
 import type { GetZkLoginAddressParams } from './types'
 
+// Keyed by JWT: the token uniquely identifies the user/session the address
+// is derived for.
 const cache = new Map<string, ZkLoginAddressData>()
-
-function cacheKey(params: GetZkLoginAddressParams): string {
-  return `${params.jwt}`
-}
 
 /**
  * Clear the in-memory cache of zkLogin address lookups.
@@ -19,13 +17,12 @@ export function clearZkLoginAddressCache(): void {
 export async function getZkLoginAddress(
   params: GetZkLoginAddressParams,
 ): Promise<ZkLoginAddressData> {
-  const key = cacheKey(params)
-  const cached = cache.get(key)
+  const { jwt } = params
+
+  const cached = cache.get(jwt)
   if (cached !== undefined) {
     return cached
   }
-
-  const { jwt } = params
 
   const { apiBaseUrl, tenant } = getApiContext(jwt)
 
@@ -57,7 +54,7 @@ export async function getZkLoginAddress(
     )
   }
 
-  cache.set(key, responseJson)
+  cache.set(jwt, responseJson)
 
   return responseJson
 }

--- a/packages/shared/src/auth/getZkLoginAddress.ts
+++ b/packages/shared/src/auth/getZkLoginAddress.ts
@@ -51,9 +51,9 @@ export async function getZkLoginAddress(
 
   const responseJson = (await response.json()) as unknown as ZkLoginAddressData
 
-  if (!responseJson.salt || !responseJson.address) {
+  if (!responseJson.salt || !responseJson.address || !responseJson.publicKey) {
     throw new Error(
-      `zkLogin address response missing salt/address: ${JSON.stringify(responseJson)}`,
+      `zkLogin address response missing salt/address/publicKey: ${JSON.stringify(responseJson)}`,
     )
   }
 

--- a/packages/shared/src/auth/getZkLoginAddress.ts
+++ b/packages/shared/src/auth/getZkLoginAddress.ts
@@ -1,10 +1,11 @@
-import type { ZkLoginAddressResponse } from '#/types/enoki'
+import type { ZkLoginAddressData } from '#/types/enoki'
+import { getApiContext } from './getApiContext'
 import type { GetZkLoginAddressParams } from './types'
 
-const cache = new Map<string, ZkLoginAddressResponse>()
+const cache = new Map<string, ZkLoginAddressData>()
 
 function cacheKey(params: GetZkLoginAddressParams): string {
-  return `${params.enokiApiKey}:${params.jwt}`
+  return `${params.jwt}`
 }
 
 /**
@@ -17,29 +18,46 @@ export function clearZkLoginAddressCache(): void {
 
 export async function getZkLoginAddress(
   params: GetZkLoginAddressParams,
-): Promise<ZkLoginAddressResponse> {
+): Promise<ZkLoginAddressData> {
   const key = cacheKey(params)
   const cached = cache.get(key)
   if (cached !== undefined) {
     return cached
   }
 
-  const { jwt, enokiApiKey } = params
+  const { jwt } = params
 
-  const response = await fetch('https://api.enoki.mystenlabs.com/v1/zklogin', {
+  const { apiBaseUrl, tenant } = getApiContext(jwt)
+
+  const response = await fetch(`${apiBaseUrl}/auth/zklogin`, {
     method: 'GET',
     headers: {
-      Authorization: enokiApiKey,
-      'zklogin-jwt': jwt,
+      'X-Tenant': tenant,
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${jwt}`,
     },
   })
 
-  const responseJson =
-    (await response.json()) as unknown as ZkLoginAddressResponse
-
-  if (responseJson.data !== undefined) {
-    cache.set(key, responseJson)
+  if (!response.ok) {
+    // The endpoint returns errors in more than one shape (`{ error: string }`
+    // for proxy/tenant failures, RFC-7807 `{ title, status, detail }` from the
+    // handler). Surface the raw body so the real cause isn't masked by a
+    // generic "no data" error downstream.
+    const body = await response.text()
+    throw new Error(
+      `zkLogin address request failed (${response.status}): ${body}`,
+    )
   }
+
+  const responseJson = (await response.json()) as unknown as ZkLoginAddressData
+
+  if (!responseJson.salt || !responseJson.address) {
+    throw new Error(
+      `zkLogin address response missing salt/address: ${JSON.stringify(responseJson)}`,
+    )
+  }
+
+  cache.set(key, responseJson)
 
   return responseJson
 }

--- a/packages/shared/src/auth/stores/__tests__/authExtensionLogin.test.ts
+++ b/packages/shared/src/auth/stores/__tests__/authExtensionLogin.test.ts
@@ -72,10 +72,7 @@ describe('authExtensionLogin()', () => {
       )
 
       expect(user).toBeDefined()
-      expect(h.mockEnrichUser).toHaveBeenCalledWith(
-        expect.any(User),
-        expect.any(Function),
-      )
+      expect(h.mockEnrichUser).toHaveBeenCalledWith(expect.any(User))
       expect(h.mockStoreUser).toHaveBeenCalledWith(expect.any(User))
       expect(h.mockSyncPrimaryJwt).toHaveBeenCalledWith(expect.any(User))
       expect(mockSet).toHaveBeenCalledWith(

--- a/packages/shared/src/auth/stores/__tests__/authStore.extensionLogin.test.ts
+++ b/packages/shared/src/auth/stores/__tests__/authStore.extensionLogin.test.ts
@@ -183,10 +183,7 @@ describe('authStore.extensionLogin()', () => {
 
       expect(user).toBe(enrichedUser)
       expect(h.mockDecodeJwt).toHaveBeenCalledWith(tokenResponse.id_token)
-      expect(h.mockEnrichUser).toHaveBeenCalledWith(
-        expect.any(User),
-        expect.any(Function),
-      )
+      expect(h.mockEnrichUser).toHaveBeenCalledWith(expect.any(User))
       // storeUser and syncPrimaryJwt must receive the enriched user, not the original
       expect(h.mockStoreUser).toHaveBeenCalledWith(enrichedUser)
       expect(h.mockSyncPrimaryJwt).toHaveBeenCalledWith(enrichedUser)

--- a/packages/shared/src/auth/stores/__tests__/authStore.initialize.browser.test.ts
+++ b/packages/shared/src/auth/stores/__tests__/authStore.initialize.browser.test.ts
@@ -216,10 +216,7 @@ describe('authStore.initialize() (extension path)', () => {
       expect((h.mockStoreUser.mock.calls[1][0] as User).access_token).toBe(
         refreshedUser.access_token,
       )
-      expect(h.mockEnrichUser).toHaveBeenCalledWith(
-        expect.any(User),
-        expect.any(Function),
-      )
+      expect(h.mockEnrichUser).toHaveBeenCalledWith(expect.any(User))
     })
 
     it('sets user to null when silent renew fails', async () => {

--- a/packages/shared/src/auth/stores/__tests__/authStore.initialize.web.browser.test.ts
+++ b/packages/shared/src/auth/stores/__tests__/authStore.initialize.web.browser.test.ts
@@ -162,10 +162,7 @@ describe('authStore.initialize() (web path)', () => {
       await useAuthStore.getState().initialize()
 
       expect(h.mockSigninSilent).toHaveBeenCalledOnce()
-      expect(h.mockEnrichUser).toHaveBeenCalledWith(
-        expect.any(User),
-        expect.any(Function),
-      )
+      expect(h.mockEnrichUser).toHaveBeenCalledWith(expect.any(User))
       expect(h.mockStoreUser).toHaveBeenCalledWith(refreshed)
       expect(h.mockSyncPrimaryJwt).toHaveBeenCalledWith(refreshed)
       expect(useAuthStore.getState().user).toBe(refreshed)

--- a/packages/shared/src/auth/stores/__tests__/authWorkflowUtils.test.ts
+++ b/packages/shared/src/auth/stores/__tests__/authWorkflowUtils.test.ts
@@ -1,45 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
-const mockIsBrowser = vi.hoisted(() => vi.fn(() => true))
-
-vi.mock('#/utils', () => ({
-  isBrowser: () => mockIsBrowser(),
-}))
-
-import {
-  getEnokiApiKey,
-  getErrorMessage,
-} from '#/auth/stores/authWorkflowUtils'
-
-describe('getEnokiApiKey', () => {
-  beforeEach(() => {
-    mockIsBrowser.mockReturnValue(true)
-  })
-
-  afterEach(() => {
-    vi.clearAllMocks()
-    vi.unstubAllGlobals()
-    vi.unstubAllEnvs()
-  })
-
-  it('getEnokiApiKey() when isBrowser() is true and env exists', () => {
-    mockIsBrowser.mockReturnValue(true)
-    vi.stubEnv('VITE_ENOKI_API_KEY', 'test-enoki-key')
-    expect(getEnokiApiKey()).toBe('test-enoki-key')
-  })
-
-  it('getEnokiApiKey() when browser env is missing', () => {
-    vi.stubEnv('VITE_ENOKI_API_KEY', undefined)
-    expect(getEnokiApiKey()).toBe('')
-  })
-
-  it('getEnokiApiKey() when isBrowser() is false, reading process.env', () => {
-    mockIsBrowser.mockReturnValue(false)
-    vi.stubGlobal('process', { env: { VITE_ENOKI_API_KEY: 'node-key' } })
-
-    expect(getEnokiApiKey()).toBe('node-key')
-  })
-})
+import { getErrorMessage } from '#/auth/stores/authWorkflowUtils'
 
 describe('getErrorMessage', () => {
   it("getErrorMessage(new Error('New Error')) === 'New Error'", () => {

--- a/packages/shared/src/auth/stores/authStore.ts
+++ b/packages/shared/src/auth/stores/authStore.ts
@@ -9,7 +9,6 @@ import {
   clearAuthSession,
   createExtensionAuthListener,
   finishExtensionLogout,
-  getEnokiApiKey,
   getErrorMessage,
   initializeExtensionSession,
   initializeWebSession,
@@ -25,8 +24,6 @@ import { AUTH_STORAGE_KEY } from '#/utils/storageKeys'
 
 // biome-ignore lint/suspicious/noExplicitAny: chrome is a global object
 declare const chrome: any
-
-export { getEnokiApiKey }
 
 const log = createLogger()
 

--- a/packages/shared/src/auth/stores/authStoreWorkflows.ts
+++ b/packages/shared/src/auth/stores/authStoreWorkflows.ts
@@ -12,6 +12,5 @@ export {
   type AuthGet,
   type AuthSet,
   type GetUserManagerInstance,
-  getEnokiApiKey,
   getErrorMessage,
 } from './authWorkflowUtils'

--- a/packages/shared/src/auth/stores/authUserSession.ts
+++ b/packages/shared/src/auth/stores/authUserSession.ts
@@ -7,7 +7,6 @@ import {
 import { userToJwtResponse } from '#/auth/userToJwtResponse'
 import { resolveExpiresAt } from '#/auth/utils/authStoreUtils'
 import type { JwtResponse, OAuthTokenResponse } from '#/types/authTypes'
-import { getEnokiApiKey } from './authWorkflowUtils'
 
 export function buildUserFromJwt(jwt: JwtResponse): User {
   // Stored JWTs do not include the full oidc-client-ts User shape.
@@ -69,7 +68,7 @@ export async function persistEnrichedUser(
    * salt must not sit in browser-accessible storage. Signing always re-derives
    * salt on demand via getUserForNetwork so nothing breaks at runtime.
    */
-  const enrichedUser = await enrichUserWithZkLoginIfNeeded(user, getEnokiApiKey)
+  const enrichedUser = await enrichUserWithZkLoginIfNeeded(user)
   const { salt: _stripped, ...profileWithoutSalt } = (enrichedUser.profile ??
     {}) as Record<string, unknown>
   const userToStore = new User({

--- a/packages/shared/src/auth/stores/authWorkflowUtils.ts
+++ b/packages/shared/src/auth/stores/authWorkflowUtils.ts
@@ -1,6 +1,5 @@
 import type { UserManager } from 'oidc-client-ts'
 import type { AuthState } from '#/auth/types'
-import { isBrowser } from '#/utils'
 
 /*
  * The Zustand store owns UI state updates, while workflow modules own auth
@@ -10,14 +9,6 @@ import { isBrowser } from '#/utils'
 export type AuthSet = (partial: Partial<AuthState>) => void
 export type AuthGet = () => AuthState
 export type GetUserManagerInstance = () => UserManager
-
-export const getEnokiApiKey = (): string => {
-  if (isBrowser()) {
-    return import.meta.env.VITE_ENOKI_API_KEY ?? ''
-  }
-  // biome-ignore lint/suspicious/noExplicitAny: Node.js process.env access requires any type
-  return (globalThis as any)?.process?.env?.VITE_ENOKI_API_KEY ?? ''
-}
 
 export function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : 'Unknown error'

--- a/packages/shared/src/auth/types.ts
+++ b/packages/shared/src/auth/types.ts
@@ -26,7 +26,6 @@ export type GlobalWithProcessEnv = typeof globalThis & {
 
 export interface GetZkLoginAddressParams {
   jwt: string
-  enokiApiKey: string
 }
 
 export interface AuthState {

--- a/packages/shared/src/auth/userJwtSync.ts
+++ b/packages/shared/src/auth/userJwtSync.ts
@@ -9,13 +9,10 @@ import { userToJwtResponse } from './userToJwtResponse'
 const log = createLogger()
 
 /**
- * Ensures `profile.sui_address` (and Enoki `salt`) exist by calling Enoki only when
- * `sui_address` is missing on the user profile.
+ * Ensures `profile.sui_address` (and `salt`) exist by calling the zkLogin
+ * address endpoint only when `sui_address` is missing on the user profile.
  */
-export async function enrichUserWithZkLoginIfNeeded(
-  user: User,
-  getEnokiApiKey: () => string,
-): Promise<User> {
+export async function enrichUserWithZkLoginIfNeeded(user: User): Promise<User> {
   const idToken = user.id_token
   if (!idToken) {
     return user
@@ -35,20 +32,9 @@ export async function enrichUserWithZkLoginIfNeeded(
     return user
   }
 
-  const zkLoginResponse = await getZkLoginAddress({
+  const { salt, address } = await getZkLoginAddress({
     jwt: idToken,
-    enokiApiKey: getEnokiApiKey(),
   })
-
-  if (zkLoginResponse.error) {
-    throw new Error(zkLoginResponse.error.message)
-  }
-
-  if (!zkLoginResponse.data) {
-    throw new Error('No zkLogin address data received')
-  }
-
-  const { salt, address } = zkLoginResponse.data
   const decodedJwt = decodeJwt(idToken) as IdTokenClaims
 
   return new User({

--- a/packages/shared/src/auth/utils/__tests__/authStoreUtils.test.ts
+++ b/packages/shared/src/auth/utils/__tests__/authStoreUtils.test.ts
@@ -205,7 +205,7 @@ describe('getUserForNetwork', () => {
     expect(getZkLoginAddress).not.toHaveBeenCalled()
   })
 
-  it('returns null when zkLogin returns error', async () => {
+  it('returns null when the zkLogin request throws', async () => {
     vi.mocked(getJwt).mockResolvedValue({
       access_token: 'a',
       id_token: tokenWithClaims,
@@ -213,25 +213,9 @@ describe('getUserForNetwork', () => {
       scope: 's',
       token_type: 'Bearer',
     })
-    vi.mocked(getZkLoginAddress).mockResolvedValue({
-      data: undefined,
-      error: { message: 'enoki failed' },
-    })
-    await expect(getUserForNetwork('sui:testnet')).resolves.toBeNull()
-  })
-
-  it('returns null when zkLogin has no data', async () => {
-    vi.mocked(getJwt).mockResolvedValue({
-      access_token: 'a',
-      id_token: tokenWithClaims,
-      expires_in: 3600,
-      scope: 's',
-      token_type: 'Bearer',
-    })
-    vi.mocked(getZkLoginAddress).mockResolvedValue({
-      data: undefined,
-      error: undefined,
-    })
+    vi.mocked(getZkLoginAddress).mockRejectedValue(
+      new Error('zkLogin address request failed (401): unauthorized'),
+    )
     await expect(getUserForNetwork('sui:testnet')).resolves.toBeNull()
   })
 
@@ -245,12 +229,9 @@ describe('getUserForNetwork', () => {
       expires_at: 2_000_000_000,
     })
     vi.mocked(getZkLoginAddress).mockResolvedValue({
-      data: {
-        address: '0xsui',
-        salt: '99',
-        publicKey: 'pk',
-      },
-      error: undefined,
+      address: '0xsui',
+      salt: '99',
+      publicKey: 'pk',
     })
 
     const user = await getUserForNetwork('sui:testnet')
@@ -398,8 +379,9 @@ describe('getUserForNetwork — sui_address from claims', () => {
     }).encode()
     vi.mocked(getJwt).mockResolvedValue(storedJwtWith(idToken))
     vi.mocked(getZkLoginAddress).mockResolvedValue({
-      data: { address: '0xzk', salt: '5', publicKey: 'pk' },
-      error: undefined,
+      address: '0xzk',
+      salt: '5',
+      publicKey: 'pk',
     })
 
     const user = await getUserForNetwork('sui:testnet')

--- a/packages/shared/src/auth/utils/authStoreUtils.ts
+++ b/packages/shared/src/auth/utils/authStoreUtils.ts
@@ -3,7 +3,6 @@ import { decodeJwt } from 'jose'
 import { type IdTokenClaims, User } from 'oidc-client-ts'
 import { getZkLoginAddress } from '#/auth/getZkLoginAddress'
 import { getJwt } from '#/auth/storageService'
-import { getEnokiApiKey } from '#/auth/stores/authStore'
 import { decodeJwtSafely } from '#/auth/utils/jwtUtils'
 import type { JwtResponse } from '#/types/authTypes'
 import { createLogger } from '#/utils/logger'
@@ -90,20 +89,19 @@ export async function getUserForNetwork(chain: SuiChain): Promise<User | null> {
     })
   }
 
-  const zkLoginResponse = await getZkLoginAddress({
-    jwt: storedJwt.id_token,
-    enokiApiKey: getEnokiApiKey(),
-  })
-
-  if (zkLoginResponse.error || !zkLoginResponse.data) {
+  let address: string
+  let salt: string
+  try {
+    ;({ address, salt } = await getZkLoginAddress({
+      jwt: storedJwt.id_token,
+    }))
+  } catch (error) {
     log.error('Failed to get zkLogin address for network JWT', {
       chain,
-      error: zkLoginResponse.error,
+      error,
     })
     return null
   }
-
-  const { address, salt } = zkLoginResponse.data
 
   return new User({
     ...storedJwt,

--- a/packages/shared/src/types/enoki.ts
+++ b/packages/shared/src/types/enoki.ts
@@ -21,8 +21,5 @@ export interface ZkLoginAddressData {
   publicKey: string
 }
 
-export interface ZkLoginAddressResponse
-  extends EnokiResponse<ZkLoginAddressData> {}
-
 export interface ZkProofResponse
   extends EnokiResponse<ZkLoginSignatureInputs> {}


### PR DESCRIPTION
Moves the zkLogin address lookup off Enoki (`api.enoki.mystenlabs.com/v1/zklogin`) onto the EVE Frontier auth API (`/auth/zklogin`), hardens the surrounding error handling, and removes the Enoki API key from that path.

### Changes

**Address lookup**
- `getZkLoginAddress`: call `/auth/zklogin` with the host/tenant derived from the JWT via `getApiContext`; throw with the real status + body on failure; validate `salt`/`address` and cache only successful responses.
- Drop `enokiApiKey` from `GetZkLoginAddressParams` and remove the `ZkLoginAddressResponse` (Enoki envelope) type.
- Update callers (`userJwtSync`, `CallbackScreen`, `dappLogin`, `authStoreUtils`) to the throw-on-failure contract.
- Remove the now-unused `getEnokiApiKey` helper and its re-exports.

**Docs / config**
- Remove `VITE_ENOKI_API_KEY` from `.envsample` and `README.md`.
- Update `docs/TROUBLESHOOTING.md` address-derivation guidance to reference the JWT / API Gateway instead of the Enoki key.

**Tests**
- Update affected `shared` and extension tests for the new endpoint, error contract, and single-arg `enrichUserWithZkLoginIfNeeded`.