### PR TITLE
feat: remove address aliases + warn on address-alias transactions

### DIFF
--- a/apps/extension/CHANGELOG.md
+++ b/apps/extension/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @evevault/extension
 
+## 0.0.14
+
+### Patch Changes
+
+- address aliasing
+- Updated dependencies
+  - @evevault/shared@0.0.14
+
 ## 0.0.13
 
 ### Patch Changes

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evevault/extension",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "type": "module",
   "scripts": {
     "dev": "wxt",

--- a/apps/extension/src/features/wallet/__tests__/transactionRiskReview.test.ts
+++ b/apps/extension/src/features/wallet/__tests__/transactionRiskReview.test.ts
@@ -65,6 +65,27 @@ describe('reviewTransaction', () => {
     )
   })
 
+  it('flags address-alias module calls as dangerous', () => {
+    const findings = reviewTransaction({
+      commands: [
+        {
+          MoveCall: {
+            package:
+              '0x0000000000000000000000000000000000000000000000000000000000000002',
+            module: 'address_alias',
+            function: 'add',
+          },
+        },
+      ],
+    })
+
+    expect(findings).toContainEqual({
+      severity: 'danger',
+      title: 'Modifies address aliases',
+      detail: 'This can add or remove address aliases for your account.',
+    })
+  })
+
   it('flags shared object references', () => {
     const findings = reviewTransaction({
       inputs: [

--- a/apps/extension/src/features/wallet/__tests__/transactionRiskReview.test.ts
+++ b/apps/extension/src/features/wallet/__tests__/transactionRiskReview.test.ts
@@ -86,6 +86,58 @@ describe('reviewTransaction', () => {
     })
   })
 
+  it('matches short-form alias packages and dedupes repeated alias calls', () => {
+    const findings = reviewTransaction({
+      commands: [
+        {
+          MoveCall: {
+            package: '0x2',
+            module: 'address_alias',
+            function: 'add',
+          },
+        },
+        {
+          MoveCall: {
+            package:
+              '0x0000000000000000000000000000000000000000000000000000000000000002',
+            module: 'address_alias',
+            function: 'remove',
+          },
+        },
+      ],
+    })
+
+    // Short-form ("0x2") and fully padded packages both match, and the two
+    // alias calls collapse to a single finding.
+    expect(
+      findings.filter((f) => f.title === 'Modifies address aliases'),
+    ).toEqual([
+      {
+        severity: 'danger',
+        title: 'Modifies address aliases',
+        detail: 'This can add or remove address aliases for your account.',
+      },
+    ])
+  })
+
+  it('does not flag or throw on a malformed alias package value', () => {
+    const findings = reviewTransaction({
+      commands: [
+        {
+          MoveCall: {
+            package: 'not-a-real-address',
+            module: 'address_alias',
+            function: 'add',
+          },
+        },
+      ],
+    })
+
+    expect(findings.some((f) => f.title === 'Modifies address aliases')).toBe(
+      false,
+    )
+  })
+
   it('flags shared object references', () => {
     const findings = reviewTransaction({
       inputs: [

--- a/apps/extension/src/features/wallet/components/TransactionRiskPanel.tsx
+++ b/apps/extension/src/features/wallet/components/TransactionRiskPanel.tsx
@@ -9,25 +9,27 @@ export function TransactionRiskPanel({
   if (findings.length === 0) return null
 
   return (
-    <div className="w-[80vw] max-h-32 overflow-y-auto border border-[var(--matter-05)] p-2 text-left">
+    <div className="w-[80vw] max-h-32 overflow-y-auto border border(--matter-05)] p-2 text-left">
       <Text size="small" color="grey-neutral">
         Transaction warnings
       </Text>
       <div className="mt-2 flex flex-col gap-2">
-        {findings.map((finding) => (
-          <div key={`${finding.severity}:${finding.title}`}>
-            <Text
-              size="small"
-              variant="bold"
-              color={finding.severity === 'danger' ? 'error' : 'neutral'}
-            >
-              {finding.title}
-            </Text>
-            <Text size="xsmall" color="grey-neutral">
-              {finding.detail}
-            </Text>
-          </div>
-        ))}
+        {findings
+          .sort((a, b) => (a.severity === 'danger' ? -1 : 1))
+          .map((finding) => (
+            <div key={`${finding.severity}:${finding.title}`}>
+              <Text
+                size="small"
+                variant="bold"
+                color={finding.severity === 'danger' ? 'error' : 'neutral'}
+              >
+                {finding.title}
+              </Text>
+              <Text size="xsmall" color="grey-neutral">
+                {finding.detail}
+              </Text>
+            </div>
+          ))}
       </div>
     </div>
   )

--- a/apps/extension/src/features/wallet/components/TransactionRiskPanel.tsx
+++ b/apps/extension/src/features/wallet/components/TransactionRiskPanel.tsx
@@ -9,13 +9,17 @@ export function TransactionRiskPanel({
   if (findings.length === 0) return null
 
   return (
-    <div className="w-[80vw] max-h-32 overflow-y-auto border border(--matter-05)] p-2 text-left">
+    <div className="w-[80vw] max-h-32 overflow-y-auto border border-[var(--matter-05)] p-2 text-left">
       <Text size="small" color="grey-neutral">
         Transaction warnings
       </Text>
       <div className="mt-2 flex flex-col gap-2">
-        {findings
-          .sort((a, b) => (a.severity === 'danger' ? -1 : 1))
+        {[...findings]
+          .sort(
+            (a, b) =>
+              (a.severity === 'danger' ? 0 : 1) -
+              (b.severity === 'danger' ? 0 : 1),
+          )
           .map((finding) => (
             <div key={`${finding.severity}:${finding.title}`}>
               <Text

--- a/apps/extension/src/features/wallet/components/__tests__/SignExecuteTransaction.test.tsx
+++ b/apps/extension/src/features/wallet/components/__tests__/SignExecuteTransaction.test.tsx
@@ -1,12 +1,15 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockUseTransactionSigning, mockUseWalletSigningContext } = vi.hoisted(
-  () => ({
-    mockUseTransactionSigning: vi.fn(),
-    mockUseWalletSigningContext: vi.fn(),
-  }),
-)
+const {
+  mockUseTransactionSigning,
+  mockUseWalletSigningContext,
+  mockAddressAliasModule,
+} = vi.hoisted(() => ({
+  mockUseTransactionSigning: vi.fn(),
+  mockUseWalletSigningContext: vi.fn(),
+  mockAddressAliasModule: '0xaddress_alias_module',
+}))
 
 vi.mock('@/features/wallet/hooks', () => ({
   useTransactionSigning: mockUseTransactionSigning,
@@ -14,6 +17,7 @@ vi.mock('@/features/wallet/hooks', () => ({
 
 vi.mock('@evevault/shared/wallet', () => ({
   useWalletSigningContext: mockUseWalletSigningContext,
+  ADDRESS_ALIAS_MODULE: mockAddressAliasModule,
 }))
 
 vi.mock('@tanstack/react-query', () => ({

--- a/apps/extension/src/features/wallet/components/__tests__/SignSponsoredTransaction.test.tsx
+++ b/apps/extension/src/features/wallet/components/__tests__/SignSponsoredTransaction.test.tsx
@@ -5,12 +5,15 @@ import {
   parsePendingSponsoredAction,
 } from '../SignSponsoredTransaction'
 
-const { mockUsePendingSignAction, mockUseWalletSigningContext } = vi.hoisted(
-  () => ({
-    mockUsePendingSignAction: vi.fn(),
-    mockUseWalletSigningContext: vi.fn(),
-  }),
-)
+const {
+  mockUsePendingSignAction,
+  mockUseWalletSigningContext,
+  mockAddressAliasModule,
+} = vi.hoisted(() => ({
+  mockUsePendingSignAction: vi.fn(),
+  mockUseWalletSigningContext: vi.fn(),
+  mockAddressAliasModule: '0xaddress_alias_module',
+}))
 
 vi.mock('@/features/wallet/hooks', () => ({
   usePendingSignAction: mockUsePendingSignAction,
@@ -18,6 +21,7 @@ vi.mock('@/features/wallet/hooks', () => ({
 
 vi.mock('@evevault/shared/wallet', () => ({
   useWalletSigningContext: mockUseWalletSigningContext,
+  ADDRESS_ALIAS_MODULE: mockAddressAliasModule,
 }))
 
 vi.mock('@evevault/shared/utils', async (importOriginal) => {

--- a/apps/extension/src/features/wallet/components/__tests__/TransactionRiskPanel.test.tsx
+++ b/apps/extension/src/features/wallet/components/__tests__/TransactionRiskPanel.test.tsx
@@ -21,6 +21,11 @@ describe('TransactionRiskPanel', () => {
         title: 'Transfers objects',
         detail: 'This can move owned objects.',
       },
+      {
+        severity: 'danger',
+        title: 'Modifies address aliases',
+        detail: 'This can add or remove address aliases for your account.',
+      },
     ]
 
     render(<TransactionRiskPanel findings={findings} />)
@@ -29,6 +34,12 @@ describe('TransactionRiskPanel', () => {
     expect(screen.getByText('Transfers objects')).toBeInTheDocument()
     expect(screen.getByText('Review the package.')).toBeInTheDocument()
     expect(screen.getByText('This can move owned objects.')).toBeInTheDocument()
+    expect(screen.getByText('Modifies address aliases')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'This can add or remove address aliases for your account.',
+      ),
+    ).toBeInTheDocument()
   })
 
   it('renders the panel header for non-empty findings', () => {

--- a/apps/extension/src/features/wallet/components/__tests__/TransactionRiskPanel.test.tsx
+++ b/apps/extension/src/features/wallet/components/__tests__/TransactionRiskPanel.test.tsx
@@ -42,6 +42,21 @@ describe('TransactionRiskPanel', () => {
     ).toBeInTheDocument()
   })
 
+  it('renders danger findings before warnings', () => {
+    const findings: TransactionRiskFinding[] = [
+      { severity: 'warning', title: 'Calls Move code', detail: 'w' },
+      { severity: 'danger', title: 'Transfers objects', detail: 'd' },
+    ]
+
+    render(<TransactionRiskPanel findings={findings} />)
+
+    const titles = screen.getAllByText(/Calls Move code|Transfers objects/)
+    expect(titles.map((el) => el.textContent)).toEqual([
+      'Transfers objects',
+      'Calls Move code',
+    ])
+  })
+
   it('renders the panel header for non-empty findings', () => {
     const findings: TransactionRiskFinding[] = [
       { severity: 'warning', title: 'Calls Move code', detail: 'detail' },

--- a/apps/extension/src/features/wallet/transactionRiskReview.ts
+++ b/apps/extension/src/features/wallet/transactionRiskReview.ts
@@ -1,4 +1,6 @@
 import { isRecord } from '@evevault/shared/utils'
+import { ADDRESS_ALIAS_MODULE } from '@evevault/shared/wallet'
+import { normalizeSuiAddress } from '@mysten/sui/utils'
 
 export type TransactionRiskSeverity = 'danger' | 'warning'
 
@@ -25,6 +27,11 @@ const FINDINGS = {
     severity: 'danger',
     title: 'Transfers objects',
     detail: 'This can move owned objects or tokens out of your account.',
+  },
+  addressAlias: {
+    severity: 'danger',
+    title: 'Modifies address aliases',
+    detail: 'This can add or remove address aliases for your account.',
   },
   moveCall: {
     severity: 'warning',
@@ -57,6 +64,16 @@ const COMMAND_RISK_RULES: Record<string, TransactionRiskFinding> = {
   movecall: FINDINGS.moveCall,
   makemovevec: FINDINGS.makeMoveVec,
 }
+
+// Address-alias operations are plain MoveCalls into `0x2::address_alias`, so
+// they can't be matched by command kind (that's always "MoveCall"). We match on
+// the call target instead. Package addresses may arrive short ("0x2") or fully
+// padded, so compare in normalized form.
+const [ADDRESS_ALIAS_PACKAGE, ADDRESS_ALIAS_MODULE_NAME] =
+  ADDRESS_ALIAS_MODULE.split('::')
+const NORMALIZED_ADDRESS_ALIAS_PACKAGE = normalizeSuiAddress(
+  ADDRESS_ALIAS_PACKAGE,
+)
 
 function normalizeKey(key: string): string {
   return key.toLowerCase().replace(/[^a-z0-9]/g, '')
@@ -110,11 +127,32 @@ function getCommandName(command: unknown): string | null {
   return commandKeys[0] ?? null
 }
 
+// True when the command is a MoveCall into the address-alias module. These
+// calls add/remove aliases, which can hand full control of the account to
+// another address, so they warrant the danger-class finding.
+function isAddressAliasCall(command: unknown): boolean {
+  if (!isRecord(command)) return false
+
+  const moveCall = command.MoveCall ?? command.moveCall
+  if (!isRecord(moveCall)) return false
+
+  const pkg = moveCall.package
+  const module = moveCall.module
+  if (typeof pkg !== 'string' || typeof module !== 'string') return false
+
+  return (
+    normalizeSuiAddress(pkg) === NORMALIZED_ADDRESS_ALIAS_PACKAGE &&
+    module === ADDRESS_ALIAS_MODULE_NAME
+  )
+}
+
 function reviewCommands(commands: unknown[]): TransactionRiskFinding[] {
   return commands.flatMap((command) => {
     const commandName = getCommandName(command)
     const finding = commandName ? COMMAND_RISK_RULES[commandName] : undefined
-    return finding ? [finding] : []
+    const findings = finding ? [finding] : []
+    if (isAddressAliasCall(command)) findings.push(FINDINGS.addressAlias)
+    return findings
   })
 }
 
@@ -144,6 +182,7 @@ export function reviewTransaction(
   // drifted, or the payload isn't a programmable transaction at all). Treat it
   // as unverified (danger) rather than silently "safe" — this is the fail-safe
   // that stops an unrecognized payload from bypassing the approval gate.
+
   if (commands === undefined && inputs === undefined) {
     return [FINDINGS.unverified]
   }

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @evevault/web
 
+## 0.0.14
+
+### Patch Changes
+
+- Updated dependencies
+  - @evevault/shared@0.0.14
+
 ## 0.0.13
 
 ### Patch Changes

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evevault/web",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @evevault/shared
 
+## 0.0.14
+
+### Patch Changes
+
+- address aliasing
+
 ## 0.0.13
 
 ### Patch Changes

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evevault/shared",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "imports": {

--- a/packages/shared/src/screens/AddressAliasesScreen/AddressAliasesScreen.tsx
+++ b/packages/shared/src/screens/AddressAliasesScreen/AddressAliasesScreen.tsx
@@ -90,22 +90,26 @@ export const AddressAliasesScreen: React.FC<AddressAliasesScreenProps> = ({
             <ul className="flex flex-col gap-1 w-full">
               {addressAliases.map((addressAlias) => (
                 <li key={addressAlias} className="break-all">
-                  <Text variant="light" size="small" color="neutral-90">
-                    {addressAlias}{' '}
-                    {addressAlias === ownerAddress && '(This address)'}
-                  </Text>
-
-                  {addressAlias !== ownerAddress && (
-                    <Button
-                      variant="secondary"
-                      size="small"
-                      disabled={disabled}
-                      isLoading={isSubmitting}
-                      onClick={() => removeAddressAlias(addressAlias)}
-                    >
-                      Remove
-                    </Button>
-                  )}
+                  <div
+                    key={addressAlias}
+                    className="break-all justify-start items-center gap-4 inline-flex"
+                  >
+                    <Text variant="light" size="small" color="neutral-90">
+                      {addressAlias}{' '}
+                      {addressAlias === ownerAddress && '(This address)'}
+                    </Text>
+                    {addressAlias !== ownerAddress && (
+                      <Button
+                        variant="secondary"
+                        size="small"
+                        disabled={disabled}
+                        isLoading={isSubmitting}
+                        onClick={() => removeAddressAlias(addressAlias)}
+                      >
+                        Remove
+                      </Button>
+                    )}
+                  </div>
                 </li>
               ))}
             </ul>

--- a/packages/shared/src/screens/AddressAliasesScreen/AddressAliasesScreen.tsx
+++ b/packages/shared/src/screens/AddressAliasesScreen/AddressAliasesScreen.tsx
@@ -22,6 +22,7 @@ export const AddressAliasesScreen: React.FC<AddressAliasesScreenProps> = ({
     readError,
     enable,
     addAddressAlias,
+    removeAddressAlias,
     isSubmitting,
     error,
   } = useAddressAliases()
@@ -90,8 +91,21 @@ export const AddressAliasesScreen: React.FC<AddressAliasesScreenProps> = ({
               {addressAliases.map((addressAlias) => (
                 <li key={addressAlias} className="break-all">
                   <Text variant="light" size="small" color="neutral-90">
-                    {addressAlias}
+                    {addressAlias}{' '}
+                    {addressAlias === ownerAddress && '(This address)'}
                   </Text>
+
+                  {addressAlias !== ownerAddress && (
+                    <Button
+                      variant="secondary"
+                      size="small"
+                      disabled={disabled}
+                      isLoading={isSubmitting}
+                      onClick={() => removeAddressAlias(addressAlias)}
+                    >
+                      Remove
+                    </Button>
+                  )}
                 </li>
               ))}
             </ul>

--- a/packages/shared/src/wallet/hooks/useAddressAliases.transaction.ts
+++ b/packages/shared/src/wallet/hooks/useAddressAliases.transaction.ts
@@ -52,7 +52,7 @@ export async function enableAddressAliasTxBytes(
  * Add a new address alias to the caller's AddressAliases object.
  *
  * @param aliasesObjectId the caller's AddressAliases object id (from the read path)
- * @param addressAlias the address to add as an address alias
+ * @param addressAlias the address to add as an alias
  */
 export async function addAddressAliasTxBytes(
   senderAddress: string,
@@ -64,11 +64,32 @@ export async function addAddressAliasTxBytes(
 
   tx.moveCall({
     target: `${ADDRESS_ALIAS_MODULE}::add`,
-    arguments: [
-      // tx.object(ADDRESS_ALIAS_STATE),
-      tx.object(aliasesObjectId),
-      tx.pure.address(addressAlias),
-    ],
+    arguments: [tx.object(aliasesObjectId), tx.pure.address(addressAlias)],
+  })
+
+  tx.setSender(senderAddress)
+  tx.setGasBudget(ADDRESS_ALIAS_GAS_BUDGET)
+  const txb = await tx.build({ client: suiClient })
+  return new Uint8Array(txb)
+}
+
+/**
+ * Removes an address alias from the caller's AddressAliases object.
+ *
+ * @param aliasesObjectId the caller's AddressAliases object id (from the read path)
+ * @param addressAlias the address alias to remove
+ */
+export async function removeAddressAliasTxBytes(
+  senderAddress: string,
+  aliasesObjectId: string,
+  addressAlias: string,
+  suiClient: SuiGrpcClient,
+): Promise<Uint8Array> {
+  const tx = new Transaction()
+
+  tx.moveCall({
+    target: `${ADDRESS_ALIAS_MODULE}::remove`,
+    arguments: [tx.object(aliasesObjectId), tx.pure.address(addressAlias)],
   })
 
   tx.setSender(senderAddress)

--- a/packages/shared/src/wallet/hooks/useAddressAliases.transaction.ts
+++ b/packages/shared/src/wallet/hooks/useAddressAliases.transaction.ts
@@ -26,26 +26,39 @@ type ExecuteAddressAliasTransactionParams = {
 }
 
 /**
+ * Builds signed-ready bytes for an address alias PTB: runs the caller's
+ * command(s), sets the sender and gas budget, and serializes. Every address
+ * alias transaction shares this sender/gas/build tail.
+ */
+async function buildAddressAliasTx(
+  senderAddress: string,
+  suiClient: SuiGrpcClient,
+  addCommands: (tx: Transaction) => void,
+): Promise<Uint8Array> {
+  const tx = new Transaction()
+  addCommands(tx)
+  tx.setSender(senderAddress)
+  tx.setGasBudget(ADDRESS_ALIAS_GAS_BUDGET)
+  const txb = await tx.build({ client: suiClient })
+  return new Uint8Array(txb)
+}
+
+/**
  * Enable address alias configuration for the sender. Creates the caller's
  * AddressAliases object. Assumes `enable` transfers the object internally
  * (matching the CLI, which does not transfer a returned value). If it instead
  * RETURNS the object, capture the result and `tx.transferObjects([result], sender)`.
  */
-export async function enableAddressAliasTxBytes(
+export function enableAddressAliasTxBytes(
   senderAddress: string,
   suiClient: SuiGrpcClient,
 ): Promise<Uint8Array> {
-  const tx = new Transaction()
-
-  tx.moveCall({
-    target: `${ADDRESS_ALIAS_MODULE}::enable`,
-    arguments: [tx.object(ADDRESS_ALIAS_STATE)],
+  return buildAddressAliasTx(senderAddress, suiClient, (tx) => {
+    tx.moveCall({
+      target: `${ADDRESS_ALIAS_MODULE}::enable`,
+      arguments: [tx.object(ADDRESS_ALIAS_STATE)],
+    })
   })
-
-  tx.setSender(senderAddress)
-  tx.setGasBudget(ADDRESS_ALIAS_GAS_BUDGET)
-  const txb = await tx.build({ client: suiClient })
-  return new Uint8Array(txb)
 }
 
 /**
@@ -54,23 +67,18 @@ export async function enableAddressAliasTxBytes(
  * @param aliasesObjectId the caller's AddressAliases object id (from the read path)
  * @param addressAlias the address to add as an alias
  */
-export async function addAddressAliasTxBytes(
+export function addAddressAliasTxBytes(
   senderAddress: string,
   aliasesObjectId: string,
   addressAlias: string,
   suiClient: SuiGrpcClient,
 ): Promise<Uint8Array> {
-  const tx = new Transaction()
-
-  tx.moveCall({
-    target: `${ADDRESS_ALIAS_MODULE}::add`,
-    arguments: [tx.object(aliasesObjectId), tx.pure.address(addressAlias)],
+  return buildAddressAliasTx(senderAddress, suiClient, (tx) => {
+    tx.moveCall({
+      target: `${ADDRESS_ALIAS_MODULE}::add`,
+      arguments: [tx.object(aliasesObjectId), tx.pure.address(addressAlias)],
+    })
   })
-
-  tx.setSender(senderAddress)
-  tx.setGasBudget(ADDRESS_ALIAS_GAS_BUDGET)
-  const txb = await tx.build({ client: suiClient })
-  return new Uint8Array(txb)
 }
 
 /**
@@ -79,23 +87,18 @@ export async function addAddressAliasTxBytes(
  * @param aliasesObjectId the caller's AddressAliases object id (from the read path)
  * @param addressAlias the address alias to remove
  */
-export async function removeAddressAliasTxBytes(
+export function removeAddressAliasTxBytes(
   senderAddress: string,
   aliasesObjectId: string,
   addressAlias: string,
   suiClient: SuiGrpcClient,
 ): Promise<Uint8Array> {
-  const tx = new Transaction()
-
-  tx.moveCall({
-    target: `${ADDRESS_ALIAS_MODULE}::remove`,
-    arguments: [tx.object(aliasesObjectId), tx.pure.address(addressAlias)],
+  return buildAddressAliasTx(senderAddress, suiClient, (tx) => {
+    tx.moveCall({
+      target: `${ADDRESS_ALIAS_MODULE}::remove`,
+      arguments: [tx.object(aliasesObjectId), tx.pure.address(addressAlias)],
+    })
   })
-
-  tx.setSender(senderAddress)
-  tx.setGasBudget(ADDRESS_ALIAS_GAS_BUDGET)
-  const txb = await tx.build({ client: suiClient })
-  return new Uint8Array(txb)
 }
 
 /**

--- a/packages/shared/src/wallet/hooks/useAddressAliases.ts
+++ b/packages/shared/src/wallet/hooks/useAddressAliases.ts
@@ -5,8 +5,12 @@ import {
   addAddressAliasTxBytes,
   enableAddressAliasTxBytes,
   executeAddressAliasTx,
+  removeAddressAliasTxBytes,
 } from './useAddressAliases.transaction'
-import { validateNewAddressAlias } from './useAddressAliases.validation'
+import {
+  validateExistingAddressAlias,
+  validateNewAddressAlias,
+} from './useAddressAliases.validation'
 import { useTransactionWrite } from './useTransactionWrite'
 import { useWalletSigningContext } from './useWalletSigningContext'
 
@@ -26,6 +30,7 @@ interface UseAddressAliasesResult {
   enable: () => Promise<void>
   /** Resolves `true` when the address alias was submitted successfully. */
   addAddressAlias: (addressAlias: string) => Promise<boolean>
+  removeAddressAlias: (addressAlias: string) => Promise<boolean>
   refresh: () => Promise<void>
 
   // Write status
@@ -155,6 +160,57 @@ export function useAddressAliases(): UseAddressAliasesResult {
     ],
   )
 
+  const removeAddressAlias = useCallback(
+    async (addressAlias: string): Promise<boolean> => {
+      if (!senderAddress) {
+        setError('Connect wallet first')
+        return false
+      }
+      if (!objectId) {
+        setError('Enable address aliasing first')
+        return false
+      }
+
+      const validationError = validateExistingAddressAlias({
+        addressAlias,
+        existing: addressAliases,
+      })
+      if (validationError) {
+        setError(validationError)
+        return false
+      }
+      const trimmed = addressAlias.trim()
+      const digest = await run(
+        () =>
+          executeAddressAliasTx({
+            suiClient,
+            getSenderAddress,
+            sign,
+            buildBytes: (sender, client) =>
+              removeAddressAliasTxBytes(sender, objectId, trimmed, client),
+          }),
+        {
+          fallbackMessage: 'Failed to remove address alias',
+          onSuccess: async () => {
+            await refetch()
+          },
+        },
+      )
+      return digest !== null
+    },
+    [
+      addressAliases,
+      senderAddress,
+      objectId,
+      run,
+      setError,
+      suiClient,
+      getSenderAddress,
+      sign,
+      refetch,
+    ],
+  )
+
   return {
     isAuthenticated,
     isWalletUnlocked,
@@ -168,11 +224,10 @@ export function useAddressAliases(): UseAddressAliasesResult {
         : readQueryError
           ? 'Failed to read address aliases'
           : null,
-
     enable,
     addAddressAlias,
+    removeAddressAlias,
     refresh,
-
     isSubmitting,
     error,
     txDigest,

--- a/packages/shared/src/wallet/hooks/useAddressAliases.ts
+++ b/packages/shared/src/wallet/hooks/useAddressAliases.ts
@@ -1,3 +1,4 @@
+import type { SuiGrpcClient } from '@mysten/sui/grpc'
 import { useCallback, useEffect, useMemo } from 'react'
 import { useToast } from '#/components'
 import { useAddressAliasesQuery } from './useAddressAliases.query'
@@ -8,6 +9,7 @@ import {
   removeAddressAliasTxBytes,
 } from './useAddressAliases.transaction'
 import {
+  type ValidateAddressAliasParams,
   validateExistingAddressAlias,
   validateNewAddressAlias,
 } from './useAddressAliases.validation'
@@ -110,8 +112,20 @@ export function useAddressAliases(): UseAddressAliasesResult {
     )
   }, [senderAddress, run, setError, suiClient, getSenderAddress, sign, refetch])
 
-  const addAddressAlias = useCallback(
-    async (addressAlias: string): Promise<boolean> => {
+  // Add and remove share the same guard → validate → build → sign → refetch
+  // pipeline; only the validator, bytes builder, and error copy differ.
+  const submitAliasChange = useCallback(
+    async (
+      addressAlias: string,
+      validate: (params: ValidateAddressAliasParams) => string | null,
+      buildBytes: (
+        sender: string,
+        objectId: string,
+        alias: string,
+        client: SuiGrpcClient,
+      ) => Promise<Uint8Array>,
+      fallbackMessage: string,
+    ): Promise<boolean> => {
       if (!senderAddress) {
         setError('Connect wallet first')
         return false
@@ -120,7 +134,7 @@ export function useAddressAliases(): UseAddressAliasesResult {
         setError('Enable address aliasing first')
         return false
       }
-      const validationError = validateNewAddressAlias({
+      const validationError = validate({
         addressAlias,
         existing: addressAliases,
       })
@@ -136,10 +150,10 @@ export function useAddressAliases(): UseAddressAliasesResult {
             getSenderAddress,
             sign,
             buildBytes: (sender, client) =>
-              addAddressAliasTxBytes(sender, objectId, trimmed, client),
+              buildBytes(sender, objectId, trimmed, client),
           }),
         {
-          fallbackMessage: 'Failed to add address alias',
+          fallbackMessage,
           onSuccess: async () => {
             await refetch()
           },
@@ -160,55 +174,26 @@ export function useAddressAliases(): UseAddressAliasesResult {
     ],
   )
 
-  const removeAddressAlias = useCallback(
-    async (addressAlias: string): Promise<boolean> => {
-      if (!senderAddress) {
-        setError('Connect wallet first')
-        return false
-      }
-      if (!objectId) {
-        setError('Enable address aliasing first')
-        return false
-      }
-
-      const validationError = validateExistingAddressAlias({
+  const addAddressAlias = useCallback(
+    (addressAlias: string) =>
+      submitAliasChange(
         addressAlias,
-        existing: addressAliases,
-      })
-      if (validationError) {
-        setError(validationError)
-        return false
-      }
-      const trimmed = addressAlias.trim()
-      const digest = await run(
-        () =>
-          executeAddressAliasTx({
-            suiClient,
-            getSenderAddress,
-            sign,
-            buildBytes: (sender, client) =>
-              removeAddressAliasTxBytes(sender, objectId, trimmed, client),
-          }),
-        {
-          fallbackMessage: 'Failed to remove address alias',
-          onSuccess: async () => {
-            await refetch()
-          },
-        },
-      )
-      return digest !== null
-    },
-    [
-      addressAliases,
-      senderAddress,
-      objectId,
-      run,
-      setError,
-      suiClient,
-      getSenderAddress,
-      sign,
-      refetch,
-    ],
+        validateNewAddressAlias,
+        addAddressAliasTxBytes,
+        'Failed to add address alias',
+      ),
+    [submitAliasChange],
+  )
+
+  const removeAddressAlias = useCallback(
+    (addressAlias: string) =>
+      submitAliasChange(
+        addressAlias,
+        validateExistingAddressAlias,
+        removeAddressAliasTxBytes,
+        'Failed to remove address alias',
+      ),
+    [submitAliasChange],
   )
 
   return {

--- a/packages/shared/src/wallet/hooks/useAddressAliases.validation.ts
+++ b/packages/shared/src/wallet/hooks/useAddressAliases.validation.ts
@@ -41,8 +41,14 @@ export const validateExistingAddressAlias = ({
 }: ValidateAddressAliasParams): string | null => {
   const trimmed = addressAlias.trim()
 
+  if (!trimmed) {
+    return 'Enter an address to remove'
+  }
+  if (!isValidSuiAddress(trimmed)) {
+    return 'Not a valid Sui address'
+  }
   if (!existing.includes(trimmed)) {
-    return 'Address is not an address alias'
+    return 'Address is not an existing address alias'
   }
   return null
 }

--- a/packages/shared/src/wallet/hooks/useAddressAliases.validation.ts
+++ b/packages/shared/src/wallet/hooks/useAddressAliases.validation.ts
@@ -1,7 +1,7 @@
 import { isValidSuiAddress } from '@mysten/sui/utils'
 import { MAX_ADDRESS_ALIASES } from './useAddressAliases.config'
 
-type ValidateAddressAliasParams = {
+export type ValidateAddressAliasParams = {
   addressAlias: string
   existing: string[]
 }

--- a/packages/shared/src/wallet/hooks/useAddressAliases.validation.ts
+++ b/packages/shared/src/wallet/hooks/useAddressAliases.validation.ts
@@ -30,3 +30,19 @@ export const validateNewAddressAlias = ({
   }
   return null
 }
+
+/**
+ * Returns an error when the address is not a current address alias, or `null`
+ * when it is safe to remove.
+ */
+export const validateExistingAddressAlias = ({
+  addressAlias,
+  existing,
+}: ValidateAddressAliasParams): string | null => {
+  const trimmed = addressAlias.trim()
+
+  if (!existing.includes(trimmed)) {
+    return 'Address is not an address alias'
+  }
+  return null
+}

--- a/packages/shared/src/wallet/index.ts
+++ b/packages/shared/src/wallet/index.ts
@@ -7,7 +7,10 @@ export {
 } from '../types/wallet'
 export { useActiveSuiAddress } from './hooks/useActiveSuiAddress'
 export { useAddressAliases } from './hooks/useAddressAliases'
-export type { AddressAliasesInfo } from './hooks/useAddressAliases.config'
+export {
+  ADDRESS_ALIAS_MODULE,
+  type AddressAliasesInfo,
+} from './hooks/useAddressAliases.config'
 export { useBalance } from './hooks/useBalance'
 export { useSendToken } from './hooks/useSendToken'
 export { useTransactionHistory } from './hooks/useTransactionHistory'


### PR DESCRIPTION
Builds on the address-alias management screen:

1. **Remove an address alias**.
2. **Transaction risk warning** — any transaction that calls the on-chain `0x2::address_alias` module is now flagged as a **danger**-level risk in the sign/approve flow, requiring explicit acknowledgement.

### Changes

**Remove address alias** (`packages/shared`)
- `useAddressAliases` exposes a new `removeAddressAlias(addressAlias)` action that validates the alias exists, builds and signs a `0x2::address_alias::remove` transaction, and refetches on success.
- New `removeAddressAliasTxBytes()` transaction builder alongside the existing add/enable builders.
- New `validateExistingAddressAlias()` validator — returns an error when the address isn't a current alias (mirrors the add-side `validateNewAddressAlias`).
- `AddressAliasesScreen` renders a **Remove** button per alias, hides it for the owner's own address, and labels that row `(This address)`.
<img width="829" height="720" alt="Screenshot 2026-07-03 at 14 53 13" src="https://github.com/user-attachments/assets/305174ff-2810-455c-8e54-e9382937859e" />

**Transaction risk review** (`apps/extension`)
- Added an `addressAlias` danger finding: *"Modifies address aliases — This can add or remove address aliases for your account."*
- Detection now inspects `MoveCall` targets (`package` + `module`, compared via `normalizeSuiAddress`) and matches `0x2::address_alias`, since alias operations are ordinary Move calls and can't be matched by command kind. Replaces a dead command-name rule that could never fire.
- `TransactionRiskPanel` sorts danger findings above warnings.
<img width="441" height="747" alt="Screenshot 2026-07-03 at 13 55 53" src="https://github.com/user-attachments/assets/2862647c-f36e-49ea-b478-a0d99100d291" />

**Housekeeping**
- Tightened the `validateExistingAddressAlias` error copy/doc (`"Address is not an address alias"`).
- Version bumps + changelog entries for `shared`, `web`, and `extension`.