### PR TITLE
feat(web): add desktop sidebar with centralised `/wallet` auth guard

### DIFF
--- a/apps/extension/src/features/wallet/components/AuthenticatedWalletView.tsx
+++ b/apps/extension/src/features/wallet/components/AuthenticatedWalletView.tsx
@@ -5,12 +5,14 @@ import {
   TenantSelector,
   Text,
   TokenListSection,
+  useToast,
 } from '@evevault/shared/components'
 import { useUnlockTimeRemaining } from '@evevault/shared/hooks'
 import { EXTENSION_ROUTES, getSuiscanUrl } from '@evevault/shared/utils'
 import type { SuiChain } from '@mysten/wallet-standard'
 import { useNavigate } from '@tanstack/react-router'
 import type { User } from 'oidc-client-ts'
+import { useEffect } from 'react'
 import { APP_VERSION } from '@/lib/appVersion'
 
 /**
@@ -78,11 +80,21 @@ export function AuthenticatedWalletView({
   onNetworkSwitchStart: (previousNetwork: string, targetNetwork: string) => void
 }) {
   const navigate = useNavigate()
+  const { showErrorToast } = useToast()
   const openFaucet = faucetUrl
     ? () => window.open(faucetUrl, '_blank', 'noopener,noreferrer')
     : undefined
   // Display only of the vault unlock window.
   const unlockRemainingLabel = useUnlockTimeRemaining(devMode) ?? undefined
+
+  // Surface auth/device failures as transient toasts rather than inline text.
+  useEffect(() => {
+    if (authError) showErrorToast('AuthError', authError)
+  }, [authError, showErrorToast])
+
+  useEffect(() => {
+    if (deviceError) showErrorToast('DeviceError', deviceError)
+  }, [deviceError, showErrorToast])
 
   return (
     <div className="flex flex-col h-full">
@@ -131,8 +143,6 @@ export function AuthenticatedWalletView({
         <TenantSelector currentTenantId={tenantId} viewOnly={true} />
       </div>
 
-      {authError && <Text color="error">AuthError: {authError}</Text>}
-      {deviceError && <Text color="error">DeviceError: {deviceError}</Text>}
       {txDigest && (
         <TransactionDigestLink
           chain={chain}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from "./routes/__root"
 import { Route as NotFoundRouteImport } from "./routes/not-found"
 import { Route as CallbackRouteImport } from "./routes/callback"
+import { Route as WalletRouteRouteImport } from "./routes/wallet/route"
 import { Route as IndexRouteImport } from "./routes/index"
 import { Route as WalletIndexRouteImport } from "./routes/wallet/index"
 import { Route as WalletTransactionsRouteImport } from "./routes/wallet.transactions"
@@ -28,39 +29,45 @@ const CallbackRoute = CallbackRouteImport.update({
   path: "/callback",
   getParentRoute: () => rootRouteImport,
 } as any)
+const WalletRouteRoute = WalletRouteRouteImport.update({
+  id: "/wallet",
+  path: "/wallet",
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: "/",
   path: "/",
   getParentRoute: () => rootRouteImport,
 } as any)
 const WalletIndexRoute = WalletIndexRouteImport.update({
-  id: "/wallet/",
-  path: "/wallet/",
-  getParentRoute: () => rootRouteImport,
+  id: "/",
+  path: "/",
+  getParentRoute: () => WalletRouteRoute,
 } as any)
 const WalletTransactionsRoute = WalletTransactionsRouteImport.update({
-  id: "/wallet/transactions",
-  path: "/wallet/transactions",
-  getParentRoute: () => rootRouteImport,
+  id: "/transactions",
+  path: "/transactions",
+  getParentRoute: () => WalletRouteRoute,
 } as any)
 const WalletSendTokenRoute = WalletSendTokenRouteImport.update({
-  id: "/wallet/send-token",
-  path: "/wallet/send-token",
-  getParentRoute: () => rootRouteImport,
+  id: "/send-token",
+  path: "/send-token",
+  getParentRoute: () => WalletRouteRoute,
 } as any)
 const WalletAddressAliasesRoute = WalletAddressAliasesRouteImport.update({
-  id: "/wallet/address-aliases",
-  path: "/wallet/address-aliases",
-  getParentRoute: () => rootRouteImport,
+  id: "/address-aliases",
+  path: "/address-aliases",
+  getParentRoute: () => WalletRouteRoute,
 } as any)
 const WalletAddTokenRoute = WalletAddTokenRouteImport.update({
-  id: "/wallet/add-token",
-  path: "/wallet/add-token",
-  getParentRoute: () => rootRouteImport,
+  id: "/add-token",
+  path: "/add-token",
+  getParentRoute: () => WalletRouteRoute,
 } as any)
 
 export interface FileRoutesByFullPath {
   "/": typeof IndexRoute
+  "/wallet": typeof WalletRouteRouteWithChildren
   "/callback": typeof CallbackRoute
   "/not-found": typeof NotFoundRoute
   "/wallet/add-token": typeof WalletAddTokenRoute
@@ -82,6 +89,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   "/": typeof IndexRoute
+  "/wallet": typeof WalletRouteRouteWithChildren
   "/callback": typeof CallbackRoute
   "/not-found": typeof NotFoundRoute
   "/wallet/add-token": typeof WalletAddTokenRoute
@@ -94,6 +102,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | "/"
+    | "/wallet"
     | "/callback"
     | "/not-found"
     | "/wallet/add-token"
@@ -114,6 +123,7 @@ export interface FileRouteTypes {
   id:
     | "__root__"
     | "/"
+    | "/wallet"
     | "/callback"
     | "/not-found"
     | "/wallet/add-token"
@@ -125,13 +135,9 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  WalletRouteRoute: typeof WalletRouteRouteWithChildren
   CallbackRoute: typeof CallbackRoute
   NotFoundRoute: typeof NotFoundRoute
-  WalletAddTokenRoute: typeof WalletAddTokenRoute
-  WalletAddressAliasesRoute: typeof WalletAddressAliasesRoute
-  WalletSendTokenRoute: typeof WalletSendTokenRoute
-  WalletTransactionsRoute: typeof WalletTransactionsRoute
-  WalletIndexRoute: typeof WalletIndexRoute
 }
 
 declare module "@tanstack/react-router" {
@@ -150,6 +156,13 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof CallbackRouteImport
       parentRoute: typeof rootRouteImport
     }
+    "/wallet": {
+      id: "/wallet"
+      path: "/wallet"
+      fullPath: "/wallet"
+      preLoaderRoute: typeof WalletRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     "/": {
       id: "/"
       path: "/"
@@ -159,51 +172,67 @@ declare module "@tanstack/react-router" {
     }
     "/wallet/": {
       id: "/wallet/"
-      path: "/wallet"
+      path: "/"
       fullPath: "/wallet/"
       preLoaderRoute: typeof WalletIndexRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof WalletRouteRoute
     }
     "/wallet/transactions": {
       id: "/wallet/transactions"
-      path: "/wallet/transactions"
+      path: "/transactions"
       fullPath: "/wallet/transactions"
       preLoaderRoute: typeof WalletTransactionsRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof WalletRouteRoute
     }
     "/wallet/send-token": {
       id: "/wallet/send-token"
-      path: "/wallet/send-token"
+      path: "/send-token"
       fullPath: "/wallet/send-token"
       preLoaderRoute: typeof WalletSendTokenRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof WalletRouteRoute
     }
     "/wallet/address-aliases": {
       id: "/wallet/address-aliases"
-      path: "/wallet/address-aliases"
+      path: "/address-aliases"
       fullPath: "/wallet/address-aliases"
       preLoaderRoute: typeof WalletAddressAliasesRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof WalletRouteRoute
     }
     "/wallet/add-token": {
       id: "/wallet/add-token"
-      path: "/wallet/add-token"
+      path: "/add-token"
       fullPath: "/wallet/add-token"
       preLoaderRoute: typeof WalletAddTokenRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof WalletRouteRoute
     }
   }
 }
 
-const rootRouteChildren: RootRouteChildren = {
-  IndexRoute: IndexRoute,
-  CallbackRoute: CallbackRoute,
-  NotFoundRoute: NotFoundRoute,
+interface WalletRouteRouteChildren {
+  WalletAddTokenRoute: typeof WalletAddTokenRoute
+  WalletAddressAliasesRoute: typeof WalletAddressAliasesRoute
+  WalletSendTokenRoute: typeof WalletSendTokenRoute
+  WalletTransactionsRoute: typeof WalletTransactionsRoute
+  WalletIndexRoute: typeof WalletIndexRoute
+}
+
+const WalletRouteRouteChildren: WalletRouteRouteChildren = {
   WalletAddTokenRoute: WalletAddTokenRoute,
   WalletAddressAliasesRoute: WalletAddressAliasesRoute,
   WalletSendTokenRoute: WalletSendTokenRoute,
   WalletTransactionsRoute: WalletTransactionsRoute,
   WalletIndexRoute: WalletIndexRoute,
+}
+
+const WalletRouteRouteWithChildren = WalletRouteRoute._addFileChildren(
+  WalletRouteRouteChildren,
+)
+
+const rootRouteChildren: RootRouteChildren = {
+  IndexRoute: IndexRoute,
+  WalletRouteRoute: WalletRouteRouteWithChildren,
+  CallbackRoute: CallbackRoute,
+  NotFoundRoute: NotFoundRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/web/src/routes/wallet.address-aliases.tsx
+++ b/apps/web/src/routes/wallet.address-aliases.tsx
@@ -1,5 +1,4 @@
 import { useAuthStore, useContextStore } from '@evevault/shared'
-import { requireAuth } from '@evevault/shared/router'
 import { AddressAliasesScreen } from '@evevault/shared/screens'
 import { WEB_ROUTES } from '@evevault/shared/utils'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
@@ -21,6 +20,5 @@ function AddressAliasesPage() {
 }
 
 export const Route = createFileRoute('/wallet/address-aliases')({
-  beforeLoad: () => requireAuth({ preserveRedirectPath: true }),
   component: AddressAliasesPage,
 })

--- a/apps/web/src/routes/wallet.send-token.tsx
+++ b/apps/web/src/routes/wallet.send-token.tsx
@@ -1,6 +1,5 @@
 import { SendTokenScreen, useAuthStore } from '@evevault/shared'
 import type { SendTokenSearch } from '@evevault/shared/router'
-import { requireAuth } from '@evevault/shared/router'
 import {
   createFileRoute,
   redirect,
@@ -27,7 +26,6 @@ function SendTokenPage() {
 }
 
 export const Route = createFileRoute('/wallet/send-token')({
-  beforeLoad: () => requireAuth({ preserveRedirectPath: true }),
   component: SendTokenPage,
   validateSearch: (search: Record<string, unknown>): SendTokenSearch => {
     const coinType = (search.coinType as string) || ''

--- a/apps/web/src/routes/wallet.transactions.tsx
+++ b/apps/web/src/routes/wallet.transactions.tsx
@@ -3,7 +3,6 @@ import {
   useAuthStore,
   useContextStore,
 } from '@evevault/shared'
-import { requireAuth } from '@evevault/shared/router'
 import { WEB_ROUTES } from '@evevault/shared/utils'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 
@@ -24,6 +23,5 @@ function TransactionsPage() {
 }
 
 export const Route = createFileRoute('/wallet/transactions')({
-  beforeLoad: () => requireAuth({ preserveRedirectPath: true }),
   component: TransactionsPage,
 })

--- a/apps/web/src/routes/wallet/add-token.tsx
+++ b/apps/web/src/routes/wallet/add-token.tsx
@@ -1,5 +1,4 @@
 import { AddTokenScreen, useAuthStore, useContext } from '@evevault/shared'
-import { requireAuth } from '@evevault/shared/router'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 
 function AddTokenPage() {
@@ -22,6 +21,5 @@ function AddTokenPage() {
 }
 
 export const Route = createFileRoute('/wallet/add-token')({
-  beforeLoad: () => requireAuth({ preserveRedirectPath: true }),
   component: AddTokenPage,
 })

--- a/apps/web/src/routes/wallet/index.tsx
+++ b/apps/web/src/routes/wallet/index.tsx
@@ -1,11 +1,9 @@
-import { requireAuth } from '@evevault/shared/router'
 import { createFileRoute } from '@tanstack/react-router'
 import { WalletScreen } from '@/features/wallet/components/WalletScreen'
 
 export const Route = createFileRoute('/wallet/')({
   beforeLoad: () => {
     document.title = 'EVE Vault - Wallet'
-    requireAuth({ preserveRedirectPath: true })
   },
   component: WalletScreen,
 })

--- a/apps/web/src/routes/wallet/route.tsx
+++ b/apps/web/src/routes/wallet/route.tsx
@@ -1,0 +1,12 @@
+import { requireAuth } from '@evevault/shared/router'
+import { createFileRoute, Outlet } from '@tanstack/react-router'
+
+/**
+ * Layout route guarding the entire /wallet subtree.
+ * beforeLoad runs parent-first on every navigation, so child routes
+ * don't need their own requireAuth call.
+ */
+export const Route = createFileRoute('/wallet')({
+  beforeLoad: () => requireAuth({ preserveRedirectPath: true }),
+  component: Outlet,
+})

