### PR TITLE
refactor: zkLogin epoch timing with wallet-core epoch module

### DIFF
--- a/packages/shared/src/sui/__tests__/rpcEpoch.test.ts
+++ b/packages/shared/src/sui/__tests__/rpcEpoch.test.ts
@@ -2,10 +2,10 @@ import { SUI_LOCALNET_CHAIN } from '@mysten/wallet-standard'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { DEFAULT_EPOCH_DURATION_MS } from '#/utils/constants'
 
-const mockGetEpoch = vi.fn()
+const mockGetCurrentSystemState = vi.fn()
 const mockCreateSuiClient = vi.fn((..._args: unknown[]) => ({
-  ledgerService: {
-    getEpoch: mockGetEpoch,
+  core: {
+    getCurrentSystemState: mockGetCurrentSystemState,
   },
 }))
 
@@ -30,8 +30,12 @@ describe('getCurrentEpochFromRpc', () => {
   })
 
   it('creates a localnet SUI client with the provided URL', async () => {
-    mockGetEpoch.mockReturnValue({
-      response: Promise.resolve({ epoch: { epoch: 3, start: 1000 } }),
+    mockGetCurrentSystemState.mockResolvedValue({
+      systemState: {
+        epoch: '3',
+        epochStartTimestampMs: '1000',
+        parameters: { epochDurationMs: String(DEFAULT_EPOCH_DURATION_MS) },
+      },
     })
 
     await getCurrentEpochFromRpc('http://127.0.0.1:9000')
@@ -42,35 +46,40 @@ describe('getCurrentEpochFromRpc', () => {
     )
   })
 
-  it('extracts epochNumber and computes maxEpochTimestampMs', async () => {
-    mockGetEpoch.mockReturnValue({
-      response: Promise.resolve({ epoch: { epoch: '11', start: '5000' } }),
+  it('derives numericMaxEpoch and maxEpochTimestampMs from system state', async () => {
+    mockGetCurrentSystemState.mockResolvedValue({
+      systemState: {
+        epoch: '11',
+        epochStartTimestampMs: '5000',
+        parameters: { epochDurationMs: '60000' },
+      },
     })
 
     await expect(
       getCurrentEpochFromRpc('http://127.0.0.1:9000'),
     ).resolves.toEqual({
       numericMaxEpoch: 11,
-      maxEpochTimestampMs: 5000 + DEFAULT_EPOCH_DURATION_MS,
+      maxEpochTimestampMs: 5000 + 60000,
     })
   })
 
-  it('coerces null or undefined epoch fields to 0', async () => {
-    mockGetEpoch.mockReturnValue({
-      response: Promise.resolve({ epoch: { epoch: null, start: undefined } }),
+  it('throws when system state returns non-numeric epoch fields', async () => {
+    mockGetCurrentSystemState.mockResolvedValue({
+      systemState: {
+        epoch: 'not-a-number',
+        epochStartTimestampMs: '5000',
+        parameters: { epochDurationMs: '60000' },
+      },
     })
 
     await expect(
       getCurrentEpochFromRpc('http://127.0.0.1:9000'),
-    ).resolves.toEqual({
-      numericMaxEpoch: 0,
-      maxEpochTimestampMs: DEFAULT_EPOCH_DURATION_MS,
-    })
+    ).rejects.toThrow(/non-numeric epoch fields/)
   })
 
   it('propagates gRPC errors to the caller', async () => {
     const error = new Error('grpc unavailable')
-    mockGetEpoch.mockReturnValue({ response: Promise.reject(error) })
+    mockGetCurrentSystemState.mockRejectedValue(error)
 
     await expect(getCurrentEpochFromRpc('http://127.0.0.1:9000')).rejects.toBe(
       error,

--- a/packages/shared/src/sui/graphqlEpoch.ts
+++ b/packages/shared/src/sui/graphqlEpoch.ts
@@ -54,7 +54,7 @@ export async function getCurrentEpochFromGraphQL(chain: SuiChain): Promise<{
       ? new Date(epoch.endTimestamp).getTime() - startMs
       : DEFAULT_EPOCH_DURATION_MS,
   }
-  // epochsFromCurrent: 0 binds maxEpoch to the current epoch — no buffer.
+  // maxEpoch = current epoch
   const state = computeEpochState(info, {
     epochsFromCurrent: 0,
     nowMs: Date.now(),

--- a/packages/shared/src/sui/graphqlEpoch.ts
+++ b/packages/shared/src/sui/graphqlEpoch.ts
@@ -1,3 +1,7 @@
+import {
+  type ChainEpochInfo,
+  computeEpochState,
+} from '@evefrontier/wallet-core/epoch'
 import type { SuiChain } from '@mysten/wallet-standard'
 import { DEFAULT_EPOCH_DURATION_MS } from '#/utils/constants'
 import { createLogger } from '#/utils/logger'
@@ -35,9 +39,6 @@ export async function getCurrentEpochFromGraphQL(chain: SuiChain): Promise<{
   const startMs = epoch.startTimestamp
     ? new Date(epoch.startTimestamp).getTime()
     : 0
-  const endMs = epoch.endTimestamp
-    ? new Date(epoch.endTimestamp).getTime()
-    : startMs + DEFAULT_EPOCH_DURATION_MS
 
   if (!epoch.endTimestamp) {
     log.debug('Epoch endTimestamp missing; using start + 24h fallback', {
@@ -46,8 +47,21 @@ export async function getCurrentEpochFromGraphQL(chain: SuiChain): Promise<{
     })
   }
 
+  const info: ChainEpochInfo = {
+    currentEpoch: numericMaxEpoch,
+    epochStartTimestampMs: startMs,
+    epochDurationMs: epoch.endTimestamp
+      ? new Date(epoch.endTimestamp).getTime() - startMs
+      : DEFAULT_EPOCH_DURATION_MS,
+  }
+  // epochsFromCurrent: 0 binds maxEpoch to the current epoch — no buffer.
+  const state = computeEpochState(info, {
+    epochsFromCurrent: 0,
+    nowMs: Date.now(),
+  })
+
   return {
-    numericMaxEpoch,
-    maxEpochTimestampMs: endMs,
+    numericMaxEpoch: state.numericMaxEpoch,
+    maxEpochTimestampMs: state.maxEpochTimestampMs,
   }
 }

--- a/packages/shared/src/sui/rpcEpoch.ts
+++ b/packages/shared/src/sui/rpcEpoch.ts
@@ -1,16 +1,15 @@
 import {
-  type ChainEpochInfo,
   computeEpochState,
+  fetchEpochFromSystemState,
 } from '@evefrontier/wallet-core/epoch'
 import { SUI_LOCALNET_CHAIN } from '@mysten/wallet-standard'
-import { DEFAULT_EPOCH_DURATION_MS } from '#/utils/constants'
 import { createLogger } from '#/utils/logger'
 import { createSuiClient } from './suiClient'
 
 const log = createLogger()
 
 /**
- * Fetches current epoch via GRPC for localnet.
+ * Fetches current epoch via GRPC for localnet from the on-chain system-state object.
  * Returns the same shape as getCurrentEpochFromGraphQL so callers are interchangeable.
  */
 export async function getCurrentEpochFromRpc(fullnodeUrl: string): Promise<{
@@ -19,25 +18,10 @@ export async function getCurrentEpochFromRpc(fullnodeUrl: string): Promise<{
 }> {
   const client = createSuiClient(SUI_LOCALNET_CHAIN, fullnodeUrl)
 
-  const epochResponse = await client.ledgerService
-    .getEpoch({})
-    .response.then((response) => response.epoch)
+  const info = await fetchEpochFromSystemState(client)
+  log.debug('Fetched epoch via gRPC system state', info)
 
-  const epoch = Number(epochResponse?.epoch ?? 0)
-  const startMs = Number(epochResponse?.start ?? 0)
-
-  log.debug('Fetched epoch via gRPC', {
-    epoch,
-    startMs,
-    durationMs: DEFAULT_EPOCH_DURATION_MS,
-  })
-
-  const info: ChainEpochInfo = {
-    currentEpoch: epoch,
-    epochStartTimestampMs: startMs,
-    epochDurationMs: DEFAULT_EPOCH_DURATION_MS,
-  }
-  // epochsFromCurrent: 0 binds maxEpoch to the current epoch — no buffer.
+  // maxEpoch = current epoch
   const state = computeEpochState(info, {
     epochsFromCurrent: 0,
     nowMs: Date.now(),

--- a/packages/shared/src/sui/rpcEpoch.ts
+++ b/packages/shared/src/sui/rpcEpoch.ts
@@ -1,3 +1,7 @@
+import {
+  type ChainEpochInfo,
+  computeEpochState,
+} from '@evefrontier/wallet-core/epoch'
 import { SUI_LOCALNET_CHAIN } from '@mysten/wallet-standard'
 import { DEFAULT_EPOCH_DURATION_MS } from '#/utils/constants'
 import { createLogger } from '#/utils/logger'
@@ -20,14 +24,27 @@ export async function getCurrentEpochFromRpc(fullnodeUrl: string): Promise<{
     .response.then((response) => response.epoch)
 
   const epoch = Number(epochResponse?.epoch ?? 0)
-
   const startMs = Number(epochResponse?.start ?? 0)
-  const durationMs = Number(DEFAULT_EPOCH_DURATION_MS)
 
-  log.debug('Fetched epoch via gRPC', { epoch, startMs, durationMs })
+  log.debug('Fetched epoch via gRPC', {
+    epoch,
+    startMs,
+    durationMs: DEFAULT_EPOCH_DURATION_MS,
+  })
+
+  const info: ChainEpochInfo = {
+    currentEpoch: epoch,
+    epochStartTimestampMs: startMs,
+    epochDurationMs: DEFAULT_EPOCH_DURATION_MS,
+  }
+  // epochsFromCurrent: 0 binds maxEpoch to the current epoch — no buffer.
+  const state = computeEpochState(info, {
+    epochsFromCurrent: 0,
+    nowMs: Date.now(),
+  })
 
   return {
-    numericMaxEpoch: epoch,
-    maxEpochTimestampMs: startMs + durationMs,
+    numericMaxEpoch: state.numericMaxEpoch,
+    maxEpochTimestampMs: state.maxEpochTimestampMs,
   }
 }


### PR DESCRIPTION
Routes both zkLogin epoch fetchers through `@evefrontier/wallet-core/epoch` instead of hand-rolling epoch/`maxEpoch` timing math in each fetcher. Epoch semantics now live in one shared place.

`getCurrentEpochFromGraphQL` and `getCurrentEpochFromRpc` keep their existing return shape (`{ numericMaxEpoch, maxEpochTimestampMs }`), so every downstream consumer is untouched.

## Changes

- **`graphqlEpoch.ts`** — builds a `ChainEpochInfo` from the GraphQL response and computes timing with `computeEpochState(info, { epochsFromCurrent: 0, ... })`. Behavior-preserving: with `epochsFromCurrent: 0`, `maxEpochTimestampMs` resolves to the same value as before in every branch (real end timestamp when present, `start + 24h` fallback otherwise).
- **`rpcEpoch.ts`** — replaces `ledgerService.getEpoch()` with `fetchEpochFromSystemState(client)`, which reads the on-chain system-state object. This sources the **actual** `epochDurationMs` from chain parameters rather than always assuming the 24h fallback, so localnet's `maxEpochTimestampMs` now reflects the chain's real epoch length. Non-numeric system-state fields now throw instead of silently coercing to `0`.

- Centralizes duplicated timing math and removes the local `DEFAULT_EPOCH_DURATION_MS` reliance on the gRPC path.