--- a/packages/shared/src/components/Layout/Layout.tsx
+++ b/packages/shared/src/components/Layout/Layout.tsx
@@ -36,7 +36,7 @@ export const Layout: React.FC<LayoutProps> = ({
   showNav: _showNav = true, // Reserved for future mobile nav bar visibility
   headerProps,
 }) => {
-  const { width } = useResponsive()
+  const { width, isMobile } = useResponsive()
   const [viewportHeight, setViewportHeight] = useState<number>(() => {
     if (typeof window === 'undefined') return 800
     return window.innerHeight
@@ -107,8 +107,7 @@ export const Layout: React.FC<LayoutProps> = ({
     )
   }
 
-  /// TODO: add sidebar
-  const showSidebar = false
+  const showSidebar = !isMobile
 
   return (
     <div className="flex h-screen w-full overflow-hidden">

--- a/packages/shared/src/components/TokenList/TokenSection.parts.tsx
+++ b/packages/shared/src/components/TokenList/TokenSection.parts.tsx
@@ -33,10 +33,10 @@ export function WalletAddressRow({
   walletAddress?: string
   onCopyAddress: (address: string) => void
 }) {
-  if (!walletAddress) return <div className="h-6 flex-shrink-0" />
+  if (!walletAddress) return <div className="h-6 shrink-0" />
 
   return (
-    <div className="flex justify-end items-center gap-2 w-full flex-shrink-0">
+    <div className="flex justify-end items-center gap-2 w-full shrink-0">
       <div className="flex items-center gap-1">
         <Text variant="regular" size="small" color="neutral-80">
           Wallet address:

--- a/packages/shared/src/components/TokenList/TokenSection.parts.tsx
+++ b/packages/shared/src/components/TokenList/TokenSection.parts.tsx
@@ -190,7 +190,7 @@ export function TokenActions({
   onRemoveToken: () => void
 }) {
   return (
-    <div className="flex justify-center items-center gap-1 w-full flex-shrink-0">
+    <div className="flex justify-center items-center gap-1 w-full shrink-0">
       {onAddToken ? (
         <Button variant="primary" size="small" onClick={onAddToken}>
           Add token

--- a/packages/shared/src/stores/deviceStore/actions/proofHelpers.ts
+++ b/packages/shared/src/stores/deviceStore/actions/proofHelpers.ts
@@ -203,6 +203,7 @@ const requestZkProof = async ({
     maxEpoch,
     ephemeralPublicKey,
     idToken: vendedIdToken,
+    network,
   })
   return { data, error: undefined }
 }

--- a/packages/shared/src/types/wallet.ts
+++ b/packages/shared/src/types/wallet.ts
@@ -33,6 +33,7 @@ export interface ZkProofParams {
   jwtRandomness: string
   maxEpoch: string
   ephemeralPublicKey: PublicKey
+  network: string
   idToken: string
 }
 

--- a/packages/shared/src/utils/routes.ts
+++ b/packages/shared/src/utils/routes.ts
@@ -14,12 +14,7 @@ export const FILE_ROUTE_PATHS = [
 ] as const
 
 export type RoutePath = (typeof FILE_ROUTE_PATHS)[number]
-export type NavPath =
-  | RoutePath
-  | '/tokens'
-  | '/assets'
-  | '/history'
-  | '/address-aliases'
+export type NavPath = RoutePath
 
 /**
  * Extension route paths
@@ -49,15 +44,6 @@ export const WEB_ROUTES = {
   WALLET_ADDRESS_ALIASES: '/wallet/address-aliases',
 } as const
 
-/** All valid route paths from the router (for web app) */
-export const ROUTE_PATHS: readonly NavPath[] = [
-  ...FILE_ROUTE_PATHS,
-  '/tokens',
-  '/assets',
-  '/history',
-  '/address-aliases',
-]
-
 /** Navigation items for the sidebar/bottom bar */
 export const NAV_ITEMS: readonly {
   name: string
@@ -65,18 +51,17 @@ export const NAV_ITEMS: readonly {
   icon: string
   label: string
 }[] = [
-  { name: 'tokens', path: '/tokens', icon: 'Tokens', label: 'Tokens' },
-  { name: 'assets', path: '/assets', icon: 'Assets', label: 'Assets' },
+  { name: 'assets', path: '/wallet', icon: 'Assets', label: 'Home' },
   {
     name: 'history',
-    path: '/history',
+    path: '/wallet/transactions',
     icon: 'History',
-    label: 'History',
+    label: 'Transactions',
   },
   {
     name: 'address-aliases',
-    path: '/address-aliases',
-    icon: 'Network',
+    path: '/wallet/address-aliases',
+    icon: 'Tokens',
     label: 'Address Aliases',
   },
 ] as const

--- a/packages/shared/src/wallet/__tests__/zkProof.test.ts
+++ b/packages/shared/src/wallet/__tests__/zkProof.test.ts
@@ -63,6 +63,7 @@ describe('fetchZkProof', () => {
         maxEpoch: '12',
         ephemeralPublicKey: 'ephemeral-public-key' as never,
         idToken: ID_TOKEN,
+        network: 'testnet',
       }),
     ).resolves.toEqual(proofData)
 
@@ -79,6 +80,7 @@ describe('fetchZkProof', () => {
       body: JSON.stringify({
         extendedEphemeralPublicKey: 'extended-public-key',
         maxEpoch: 12,
+        network: 'testnet',
         randomness: 'randomness',
       }),
     })
@@ -101,6 +103,7 @@ describe('fetchZkProof', () => {
         maxEpoch: '12',
         ephemeralPublicKey: 'ephemeral-public-key' as never,
         idToken: ID_TOKEN,
+        network: 'testnet',
       }),
     ).rejects.toThrow(/failed \(400\).*bad request/)
   })
@@ -122,6 +125,7 @@ describe('fetchZkProof', () => {
         maxEpoch: '12',
         ephemeralPublicKey: 'ephemeral-public-key' as never,
         idToken: ID_TOKEN,
+        network: 'testnet',
       }),
     ).rejects.toThrow(/missing required fields/)
   })
@@ -141,6 +145,7 @@ describe('fetchZkProof', () => {
         maxEpoch: '12',
         ephemeralPublicKey: 'ephemeral-public-key' as never,
         idToken: ID_TOKEN,
+        network: 'testnet',
       }),
     ).rejects.toThrow(/not valid JSON/)
   })
@@ -157,6 +162,7 @@ describe('fetchZkProof', () => {
         maxEpoch: '12',
         ephemeralPublicKey: 'ephemeral-public-key' as never,
         idToken: ID_TOKEN,
+        network: 'testnet',
       }),
     ).rejects.toThrow('Network failure')
   })

--- a/packages/shared/src/wallet/zkProof.ts
+++ b/packages/shared/src/wallet/zkProof.ts
@@ -11,7 +11,8 @@ export type { ZkProofParams }
 export const fetchZkProof = async (
   params: ZkProofParams,
 ): Promise<ZkProofData> => {
-  const { jwtRandomness, maxEpoch, ephemeralPublicKey, idToken } = params
+  const { jwtRandomness, maxEpoch, ephemeralPublicKey, idToken, network } =
+    params
 
   const extendedEphemeralPublicKey =
     getExtendedEphemeralPublicKey(ephemeralPublicKey)
@@ -19,6 +20,7 @@ export const fetchZkProof = async (
   const body = JSON.stringify({
     extendedEphemeralPublicKey: extendedEphemeralPublicKey,
     maxEpoch: Number(maxEpoch),
+    network: network,
     randomness: jwtRandomness,
   })
 


### PR DESCRIPTION
## Desktop sidebar and wallet navigation

Adds the desktop sidebar to the web app and cleans up the routing that supports it.

### Sidebar
- New left sidebar for the web app, shown above the mobile breakpoint (tablet/desktop), with **Home**, **Transactions**, and **Address Aliases** entries.
- Nav items now point at the real route paths (`/wallet`, `/wallet/transactions`, `/wallet/address-aliases`); the stale `ROUTE_PATHS` constant and dead `NavPath` union members were removed.

<img width="804" height="769" alt="Screenshot 2026-07-14 at 13 27 20" src="https://github.com/user-attachments/assets/7da41e25-c834-44a4-9727-b3231451bcac" />

### Routing
- Centralised the auth guard into a `/wallet` layout route: `beforeLoad` runs `requireAuth` once for the whole subtree instead of being repeated in each child route, so any future `/wallet` route is guarded automatically.
- Navigating to a wallet route while signed out (e.g. via a sidebar link) redirects to sign-in — or the PIN unlock screen when the vault is locked — instead of rendering an error.

### Fixes
- zkLogin proof requests now include the selected network; `network` is required on `ZkProofParams` so call sites can't omit it (with test coverage for the request body).
- Extension wallet view surfaces errors as toasts instead of inline text.
