### PR TITLE
refactor(extension): adopt WXT browser API + enable Firefox dev

### DIFF
--- a/apps/extension/entrypoints/__tests__/content.test.ts
+++ b/apps/extension/entrypoints/__tests__/content.test.ts
@@ -22,7 +22,7 @@ beforeAll(async () => {
 })
 
 beforeEach(() => {
-  vi.stubGlobal('chrome', {
+  vi.stubGlobal('browser', {
     runtime: {
       sendMessage: vi.fn(),
       getURL: vi.fn(
@@ -34,10 +34,10 @@ beforeEach(() => {
     },
     storage: {
       local: {
-        get: vi.fn(),
+        get: vi.fn(() => Promise.resolve({})),
       },
     },
-  } as unknown as typeof chrome)
+  } as unknown as typeof browser)
 })
 
 afterEach(() => {
@@ -143,8 +143,8 @@ describe('content bridge message validation', () => {
     content.handleWindowMessage(blocked)
     content.handleWindowMessage(allowed)
 
-    expect(chrome.runtime.sendMessage).toHaveBeenCalledTimes(1)
-    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith(allowed.data)
+    expect(browser.runtime.sendMessage).toHaveBeenCalledTimes(1)
+    expect(browser.runtime.sendMessage).toHaveBeenCalledWith(allowed.data)
   })
 
   it('posts public background responses to the page origin instead of wildcard origin', () => {
@@ -372,7 +372,7 @@ describe('content bridge message validation', () => {
 
     content.handleWindowMessage(crossOrigin)
 
-    expect(chrome.runtime.sendMessage).not.toHaveBeenCalled()
+    expect(browser.runtime.sendMessage).not.toHaveBeenCalled()
   })
 
   it('ignores messages that originated from the extension itself (__from guard)', () => {
@@ -384,21 +384,20 @@ describe('content bridge message validation', () => {
 
     content.handleWindowMessage(reflected)
 
-    expect(chrome.runtime.sendMessage).not.toHaveBeenCalled()
+    expect(browser.runtime.sendMessage).not.toHaveBeenCalled()
   })
 
   it('responds to get_current_chain by posting a change event to the page', async () => {
     const postMessage = vi
       .spyOn(window, 'postMessage')
       .mockImplementation(() => undefined)
-    ;(chrome.storage.local.get as ReturnType<typeof vi.fn>).mockImplementation(
-      (_keys: unknown, callback: (result: Record<string, unknown>) => void) => {
-        callback({
+    ;(browser.storage.local.get as ReturnType<typeof vi.fn>).mockImplementation(
+      () =>
+        Promise.resolve({
           'evevault:context': JSON.stringify({
             state: { chain: 'sui:mainnet' },
           }),
-        })
-      },
+        }),
     )
 
     const event = new MessageEvent('message', {

--- a/apps/extension/entrypoints/__tests__/content.test.ts
+++ b/apps/extension/entrypoints/__tests__/content.test.ts
@@ -24,7 +24,7 @@ beforeAll(async () => {
 beforeEach(() => {
   vi.stubGlobal('browser', {
     runtime: {
-      sendMessage: vi.fn(),
+      sendMessage: vi.fn().mockResolvedValue(undefined),
       getURL: vi.fn(
         (path: string) => `chrome-extension://extension-id/${path}`,
       ),

--- a/apps/extension/entrypoints/background.ts
+++ b/apps/extension/entrypoints/background.ts
@@ -1,6 +1,6 @@
-/// <reference types="chrome"/>
 /// <reference types="vite/client" />
 
+import { browser } from 'wxt/browser'
 import { handleMessage } from '../src/lib/background/handlers/messageHandler'
 import { handlePortConnection } from '../src/lib/background/handlers/portHandlers'
 import { ensureOffscreen } from '../src/lib/background/services/offscreenService'
@@ -11,8 +11,8 @@ export default defineBackground(() => {
   ensureOffscreen(false)
 
   // Set up message handling
-  chrome.runtime.onMessage.addListener(handleMessage)
+  browser.runtime.onMessage.addListener(handleMessage)
 
   // Set up port connections
-  chrome.runtime.onConnect.addListener(handlePortConnection)
+  browser.runtime.onConnect.addListener(handlePortConnection)
 })

--- a/apps/extension/entrypoints/content.ts
+++ b/apps/extension/entrypoints/content.ts
@@ -281,7 +281,9 @@ export function handleWindowMessage(event: MessageEvent) {
   }
 
   if (isAllowedPageMessage(data)) {
-    browser.runtime.sendMessage(data)
+    // Fire-and-forget to the background; ignore rejection when it's unavailable
+    // (e.g. mid-reload) rather than surfacing an unhandled promise rejection.
+    void browser.runtime.sendMessage(data).catch(() => {})
   }
 }
 

--- a/apps/extension/entrypoints/content.ts
+++ b/apps/extension/entrypoints/content.ts
@@ -1,6 +1,7 @@
 import { WalletStandardMessageTypes } from '@evevault/shared/types'
 import { createLogger, hasNoTokenMaterial } from '@evevault/shared/utils'
 import { CONTEXT_STORAGE_KEY } from '@evevault/shared/utils/storageKeys'
+import { browser } from 'wxt/browser'
 
 const log = createLogger()
 const PUBLIC_WALLET_ACTIONS = new Set<string>([
@@ -244,23 +245,19 @@ function postToPage(message: Record<string, unknown>): void {
   window.postMessage(message, targetOrigin)
 }
 
-function resolveCurrentChain(): Promise<string> {
-  return new Promise((resolve) => {
-    chrome.storage.local.get([CONTEXT_STORAGE_KEY], (result) => {
-      let chain = 'sui:testnet'
-      try {
-        const stored = result[CONTEXT_STORAGE_KEY]
-        if (stored) {
-          const parsed =
-            typeof stored === 'string' ? JSON.parse(stored) : stored
-          if (parsed?.state?.chain) chain = parsed.state.chain
-        }
-      } catch {
-        // fall back to testnet
-      }
-      resolve(chain)
-    })
-  })
+async function resolveCurrentChain(): Promise<string> {
+  let chain = 'sui:testnet'
+  try {
+    const result = await browser.storage.local.get([CONTEXT_STORAGE_KEY])
+    const stored = result[CONTEXT_STORAGE_KEY]
+    if (stored) {
+      const parsed = typeof stored === 'string' ? JSON.parse(stored) : stored
+      if (parsed?.state?.chain) chain = parsed.state.chain
+    }
+  } catch {
+    // fall back to testnet
+  }
+  return chain
 }
 
 async function handleGetCurrentChain() {
@@ -284,7 +281,7 @@ export function handleWindowMessage(event: MessageEvent) {
   }
 
   if (isAllowedPageMessage(data)) {
-    chrome.runtime.sendMessage(data)
+    browser.runtime.sendMessage(data)
   }
 }
 
@@ -305,10 +302,10 @@ export default defineContentScript({
     log.info('Eve Vault content script loaded')
 
     const injectScript = document.createElement('script')
-    injectScript.src = chrome.runtime.getURL('injected.js')
+    injectScript.src = browser.runtime.getURL('/injected.js')
     ;(document.head || document.documentElement).appendChild(injectScript)
 
     window.addEventListener('message', handleWindowMessage)
-    chrome.runtime.onMessage.addListener(forwardToPage)
+    browser.runtime.onMessage.addListener(forwardToPage)
   },
 })

--- a/apps/extension/entrypoints/keeper/__tests__/keeperTestUtils.ts
+++ b/apps/extension/entrypoints/keeper/__tests__/keeperTestUtils.ts
@@ -18,7 +18,7 @@ export type KeeperHandler = (
  *   const { dispatch, rawDispatch, unlockVault } = ctx;
  *
  *   beforeAll(async () => {
- *     vi.stubGlobal("chrome", {
+ *     vi.stubGlobal("browser", {
  *       runtime: {
  *         onMessage: { addListener: ctx.captureHandler },
  *         sendMessage: vi.fn().mockResolvedValue(undefined),
@@ -100,16 +100,16 @@ export function setupKeeperSuite(
   ctx: ReturnType<typeof createKeeperTestContext>,
 ) {
   beforeAll(async () => {
-    // chrome must exist before keeper.ts loads because it calls
-    // chrome.runtime.onMessage.addListener() at module scope.
-    vi.stubGlobal('chrome', {
+    // browser must exist before keeper.ts loads because it calls
+    // browser.runtime.onMessage.addListener() at module scope.
+    vi.stubGlobal('browser', {
       runtime: {
         id: 'test-extension-id',
         onMessage: { addListener: ctx.captureHandler },
         sendMessage: vi.fn().mockResolvedValue(undefined),
       },
     })
-    // Dynamic import so the chrome stub is in place when the module registers
+    // Dynamic import so the browser stub is in place when the module registers
     // its listener. This exercises the real message-handler registration.
     await import('../keeper')
   })

--- a/apps/extension/entrypoints/keeper/keeper.ts
+++ b/apps/extension/entrypoints/keeper/keeper.ts
@@ -1,6 +1,5 @@
-/// <reference types="chrome"/>
-
 import { KeeperMessageTypes } from '@evevault/shared'
+import { type Browser, browser } from 'wxt/browser'
 import type { BackgroundMessage } from '@/lib/background/types'
 import { handleKeeperMessage, type KeeperSendResponse } from './keeperHandlers'
 
@@ -10,16 +9,16 @@ import { handleKeeperMessage, type KeeperSendResponse } from './keeperHandlers'
  * This offscreen document stays alive much longer than the service worker
  * and provides a stable place to store the decrypted ephemeral key.
  */
-chrome.runtime.onMessage.addListener(
+browser.runtime.onMessage.addListener(
   (
     message: BackgroundMessage,
-    sender: chrome.runtime.MessageSender,
+    sender: Browser.runtime.MessageSender,
     sendResponse: KeeperSendResponse,
   ) => handleKeeperMessage(message, sender, sendResponse),
 )
 
 console.log('Keeper offscreen document initialized')
 
-chrome.runtime.sendMessage({ type: KeeperMessageTypes.READY }).catch(() => {
+browser.runtime.sendMessage({ type: KeeperMessageTypes.READY }).catch(() => {
   // Ignore errors if background script isn't listening
 })

--- a/apps/extension/entrypoints/keeper/keeperHandlers.ts
+++ b/apps/extension/entrypoints/keeper/keeperHandlers.ts
@@ -1,9 +1,10 @@
 import { KeeperMessageTypes } from '@evevault/shared'
+import type { Browser } from 'wxt/browser'
 import { isExtensionSender } from '@/lib/background/senderGuard'
 import type { BackgroundMessage } from '@/lib/background/types'
 import type { KeeperHandler, KeeperSendResponse } from './keeperTypes'
 
-type MsgSender = chrome.runtime.MessageSender
+type MsgSender = Browser.runtime.MessageSender
 
 import {
   handleLocalnetGetAddress,

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "wxt",
-    "dev:firefox": "wxt -b firefox",
+    "dev:firefox": "wxt -b firefox --port 3002",
     "build": "wxt build",
     "build:webstore": "WXT_WEBSTORE_BUILD=true wxt build",
     "build:firefox": "wxt build -b firefox",

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -32,7 +32,6 @@
   "devDependencies": {
     "@tanstack/router-plugin": "^1.168.13",
     "@tailwindcss/vite": "^4.3.0",
-    "@types/chrome": "^0.0.280",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "@wxt-dev/module-react": "^1.2.2",

--- a/apps/extension/src/features/wallet/components/__tests__/SignPersonalMessage.test.tsx
+++ b/apps/extension/src/features/wallet/components/__tests__/SignPersonalMessage.test.tsx
@@ -125,7 +125,7 @@ describe('SignPersonalMessage', () => {
     expect(screen.getByText('Hello world')).toBeInTheDocument()
   })
 
-  it('decodes a number-array message (post-chrome-storage serialization)', async () => {
+  it('decodes a number-array message (post-browser-storage serialization)', async () => {
     const encoded = Array.from(new TextEncoder().encode('Array msg'))
     stubPending({
       windowId: 1,
@@ -140,7 +140,7 @@ describe('SignPersonalMessage', () => {
   it('decodes a plain-object message with numeric keys', async () => {
     const text = 'Object msg'
     const bytes = new TextEncoder().encode(text)
-    // chrome.storage serialises Uint8Array as { '0': 72, '1': 101, ... }
+    // browser.storage serialises Uint8Array as { '0': 72, '1': 101, ... }
     const objectMsg = Object.fromEntries(
       [...bytes].map((v, i) => [String(i), v]),
     )

--- a/apps/extension/src/features/wallet/hooks/__tests__/usePendingSignAction.test.tsx
+++ b/apps/extension/src/features/wallet/hooks/__tests__/usePendingSignAction.test.tsx
@@ -47,14 +47,14 @@ function makeOptions(parsePending = vi.fn(async (a: unknown) => a)) {
 }
 
 function stubStorage(pendingAction: unknown) {
-  vi.stubGlobal('chrome', {
+  vi.stubGlobal('browser', {
     storage: {
       local: {
         get: vi.fn(() => Promise.resolve({ pendingAction })),
         set: vi.fn(() => Promise.resolve()),
       },
     },
-  } as unknown as typeof chrome)
+  } as unknown as typeof browser)
 }
 
 beforeEach(() => {
@@ -107,14 +107,14 @@ describe('usePendingSignAction', () => {
       expect(result.current.pending).toBeNull()
     })
 
-    it('sets error when chrome.storage.local.get rejects', async () => {
-      vi.stubGlobal('chrome', {
+    it('sets error when browser.storage.local.get rejects', async () => {
+      vi.stubGlobal('browser', {
         storage: {
           local: {
             get: vi.fn(() => Promise.reject(new Error('idb crash'))),
           },
         },
-      } as unknown as typeof chrome)
+      } as unknown as typeof browser)
 
       const { result } = renderHook(() => usePendingSignAction(makeOptions()))
 
@@ -135,7 +135,7 @@ describe('usePendingSignAction', () => {
         error: 'x',
       })
       expect(stored).toBe(false)
-      expect(chrome.storage.local.set).not.toHaveBeenCalled()
+      expect(browser.storage.local.set).not.toHaveBeenCalled()
     })
 
     it('returns false and does not write when requestId is missing', async () => {
@@ -149,7 +149,7 @@ describe('usePendingSignAction', () => {
         error: 'x',
       })
       expect(stored).toBe(false)
-      expect(chrome.storage.local.set).not.toHaveBeenCalled()
+      expect(browser.storage.local.set).not.toHaveBeenCalled()
     })
 
     it('writes transactionResult and returns true when pending has requestId', async () => {
@@ -163,7 +163,7 @@ describe('usePendingSignAction', () => {
         error: 'rejected',
       })
       expect(stored).toBe(true)
-      expect(chrome.storage.local.set).toHaveBeenCalledWith({
+      expect(browser.storage.local.set).toHaveBeenCalledWith({
         transactionResult: {
           status: 'error',
           error: 'rejected',
@@ -182,7 +182,7 @@ describe('usePendingSignAction', () => {
       await waitFor(() => expect(result.current.pending).toEqual(action))
 
       await result.current.storeErrorResult('something went wrong')
-      expect(chrome.storage.local.set).toHaveBeenCalledWith({
+      expect(browser.storage.local.set).toHaveBeenCalledWith({
         transactionResult: {
           status: 'error',
           error: 'something went wrong',
@@ -206,7 +206,7 @@ describe('usePendingSignAction', () => {
 
       await act(() => result.current.handleReject())
 
-      expect(chrome.storage.local.set).not.toHaveBeenCalled()
+      expect(browser.storage.local.set).not.toHaveBeenCalled()
       expect(closeSpy).not.toHaveBeenCalled()
     })
 
@@ -221,7 +221,7 @@ describe('usePendingSignAction', () => {
 
       await act(() => result.current.handleReject())
 
-      expect(chrome.storage.local.set).toHaveBeenCalledWith({
+      expect(browser.storage.local.set).toHaveBeenCalledWith({
         transactionResult: {
           status: 'error',
           error: 'User rejected',

--- a/apps/extension/src/features/wallet/hooks/useAppInitialization.ts
+++ b/apps/extension/src/features/wallet/hooks/useAppInitialization.ts
@@ -2,6 +2,7 @@ import { useAuth } from '@evevault/shared/auth'
 import { useDeviceStore } from '@evevault/shared/stores/deviceStore'
 import { createLogger, DEVICE_STORAGE_KEY } from '@evevault/shared/utils'
 import { useEffect, useState } from 'react'
+import { browser } from 'wxt/browser'
 
 const log = createLogger()
 
@@ -20,10 +21,9 @@ export function useAppInitialization() {
       if (
         state.isLocked &&
         !prevState.isLocked &&
-        typeof chrome !== 'undefined' &&
-        chrome.runtime?.sendMessage
+        browser?.runtime?.sendMessage
       ) {
-        chrome.runtime.sendMessage({
+        browser.runtime.sendMessage({
           event: 'change',
           payload: { accounts: [] },
         })
@@ -43,7 +43,7 @@ export function useAppInitialization() {
         // Subscribe to device store changes for debugging
         unsubscribe = useDeviceStore.subscribe(async (state, prevState) => {
           log.debug('Device store changed', { state, prevState })
-          const storageSnapshot = await chrome.storage.local.get([
+          const storageSnapshot = await browser.storage.local.get([
             DEVICE_STORAGE_KEY,
           ])
           log.debug('Storage after change', storageSnapshot)

--- a/apps/extension/src/features/wallet/hooks/useAppInitialization.ts
+++ b/apps/extension/src/features/wallet/hooks/useAppInitialization.ts
@@ -23,10 +23,13 @@ export function useAppInitialization() {
         !prevState.isLocked &&
         browser?.runtime?.sendMessage
       ) {
-        browser.runtime.sendMessage({
-          event: 'change',
-          payload: { accounts: [] },
-        })
+        // Fire-and-forget; ignore rejection when no receiver is listening.
+        void browser.runtime
+          .sendMessage({
+            event: 'change',
+            payload: { accounts: [] },
+          })
+          .catch(() => {})
       }
     })
     return unsubscribe

--- a/apps/extension/src/features/wallet/hooks/usePendingSignAction.ts
+++ b/apps/extension/src/features/wallet/hooks/usePendingSignAction.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '@evevault/shared/utils'
 import { useEffect, useState } from 'react'
+import { browser } from 'wxt/browser'
 import { useSignPopupAuth } from './useSignPopupAuth'
 
 const log = createLogger()
@@ -56,7 +57,7 @@ export function usePendingSignAction<TPending extends { requestId?: string }>({
   const auth = useSignPopupAuth()
 
   useEffect(() => {
-    chrome.storage.local
+    browser.storage.local
       .get('pendingAction')
       .then(async (data) => {
         const pendingAction = data.pendingAction
@@ -96,7 +97,7 @@ export function usePendingSignAction<TPending extends { requestId?: string }>({
       return false
     }
 
-    await chrome.storage.local.set({
+    await browser.storage.local.set({
       transactionResult: {
         ...result,
         windowId: getWindowId(targetPending),

--- a/apps/extension/src/lib/background/handlers/__tests__/localVaultHandlers.test.ts
+++ b/apps/extension/src/lib/background/handlers/__tests__/localVaultHandlers.test.ts
@@ -1,5 +1,6 @@
 import { SUI_PRIVATE_KEY_PREFIX } from '@mysten/sui/cryptography'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Browser } from 'wxt/browser'
 import {
   _handleLocalnetGetAddress,
   _handleLocalnetSetKeypair,
@@ -23,7 +24,7 @@ vi.mock('@evevault/shared/types', () => ({
   },
 }))
 
-const mockSender = {} as chrome.runtime.MessageSender
+const mockSender = {} as Browser.runtime.MessageSender
 
 function makeMessage(overrides: Partial<VaultMessage> = {}): VaultMessage {
   return {
@@ -32,8 +33,8 @@ function makeMessage(overrides: Partial<VaultMessage> = {}): VaultMessage {
   } as unknown as VaultMessage
 }
 
-function installChromeMock() {
-  globalThis.chrome = {
+function installBrowserMock() {
+  vi.stubGlobal('browser', {
     storage: {
       local: {
         get: vi.fn().mockResolvedValue({}),
@@ -41,12 +42,12 @@ function installChromeMock() {
         remove: vi.fn(),
       },
     },
-  } as unknown as typeof chrome
+  } as unknown as typeof browser)
 }
 
 describe('_handleLocalnetSetKeypair', () => {
   beforeEach(() => {
-    installChromeMock()
+    installBrowserMock()
     mockSendToKeeper.mockReset()
   })
 
@@ -75,7 +76,7 @@ describe('_handleLocalnetSetKeypair', () => {
       type: 'LOCALNET_SET_KEYPAIR',
       privateKey: `${SUI_PRIVATE_KEY_PREFIX}1abc`,
     })
-    expect(chrome.storage.local.set).toHaveBeenCalledWith({
+    expect(browser.storage.local.set).toHaveBeenCalledWith({
       'evevault:device': JSON.stringify({
         state: {
           localnet: {
@@ -86,7 +87,7 @@ describe('_handleLocalnetSetKeypair', () => {
         version: 0,
       }),
     })
-    expect(chrome.storage.local.remove).not.toHaveBeenCalled()
+    expect(browser.storage.local.remove).not.toHaveBeenCalled()
     expect(sendResponse).toHaveBeenCalledWith({
       ok: true,
       address: '0xabc',
@@ -104,7 +105,7 @@ describe('_handleLocalnetSetKeypair', () => {
     _handleLocalnetSetKeypair(message, mockSender, sendResponse)
     await new Promise((r) => setTimeout(r, 0))
 
-    expect(chrome.storage.local.set).not.toHaveBeenCalled()
+    expect(browser.storage.local.set).not.toHaveBeenCalled()
     expect(sendResponse).toHaveBeenCalledWith({
       ok: false,
       address: undefined,
@@ -122,7 +123,7 @@ describe('_handleLocalnetSetKeypair', () => {
     _handleLocalnetSetKeypair(message, mockSender, sendResponse)
     await new Promise((r) => setTimeout(r, 0))
 
-    expect(chrome.storage.local.set).not.toHaveBeenCalled()
+    expect(browser.storage.local.set).not.toHaveBeenCalled()
     expect(sendResponse).toHaveBeenCalledWith({
       ok: false,
       error: 'Keeper unavailable',
@@ -146,7 +147,7 @@ describe('_handleLocalnetSetKeypair', () => {
     )
     await new Promise((r) => setTimeout(r, 0))
 
-    const [[stored]] = (chrome.storage.local.set as ReturnType<typeof vi.fn>)
+    const [[stored]] = (browser.storage.local.set as ReturnType<typeof vi.fn>)
       .mock.calls
     const storedValue = JSON.parse(stored['evevault:device']).state.localnet
       .encryptedKey
@@ -163,7 +164,7 @@ describe('_handleLocalnetSetKeypair', () => {
 
 describe('_handleLocalnetGetAddress', () => {
   beforeEach(() => {
-    installChromeMock()
+    installBrowserMock()
     mockSendToKeeper.mockReset()
   })
 
@@ -197,7 +198,7 @@ describe('_handleLocalnetGetAddress', () => {
 
 describe('_handleLocalnetSignBytes', () => {
   beforeEach(() => {
-    installChromeMock()
+    installBrowserMock()
     mockSendToKeeper.mockReset()
   })
 

--- a/apps/extension/src/lib/background/handlers/__tests__/localnetDeviceStorage.test.ts
+++ b/apps/extension/src/lib/background/handlers/__tests__/localnetDeviceStorage.test.ts
@@ -8,14 +8,14 @@ import {
 const encryptedKey = { iv: 'iv', data: 'data', salt: 'salt' }
 
 function installChromeStorageMock(initialValue: unknown) {
-  vi.stubGlobal('chrome', {
+  vi.stubGlobal('browser', {
     storage: {
       local: {
         get: vi.fn().mockResolvedValue({ [DEVICE_STORAGE_KEY]: initialValue }),
         set: vi.fn().mockResolvedValue(undefined),
       },
     },
-  } as unknown as typeof chrome)
+  } as unknown as typeof browser)
 }
 
 describe('localnetDeviceStorage', () => {
@@ -95,7 +95,7 @@ describe('localnetDeviceStorage', () => {
 
     await writeEncryptedLocalnetKey(encryptedKey, '0xnew')
 
-    expect(chrome.storage.local.set).toHaveBeenCalledWith({
+    expect(browser.storage.local.set).toHaveBeenCalledWith({
       [DEVICE_STORAGE_KEY]: JSON.stringify({
         state: {
           anotherField: 'preserved',

--- a/apps/extension/src/lib/background/handlers/__tests__/messageHandler.test.ts
+++ b/apps/extension/src/lib/background/handlers/__tests__/messageHandler.test.ts
@@ -1,5 +1,6 @@
 import { VaultMessageTypes, WalletStandardMessageTypes } from '@evevault/shared'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Browser } from 'wxt/browser'
 import { handleMessage } from '@/lib/background/handlers/messageHandler'
 
 const { logger, mocks } = vi.hoisted(() => ({
@@ -76,52 +77,52 @@ vi.mock('@/lib/background/handlers/vaultHandlers', () => ({
   _handleLocalnetSignBytes: mocks.handleLocalnetSignBytes,
 }))
 
-function installChromeMock() {
-  vi.stubGlobal('chrome', {
+function installBrowserMock() {
+  vi.stubGlobal('browser', {
     runtime: {
       id: 'extension-id',
     },
     tabs: {
-      query: vi.fn((_queryInfo, callback) => callback([{ id: 1 }, { id: 2 }])),
+      query: vi.fn(() => Promise.resolve([{ id: 1 }, { id: 2 }])),
       sendMessage: vi.fn(() => Promise.resolve()),
     },
-  } as unknown as typeof chrome)
+  } as unknown as typeof browser)
 }
 
-function dappSender(): chrome.runtime.MessageSender {
+function dappSender(): Browser.runtime.MessageSender {
   return {
     origin: 'https://dapp.example',
     url: 'https://dapp.example/app',
     tab: {
       id: 42,
       url: 'https://dapp.example/app',
-    } as chrome.tabs.Tab,
+    } as Browser.tabs.Tab,
   }
 }
 
-function extensionSender(): chrome.runtime.MessageSender {
+function extensionSender(): Browser.runtime.MessageSender {
   return {
     url: 'chrome-extension://extension-id/popup.html',
   }
 }
 
-function extensionTabSender(): chrome.runtime.MessageSender {
+function extensionTabSender(): Browser.runtime.MessageSender {
   return {
     origin: 'chrome-extension://extension-id',
     url: 'chrome-extension://extension-id/sign_transaction.html',
     tab: {
       id: 77,
       url: 'chrome-extension://extension-id/sign_transaction.html',
-    } as chrome.tabs.Tab,
+    } as Browser.tabs.Tab,
   }
 }
 
 describe('handleMessage route policy', () => {
   beforeEach(() => {
-    installChromeMock()
+    installBrowserMock()
     vi.clearAllMocks()
     mocks.getDappRequestContext.mockImplementation(
-      (sender: chrome.runtime.MessageSender) =>
+      (sender: Browser.runtime.MessageSender) =>
         sender.tab
           ? {
               origin: 'https://dapp.example',
@@ -265,7 +266,7 @@ describe('handleMessage route policy', () => {
         sendResponse,
       ),
     ).toBe(false)
-    expect(chrome.tabs.query).not.toHaveBeenCalled()
+    expect(browser.tabs.query).not.toHaveBeenCalled()
   })
 
   it('allows wallet signing actions from tab senders only', () => {
@@ -294,7 +295,7 @@ describe('handleMessage route policy', () => {
 
   it('routes wallet signing actions from tab senders without resolving dApp context', () => {
     const sendResponse = vi.fn()
-    const sender = { tab: { id: 42 } } as chrome.runtime.MessageSender
+    const sender = { tab: { id: 42 } } as Browser.runtime.MessageSender
     expect(
       handleMessage(
         { action: WalletStandardMessageTypes.SIGN_TRANSACTION, id: 'sign-id' },
@@ -344,7 +345,7 @@ describe('handleMessage route policy', () => {
       id: 'disconnect-id',
       type: 'disconnect_success',
     })
-    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
+    expect(browser.tabs.sendMessage).toHaveBeenCalledWith(42, {
       id: 'disconnect-id',
       type: 'disconnect_success',
     })
@@ -372,7 +373,7 @@ describe('handleMessage route policy', () => {
         error: { message: 'revocation failed' },
       })
     })
-    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
+    expect(browser.tabs.sendMessage).toHaveBeenCalledWith(42, {
       id: 'disconnect-id',
       type: 'disconnect_error',
       error: { message: 'revocation failed' },
@@ -417,7 +418,7 @@ describe('handleMessage route policy', () => {
     })
   })
 
-  it('broadcasts change events to all tabs when sent by extension', () => {
+  it('broadcasts change events to all tabs when sent by extension', async () => {
     const sendResponse = vi.fn()
     const result = handleMessage(
       { event: 'change', payload: { accounts: ['0xabc'] } },
@@ -426,16 +427,18 @@ describe('handleMessage route policy', () => {
     )
 
     expect(result).toBe(true)
-    expect(chrome.tabs.query).toHaveBeenCalled()
-    // tabs.query callback runs synchronously in the mock, so sendMessage is already called
-    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(
-      1,
-      expect.objectContaining({
-        event: 'change',
-        payload: { accounts: ['0xabc'] },
-      }),
-    )
-    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(
+    expect(browser.tabs.query).toHaveBeenCalled()
+    // browser.tabs.query resolves as a promise, so sendMessage fires on a microtask.
+    await vi.waitFor(() => {
+      expect(browser.tabs.sendMessage).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({
+          event: 'change',
+          payload: { accounts: ['0xabc'] },
+        }),
+      )
+    })
+    expect(browser.tabs.sendMessage).toHaveBeenCalledWith(
       2,
       expect.objectContaining({ event: 'change' }),
     )

--- a/apps/extension/src/lib/background/handlers/__tests__/vaultHandlers.localnet.test.ts
+++ b/apps/extension/src/lib/background/handlers/__tests__/vaultHandlers.localnet.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Browser } from 'wxt/browser'
 import { handleUnlockVault } from '@/lib/background/handlers/vaultHandlers'
 import type { VaultMessage } from '@/lib/background/types'
 import { captureKeeperMessage } from './vaultHandlers.test-utils'
@@ -14,7 +15,7 @@ vi.mock('@/lib/background/services/offscreenService', () => ({
 const DEVICE_KEY = 'evevault:device'
 const HASHED_SECRET_KEY = { iv: 'iv', data: 'data', salt: 'salt' }
 
-const mockSender = {} as chrome.runtime.MessageSender
+const mockSender = {} as Browser.runtime.MessageSender
 
 function makeUnlockMessage(
   overrides: Partial<VaultMessage> = {},
@@ -46,7 +47,7 @@ function stubKeeperBridge(
           version: 0,
         })
       : undefined
-  vi.stubGlobal('chrome', {
+  vi.stubGlobal('browser', {
     storage: {
       local: {
         get: vi
@@ -59,12 +60,10 @@ function stubKeeperBridge(
       },
     },
     runtime: {
-      sendMessage: vi.fn((_msg, callback) => {
-        callback(keeperResponse)
-      }),
+      sendMessage: vi.fn(() => Promise.resolve(keeperResponse)),
       lastError: undefined,
     },
-  } as unknown as typeof chrome)
+  } as unknown as typeof browser)
 }
 
 describe('handleUnlockVault — localnet key forwarding', () => {
@@ -124,7 +123,7 @@ describe('handleUnlockVault — localnet key forwarding', () => {
       sendResponse,
     )
 
-    expect(chrome.runtime.sendMessage).not.toHaveBeenCalled()
+    expect(browser.runtime.sendMessage).not.toHaveBeenCalled()
     expect(sendResponse).toHaveBeenCalledWith(
       expect.objectContaining({ ok: false }),
     )

--- a/apps/extension/src/lib/background/handlers/__tests__/vaultHandlers.test-utils.ts
+++ b/apps/extension/src/lib/background/handlers/__tests__/vaultHandlers.test-utils.ts
@@ -1,7 +1,7 @@
 import type { vi } from 'vitest'
 
 export function captureKeeperMessage(): Record<string, unknown> | undefined {
-  const calls = (chrome.runtime.sendMessage as ReturnType<typeof vi.fn>).mock
+  const calls = (browser.runtime.sendMessage as ReturnType<typeof vi.fn>).mock
     .calls
   return calls[0]?.[0] as Record<string, unknown> | undefined
 }

--- a/apps/extension/src/lib/background/handlers/__tests__/vaultHandlers.test.ts
+++ b/apps/extension/src/lib/background/handlers/__tests__/vaultHandlers.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Browser } from 'wxt/browser'
 import {
   _handleClearZkProof,
   _handleCreateKeypair,
@@ -21,14 +22,14 @@ vi.mock('@/lib/background/services/offscreenService', () => ({
   ensureOffscreen: vi.fn().mockResolvedValue(undefined),
 }))
 
-const mockSender = {} as chrome.runtime.MessageSender
+const mockSender = {} as Browser.runtime.MessageSender
 
 function makeMessage(overrides: Partial<VaultMessage> = {}): VaultMessage {
   return { type: 'VAULT_MSG', ...overrides } as unknown as VaultMessage
 }
 
 function stubKeeperBridge(keeperResponse: unknown = { ok: true }) {
-  globalThis.chrome = {
+  vi.stubGlobal('browser', {
     storage: {
       local: {
         get: vi.fn().mockResolvedValue({}),
@@ -37,12 +38,10 @@ function stubKeeperBridge(keeperResponse: unknown = { ok: true }) {
       },
     },
     runtime: {
-      sendMessage: vi.fn((_msg, callback) => {
-        callback(keeperResponse)
-      }),
+      sendMessage: vi.fn(() => Promise.resolve(keeperResponse)),
       lastError: undefined,
     },
-  } as unknown as typeof chrome
+  } as unknown as typeof browser)
 }
 
 describe('handleLock', () => {

--- a/apps/extension/src/lib/background/handlers/__tests__/walletHandlers.test.ts
+++ b/apps/extension/src/lib/background/handlers/__tests__/walletHandlers.test.ts
@@ -1,5 +1,6 @@
 import { WalletStandardMessageTypes } from '@evevault/shared'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Browser } from 'wxt/browser'
 import { handleApprovePopup } from '@/lib/background/handlers/walletHandlers'
 import type { WalletActionMessage } from '@/lib/background/types'
 
@@ -8,7 +9,7 @@ import type { WalletActionMessage } from '@/lib/background/types'
 const TEST_REQUEST_ID = '11111111-1111-1111-1111-111111111111'
 
 type StorageListener = (changes: {
-  [key: string]: chrome.storage.StorageChange
+  [key: string]: Browser.storage.StorageChange
 }) => void
 
 // windowId 99 (from mockOpenPopupWindow) + the minted requestId are bind a
@@ -50,11 +51,11 @@ vi.mock('@evevault/shared/utils', async (importOriginal) => {
   }
 })
 
-function installChromeMock(
+function installBrowserMock(
   storageListeners: StorageListener[],
-  sendMessageImpl?: typeof chrome.tabs.sendMessage,
+  sendMessageImpl?: typeof browser.tabs.sendMessage,
 ) {
-  globalThis.chrome = {
+  vi.stubGlobal('browser', {
     storage: {
       local: {
         set: vi.fn(() => Promise.resolve()),
@@ -70,7 +71,7 @@ function installChromeMock(
     tabs: {
       sendMessage: sendMessageImpl ?? vi.fn(() => Promise.resolve()),
     },
-  } as unknown as typeof chrome
+  } as unknown as typeof browser)
 }
 
 describe('handleApprovePopup', () => {
@@ -84,7 +85,7 @@ describe('handleApprovePopup', () => {
       context: { origin: 'https://example.test' },
     })
     vi.spyOn(crypto, 'randomUUID').mockReturnValue(TEST_REQUEST_ID)
-    installChromeMock(storageListeners)
+    installBrowserMock(storageListeners)
   })
 
   afterEach(() => {
@@ -100,7 +101,7 @@ describe('handleApprovePopup', () => {
   ) {
     await handleApprovePopup(
       message,
-      sender as chrome.runtime.MessageSender,
+      sender as Browser.runtime.MessageSender,
       vi.fn(),
     )
     const wrapped = storageListeners[storageListeners.length - 1]
@@ -123,13 +124,13 @@ describe('handleApprovePopup', () => {
           id: 'req-denied',
           action: WalletStandardMessageTypes.SIGN_TRANSACTION,
         },
-        { tab: { id: 42 } } as chrome.runtime.MessageSender,
+        { tab: { id: 42 } } as Browser.runtime.MessageSender,
         sendResponse,
       )
 
       expect(result).toBe(false)
       expect(mockOpenPopupWindow).not.toHaveBeenCalled()
-      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
+      expect(browser.tabs.sendMessage).toHaveBeenCalledWith(42, {
         type: 'sign_transaction_error',
         error: 'Connect this site to EVE Vault before requesting a signature.',
         id: 'req-denied',
@@ -149,7 +150,7 @@ describe('handleApprovePopup', () => {
 
       const result = await handleApprovePopup(
         { action: WalletStandardMessageTypes.SIGN_TRANSACTION },
-        { tab: { id: 1 } } as chrome.runtime.MessageSender,
+        { tab: { id: 1 } } as Browser.runtime.MessageSender,
         sendResponse,
       )
 
@@ -167,7 +168,7 @@ describe('handleApprovePopup', () => {
 
       const result = await handleApprovePopup(
         { action: WalletStandardMessageTypes.SIGN_TRANSACTION },
-        { tab: { id: 1 } } as chrome.runtime.MessageSender,
+        { tab: { id: 1 } } as Browser.runtime.MessageSender,
         sendResponse,
       )
 
@@ -184,7 +185,7 @@ describe('handleApprovePopup', () => {
 
       await handleApprovePopup(
         { action: WalletStandardMessageTypes.SIGN_TRANSACTION },
-        { tab: { id: 1 } } as chrome.runtime.MessageSender,
+        { tab: { id: 1 } } as Browser.runtime.MessageSender,
         sendResponse,
       )
 
@@ -212,13 +213,13 @@ describe('handleApprovePopup', () => {
         signature: 'sig-bytes',
       })
 
-      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
+      expect(browser.tabs.sendMessage).toHaveBeenCalledWith(42, {
         type: 'sign_success',
         bytes: new Uint8Array([1, 2]),
         signature: 'sig-bytes',
         id: 's1',
       })
-      expect(chrome.storage.local.remove).toHaveBeenCalledWith([
+      expect(browser.storage.local.remove).toHaveBeenCalledWith([
         'pendingAction',
         'transactionResult',
       ])
@@ -241,7 +242,7 @@ describe('handleApprovePopup', () => {
         effects: 'fx',
       })
 
-      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(7, {
+      expect(browser.tabs.sendMessage).toHaveBeenCalledWith(7, {
         type: 'sign_and_execute_transaction_success',
         result: {
           bytes: new Uint8Array([9]),
@@ -268,7 +269,7 @@ describe('handleApprovePopup', () => {
         signature: 'sig',
       })
 
-      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(7, {
+      expect(browser.tabs.sendMessage).toHaveBeenCalledWith(7, {
         type: 'sign_and_execute_transaction_error',
         error: 'Missing required fields in sign_and_execute transaction result',
         id: 's3',
@@ -277,7 +278,7 @@ describe('handleApprovePopup', () => {
 
     it('logs when tabs.sendMessage rejects on sign_success', async () => {
       const sendMessage = vi.fn(() => Promise.reject(new Error('tab gone')))
-      installChromeMock(storageListeners, sendMessage)
+      installBrowserMock(storageListeners, sendMessage)
       mockOpenPopupWindow.mockResolvedValue(99)
 
       const wrapped = await getWrappedListener(
@@ -304,7 +305,7 @@ describe('handleApprovePopup', () => {
 
     it('logs when tabs.sendMessage rejects for incomplete sign-and-execute result', async () => {
       const sendMessage = vi.fn(() => Promise.reject(new Error('tab gone')))
-      installChromeMock(storageListeners, sendMessage)
+      installBrowserMock(storageListeners, sendMessage)
       mockOpenPopupWindow.mockResolvedValue(99)
 
       const wrapped = await getWrappedListener(
@@ -331,7 +332,7 @@ describe('handleApprovePopup', () => {
 
     it('logs when tabs.sendMessage rejects for sign-and-execute success', async () => {
       const sendMessage = vi.fn(() => Promise.reject(new Error('tab gone')))
-      installChromeMock(storageListeners, sendMessage)
+      installBrowserMock(storageListeners, sendMessage)
       mockOpenPopupWindow.mockResolvedValue(99)
 
       const wrapped = await getWrappedListener(
@@ -375,7 +376,7 @@ describe('handleApprovePopup', () => {
         action: WalletStandardMessageTypes.SIGN_TRANSACTION,
       })
 
-      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
+      expect(browser.tabs.sendMessage).toHaveBeenCalledWith(42, {
         type: 'sign_transaction_error',
         error: 'User said no',
         id: 'req-1',
@@ -400,7 +401,7 @@ describe('handleApprovePopup', () => {
 
       fireResult(wrapped, { status: 'error', error: 'User said no' })
 
-      expect(chrome.storage.onChanged.removeListener).toHaveBeenCalledWith(
+      expect(browser.storage.onChanged.removeListener).toHaveBeenCalledWith(
         registered,
       )
     })
@@ -411,7 +412,7 @@ describe('handleApprovePopup', () => {
         action: WalletStandardMessageTypes.SIGN_PERSONAL_MESSAGE,
       })
 
-      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
+      expect(browser.tabs.sendMessage).toHaveBeenCalledWith(42, {
         type: 'sign_personal_message_error',
         error: 'User said no',
         id: 'req-2',
@@ -429,7 +430,7 @@ describe('handleApprovePopup', () => {
         { message: 'approval object failure' },
       )
 
-      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
+      expect(browser.tabs.sendMessage).toHaveBeenCalledWith(42, {
         type: 'sign_personal_message_error',
         error: 'approval object failure',
         id: 'req-structured-error',
@@ -442,7 +443,7 @@ describe('handleApprovePopup', () => {
         action: 'unknown_wallet_action_for_test',
       })
 
-      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
+      expect(browser.tabs.sendMessage).toHaveBeenCalledWith(42, {
         type: 'sign_error',
         error: 'User said no',
         id: 'req-3',
@@ -458,7 +459,7 @@ describe('handleApprovePopup', () => {
         action: WalletStandardMessageTypes.SIGN_AND_EXECUTE_TRANSACTION,
       })
 
-      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
+      expect(browser.tabs.sendMessage).toHaveBeenCalledWith(42, {
         type: 'sign_and_execute_transaction_error',
         error: 'User said no',
         id: 'req-4',
@@ -475,7 +476,7 @@ describe('handleApprovePopup', () => {
         {},
       )
 
-      expect(chrome.tabs.sendMessage).not.toHaveBeenCalled()
+      expect(browser.tabs.sendMessage).not.toHaveBeenCalled()
     })
 
     it('does not call tabs.sendMessage when sender has no tab id (sign-and-execute error)', async () => {
@@ -487,12 +488,12 @@ describe('handleApprovePopup', () => {
         {},
       )
 
-      expect(chrome.tabs.sendMessage).not.toHaveBeenCalled()
+      expect(browser.tabs.sendMessage).not.toHaveBeenCalled()
     })
 
     it('logs when tabs.sendMessage rejects for mapped error type', async () => {
       const sendMessage = vi.fn(() => Promise.reject(new Error('tab gone')))
-      installChromeMock(storageListeners, sendMessage)
+      installBrowserMock(storageListeners, sendMessage)
       mockOpenPopupWindow.mockResolvedValue(99)
 
       await fireTransactionError({
@@ -510,7 +511,7 @@ describe('handleApprovePopup', () => {
 
     it('logs when tabs.sendMessage rejects for sign-and-execute error result', async () => {
       const sendMessage = vi.fn(() => Promise.reject(new Error('tab gone')))
-      installChromeMock(storageListeners, sendMessage)
+      installBrowserMock(storageListeners, sendMessage)
       mockOpenPopupWindow.mockResolvedValue(99)
 
       await fireTransactionError({
@@ -536,8 +537,8 @@ describe('handleApprovePopup', () => {
 
       wrapped({})
 
-      expect(chrome.tabs.sendMessage).not.toHaveBeenCalled()
-      expect(chrome.storage.local.remove).not.toHaveBeenCalled()
+      expect(browser.tabs.sendMessage).not.toHaveBeenCalled()
+      expect(browser.storage.local.remove).not.toHaveBeenCalled()
     })
 
     it('ignores transactionResult for a different popup window', async () => {
@@ -556,9 +557,9 @@ describe('handleApprovePopup', () => {
         signature: 'sig',
       })
 
-      expect(chrome.tabs.sendMessage).not.toHaveBeenCalled()
-      expect(chrome.storage.local.remove).not.toHaveBeenCalled()
-      expect(chrome.storage.onChanged.removeListener).not.toHaveBeenCalled()
+      expect(browser.tabs.sendMessage).not.toHaveBeenCalled()
+      expect(browser.storage.local.remove).not.toHaveBeenCalled()
+      expect(browser.storage.onChanged.removeListener).not.toHaveBeenCalled()
     })
 
     it('ignores a result whose requestId does not match the request', async () => {
@@ -577,9 +578,9 @@ describe('handleApprovePopup', () => {
         signature: 'sig',
       })
 
-      expect(chrome.tabs.sendMessage).not.toHaveBeenCalled()
-      expect(chrome.storage.local.remove).not.toHaveBeenCalled()
-      expect(chrome.storage.onChanged.removeListener).not.toHaveBeenCalled()
+      expect(browser.tabs.sendMessage).not.toHaveBeenCalled()
+      expect(browser.storage.local.remove).not.toHaveBeenCalled()
+      expect(browser.storage.onChanged.removeListener).not.toHaveBeenCalled()
     })
 
     it('does nothing on success when sender has no tab id', async () => {
@@ -594,8 +595,8 @@ describe('handleApprovePopup', () => {
         signature: 'sig',
       })
 
-      expect(chrome.tabs.sendMessage).not.toHaveBeenCalled()
-      expect(chrome.storage.local.remove).not.toHaveBeenCalled()
+      expect(browser.tabs.sendMessage).not.toHaveBeenCalled()
+      expect(browser.storage.local.remove).not.toHaveBeenCalled()
     })
   })
 
@@ -607,7 +608,7 @@ describe('handleApprovePopup', () => {
         {
           action: WalletStandardMessageTypes.SIGN_TRANSACTION,
         },
-        { tab: { id: 5 } } as chrome.runtime.MessageSender,
+        { tab: { id: 5 } } as Browser.runtime.MessageSender,
         vi.fn(),
       )
 
@@ -620,7 +621,7 @@ describe('handleApprovePopup', () => {
           senderTabId: 5,
         },
       )
-      expect(chrome.storage.local.remove).toHaveBeenCalledWith([
+      expect(browser.storage.local.remove).toHaveBeenCalledWith([
         'pendingAction',
         'transactionResult',
       ])

--- a/apps/extension/src/lib/background/handlers/auth/__tests__/authHelpers.test.ts
+++ b/apps/extension/src/lib/background/handlers/auth/__tests__/authHelpers.test.ts
@@ -33,7 +33,7 @@ vi.mock('jose', () => ({
 function installBrowserMock() {
   vi.stubGlobal('browser', {
     runtime: {
-      sendMessage: vi.fn(),
+      sendMessage: vi.fn().mockResolvedValue(undefined),
     },
     storage: {
       local: {
@@ -41,7 +41,7 @@ function installBrowserMock() {
       },
     },
     tabs: {
-      sendMessage: vi.fn(),
+      sendMessage: vi.fn().mockResolvedValue(undefined),
     },
   } as unknown as typeof browser)
 }

--- a/apps/extension/src/lib/background/handlers/auth/__tests__/authHelpers.test.ts
+++ b/apps/extension/src/lib/background/handlers/auth/__tests__/authHelpers.test.ts
@@ -30,24 +30,24 @@ vi.mock('jose', () => ({
   decodeJwt: mockDecodeJwt,
 }))
 
-function installChromeMock() {
-  vi.stubGlobal('chrome', {
+function installBrowserMock() {
+  vi.stubGlobal('browser', {
     runtime: {
       sendMessage: vi.fn(),
     },
     storage: {
       local: {
-        get: vi.fn(),
+        get: vi.fn(() => Promise.resolve({})),
       },
     },
     tabs: {
       sendMessage: vi.fn(),
     },
-  } as unknown as typeof chrome)
+  } as unknown as typeof browser)
 }
 
 beforeEach(() => {
-  installChromeMock()
+  installBrowserMock()
   vi.clearAllMocks()
   mockDecodeJwt.mockReturnValue({
     email: 'user@example.com',
@@ -151,10 +151,8 @@ describe('buildExtensionAuthSuccessToken', () => {
 describe('getCurrentChainFromStorage', () => {
   it('resolves chain from stored JSON string', async () => {
     const stored = JSON.stringify({ state: { chain: 'sui:mainnet' } })
-    ;(chrome.storage.local.get as ReturnType<typeof vi.fn>).mockImplementation(
-      (_keys: unknown, callback: (result: Record<string, unknown>) => void) => {
-        callback({ [CONTEXT_STORAGE_KEY]: stored })
-      },
+    ;(browser.storage.local.get as ReturnType<typeof vi.fn>).mockImplementation(
+      () => Promise.resolve({ [CONTEXT_STORAGE_KEY]: stored }),
     )
 
     const chain = await getCurrentChainFromStorage()
@@ -163,10 +161,8 @@ describe('getCurrentChainFromStorage', () => {
 
   it('resolves chain from stored object (already parsed)', async () => {
     const stored = { state: { chain: 'sui:devnet' } }
-    ;(chrome.storage.local.get as ReturnType<typeof vi.fn>).mockImplementation(
-      (_keys: unknown, callback: (result: Record<string, unknown>) => void) => {
-        callback({ [CONTEXT_STORAGE_KEY]: stored })
-      },
+    ;(browser.storage.local.get as ReturnType<typeof vi.fn>).mockImplementation(
+      () => Promise.resolve({ [CONTEXT_STORAGE_KEY]: stored }),
     )
 
     const chain = await getCurrentChainFromStorage()
@@ -175,10 +171,8 @@ describe('getCurrentChainFromStorage', () => {
 
   it('falls back to Zustand when storage returns nothing', async () => {
     mockGetChain.mockReturnValue('sui:mainnet')
-    ;(chrome.storage.local.get as ReturnType<typeof vi.fn>).mockImplementation(
-      (_keys: unknown, callback: (result: Record<string, unknown>) => void) => {
-        callback({})
-      },
+    ;(browser.storage.local.get as ReturnType<typeof vi.fn>).mockImplementation(
+      () => Promise.resolve({}),
     )
 
     const chain = await getCurrentChainFromStorage()
@@ -187,10 +181,8 @@ describe('getCurrentChainFromStorage', () => {
 
   it('falls back to Zustand when stored value has no chain field', async () => {
     mockGetChain.mockReturnValue('sui:devnet')
-    ;(chrome.storage.local.get as ReturnType<typeof vi.fn>).mockImplementation(
-      (_keys: unknown, callback: (result: Record<string, unknown>) => void) => {
-        callback({ [CONTEXT_STORAGE_KEY]: { state: {} } })
-      },
+    ;(browser.storage.local.get as ReturnType<typeof vi.fn>).mockImplementation(
+      () => Promise.resolve({ [CONTEXT_STORAGE_KEY]: { state: {} } }),
     )
 
     const chain = await getCurrentChainFromStorage()
@@ -199,10 +191,8 @@ describe('getCurrentChainFromStorage', () => {
 
   it('falls back to Zustand when JSON.parse throws', async () => {
     mockGetChain.mockReturnValue('sui:localnet')
-    ;(chrome.storage.local.get as ReturnType<typeof vi.fn>).mockImplementation(
-      (_keys: unknown, callback: (result: Record<string, unknown>) => void) => {
-        callback({ [CONTEXT_STORAGE_KEY]: 'not-valid-json{{{' })
-      },
+    ;(browser.storage.local.get as ReturnType<typeof vi.fn>).mockImplementation(
+      () => Promise.resolve({ [CONTEXT_STORAGE_KEY]: 'not-valid-json{{{' }),
     )
 
     const chain = await getCurrentChainFromStorage()
@@ -211,7 +201,7 @@ describe('getCurrentChainFromStorage', () => {
 })
 
 describe('sendExtensionAuthSuccess', () => {
-  it('sends an AUTH_SUCCESS message via chrome.runtime.sendMessage', () => {
+  it('sends an AUTH_SUCCESS message via browser.runtime.sendMessage', () => {
     const jwt = {
       access_token: 'a',
       id_token: 'i',
@@ -226,7 +216,7 @@ describe('sendExtensionAuthSuccess', () => {
 
     sendExtensionAuthSuccess('msg-id', jwt)
 
-    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith(
+    expect(browser.runtime.sendMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         id: 'msg-id',
         type: 'auth_success',
@@ -247,9 +237,9 @@ describe('sendExtensionAuthSuccess', () => {
 })
 
 describe('sendAuthError', () => {
-  it('sends an auth_error message via chrome.runtime.sendMessage', () => {
+  it('sends an auth_error message via browser.runtime.sendMessage', () => {
     sendAuthError('err-id', { message: 'something went wrong' })
-    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({
+    expect(browser.runtime.sendMessage).toHaveBeenCalledWith({
       id: 'err-id',
       type: 'auth_error',
       error: { message: 'something went wrong' },

--- a/apps/extension/src/lib/background/handlers/auth/__tests__/dappLogin.test.ts
+++ b/apps/extension/src/lib/background/handlers/auth/__tests__/dappLogin.test.ts
@@ -1,5 +1,6 @@
 import { getJwt, getZkLoginAddress } from '@evevault/shared/auth'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Browser } from 'wxt/browser'
 import { handleDappLogin } from '../dappLogin'
 import { checkKeeperUnlocked } from '../keeperHelpers'
 
@@ -104,8 +105,8 @@ const mockGetJwt = vi.mocked(getJwt)
 const mockGetZkLoginAddress = vi.mocked(getZkLoginAddress)
 const mockCheckKeeperUnlocked = vi.mocked(checkKeeperUnlocked)
 
-function installChromeMock() {
-  vi.stubGlobal('chrome', {
+function installBrowserMock() {
+  vi.stubGlobal('browser', {
     tabs: {
       sendMessage: vi.fn(() => Promise.resolve()),
     },
@@ -122,12 +123,12 @@ function installChromeMock() {
         set: vi.fn(async () => undefined),
       },
     },
-  } as unknown as typeof chrome)
+  } as unknown as typeof browser)
 }
 
 describe('handleDappLogin', () => {
   beforeEach(() => {
-    installChromeMock()
+    installBrowserMock()
     vi.clearAllMocks()
     mocks.deviceState.ephemeralKeyPairSecretKey = { iv: 'iv', data: 'data' }
     mocks.deviceState.ephemeralPublicKey = { flag: vi.fn() }
@@ -163,7 +164,7 @@ describe('handleDappLogin', () => {
           url: 'https://dapp.example/connect',
           title: 'Example dApp',
         },
-      } as chrome.runtime.MessageSender,
+      } as Browser.runtime.MessageSender,
       vi.fn(),
       42,
     )
@@ -171,14 +172,14 @@ describe('handleDappLogin', () => {
     expect(mockGetZkLoginAddress).toHaveBeenCalledWith({
       jwt: 'access-token',
     })
-    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
+    expect(browser.tabs.sendMessage).toHaveBeenCalledWith(42, {
       id: 'connect-id',
       type: 'auth_success',
       chain: 'sui:testnet',
       address: '0xzk',
       publicKey: 'AQID',
     })
-    expect(chrome.tabs.sendMessage).not.toHaveBeenCalledWith(
+    expect(browser.tabs.sendMessage).not.toHaveBeenCalledWith(
       42,
       expect.objectContaining({
         token: expect.anything(),
@@ -191,12 +192,12 @@ describe('handleDappLogin', () => {
       { id: 'ext-req' },
       {
         origin: 'chrome-extension://extension-id',
-      } as chrome.runtime.MessageSender,
+      } as Browser.runtime.MessageSender,
       vi.fn(),
       undefined,
     )
 
-    expect(chrome.tabs.sendMessage).not.toHaveBeenCalled()
+    expect(browser.tabs.sendMessage).not.toHaveBeenCalled()
   })
 
   it('sends auth_error to the tab when the keeper is locked and there is no device data', async () => {
@@ -209,12 +210,12 @@ describe('handleDappLogin', () => {
       {
         origin: 'https://dapp.example',
         tab: { id: 10, url: 'https://dapp.example/' },
-      } as chrome.runtime.MessageSender,
+      } as Browser.runtime.MessageSender,
       vi.fn(),
       10,
     )
 
-    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(
+    expect(browser.tabs.sendMessage).toHaveBeenCalledWith(
       10,
       expect.objectContaining({
         id: 'locked-req',
@@ -238,14 +239,14 @@ describe('handleDappLogin', () => {
       {
         origin: 'https://dapp.example',
         tab: { id: 20, url: 'https://dapp.example/' },
-      } as chrome.runtime.MessageSender,
+      } as Browser.runtime.MessageSender,
       vi.fn(),
       20,
     )
 
     expect(mocks.addPendingDappId).toHaveBeenCalledWith(20, 'dup-req')
     expect(mocks.openPopupWindow).not.toHaveBeenCalled()
-    expect(chrome.tabs.sendMessage).not.toHaveBeenCalled()
+    expect(browser.tabs.sendMessage).not.toHaveBeenCalled()
   })
 
   it('sends auth_error when the popup window fails to open (no device data)', async () => {
@@ -258,12 +259,12 @@ describe('handleDappLogin', () => {
       {
         origin: 'https://dapp.example',
         tab: { id: 7, url: 'https://dapp.example/' },
-      } as chrome.runtime.MessageSender,
+      } as Browser.runtime.MessageSender,
       vi.fn(),
       7,
     )
 
-    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(
+    expect(browser.tabs.sendMessage).toHaveBeenCalledWith(
       7,
       expect.objectContaining({
         type: 'auth_error',
@@ -286,14 +287,14 @@ describe('handleDappLogin', () => {
       {
         origin: 'https://dapp.example',
         tab: { id: 42, url: 'https://dapp.example/' },
-      } as chrome.runtime.MessageSender,
+      } as Browser.runtime.MessageSender,
       vi.fn(),
       42,
     )
 
     expect(mockCheckKeeperUnlocked).toHaveBeenCalledTimes(2)
     expect(mocks.openPopupWindow).not.toHaveBeenCalled()
-    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(
+    expect(browser.tabs.sendMessage).toHaveBeenCalledWith(
       42,
       expect.objectContaining({ type: 'auth_success' }),
     )
@@ -309,12 +310,12 @@ describe('handleDappLogin', () => {
       {
         origin: 'https://dapp.example',
         tab: { id: 42, url: 'https://dapp.example/' },
-      } as chrome.runtime.MessageSender,
+      } as Browser.runtime.MessageSender,
       vi.fn(),
       42,
     )
 
-    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(
+    expect(browser.tabs.sendMessage).toHaveBeenCalledWith(
       42,
       expect.objectContaining({
         id: 'zk-fail',
@@ -338,12 +339,12 @@ describe('handleDappLogin', () => {
       {
         origin: 'https://dapp.example',
         tab: { id: 42, url: 'https://dapp.example/' },
-      } as chrome.runtime.MessageSender,
+      } as Browser.runtime.MessageSender,
       vi.fn(),
       42,
     )
 
-    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(
+    expect(browser.tabs.sendMessage).toHaveBeenCalledWith(
       42,
       expect.objectContaining({
         type: 'auth_error',

--- a/apps/extension/src/lib/background/handlers/auth/__tests__/extLogin.test.ts
+++ b/apps/extension/src/lib/background/handlers/auth/__tests__/extLogin.test.ts
@@ -2,6 +2,7 @@ import { storeJwt } from '@evevault/shared'
 import { exchangeCodeForToken } from '@evevault/shared/auth'
 import { useDeviceStore } from '@evevault/shared/stores'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Browser } from 'wxt/browser'
 import { getAuthRequest } from '@/lib/background/services/oauthService'
 import { openPopupWindow } from '@/lib/background/services/popupWindow'
 import type { MessageWithId } from '@/lib/background/types'
@@ -121,15 +122,15 @@ const mockCheckKeeperUnlocked = vi.mocked(checkKeeperUnlocked)
 const mockSetPendingAuthAfterUnlock = vi.mocked(setPendingAuthAfterUnlock)
 
 function installChromeIdentityMock(responseUrl: string | undefined) {
-  vi.stubGlobal('chrome', {
+  vi.stubGlobal('browser', {
     runtime: {
       lastError: undefined,
     },
     identity: {
       getRedirectURL: vi.fn(() => 'https://extension.example/callback'),
-      launchWebAuthFlow: vi.fn((_details, callback) => callback(responseUrl)),
+      launchWebAuthFlow: vi.fn(() => Promise.resolve(responseUrl)),
     },
-  } as unknown as typeof chrome)
+  } as unknown as typeof browser)
 }
 
 function resetDeviceState() {
@@ -180,7 +181,7 @@ describe('handleExtLogin', () => {
 
     await handleExtLogin(
       makeMessage(),
-      {} as chrome.runtime.MessageSender,
+      {} as Browser.runtime.MessageSender,
       vi.fn(),
     )
 
@@ -206,7 +207,7 @@ describe('handleExtLogin', () => {
 
     const promise = handleExtLogin(
       makeMessage(),
-      {} as chrome.runtime.MessageSender,
+      {} as Browser.runtime.MessageSender,
       vi.fn(),
     )
     await vi.advanceTimersByTimeAsync(301)
@@ -229,7 +230,7 @@ describe('handleExtLogin', () => {
 
     await handleExtLogin(
       makeMessage(),
-      {} as chrome.runtime.MessageSender,
+      {} as Browser.runtime.MessageSender,
       vi.fn(),
     )
 
@@ -255,7 +256,7 @@ describe('handleExtLogin', () => {
 
     await handleExtLogin(
       makeMessage(),
-      {} as chrome.runtime.MessageSender,
+      {} as Browser.runtime.MessageSender,
       vi.fn(),
     )
 
@@ -288,7 +289,7 @@ describe('handleExtLogin', () => {
 
     await handleExtLogin(
       makeMessage(),
-      {} as chrome.runtime.MessageSender,
+      {} as Browser.runtime.MessageSender,
       vi.fn(),
     )
 
@@ -307,7 +308,7 @@ describe('handleExtLogin', () => {
 
     await handleExtLogin(
       makeMessage({ tenantId: 'tenant-explicit' }),
-      {} as chrome.runtime.MessageSender,
+      {} as Browser.runtime.MessageSender,
       vi.fn(),
     )
 
@@ -341,7 +342,7 @@ describe('handleExtLogin', () => {
 
     await handleExtLogin(
       makeMessage(),
-      {} as chrome.runtime.MessageSender,
+      {} as Browser.runtime.MessageSender,
       vi.fn(),
     )
 
@@ -364,7 +365,7 @@ describe('handleExtLogin', () => {
 
     await handleExtLogin(
       makeMessage(),
-      {} as chrome.runtime.MessageSender,
+      {} as Browser.runtime.MessageSender,
       vi.fn(),
     )
 
@@ -378,28 +379,26 @@ describe('handleExtLogin', () => {
     expect(mockSendExtensionAuthSuccess).not.toHaveBeenCalled()
   })
 
-  it('sends auth error when chrome.runtime.lastError is set', async () => {
+  it('sends auth error when launchWebAuthFlow rejects', async () => {
     mocks.deviceState.ephemeralPublicKey = { existing: true }
     mocks.deviceState.networkData = { 'sui:testnet': { nonce: 'nonce-value' } }
-    const lastError = { message: 'User cancelled' }
-    vi.stubGlobal('chrome', {
-      runtime: { lastError },
+    const rejection = { message: 'User cancelled' }
+    vi.stubGlobal('browser', {
+      runtime: {},
       identity: {
         getRedirectURL: vi.fn(() => 'https://extension.example/callback'),
-        launchWebAuthFlow: vi.fn((_details, callback) =>
-          callback('https://extension.example/callback?code=abc'),
-        ),
+        launchWebAuthFlow: vi.fn(() => Promise.reject(rejection)),
       },
-    } as unknown as typeof chrome)
+    } as unknown as typeof browser)
 
     await handleExtLogin(
       makeMessage(),
-      {} as chrome.runtime.MessageSender,
+      {} as Browser.runtime.MessageSender,
       vi.fn(),
     )
 
     await vi.waitFor(() => {
-      expect(mockSendAuthError).toHaveBeenCalledWith('message-id', lastError)
+      expect(mockSendAuthError).toHaveBeenCalledWith('message-id', rejection)
     })
   })
 
@@ -410,7 +409,7 @@ describe('handleExtLogin', () => {
 
     await handleExtLogin(
       makeMessage(),
-      {} as chrome.runtime.MessageSender,
+      {} as Browser.runtime.MessageSender,
       vi.fn(),
     )
 
@@ -428,7 +427,7 @@ describe('handleExtLogin', () => {
 
     await handleExtLogin(
       makeMessage(),
-      {} as chrome.runtime.MessageSender,
+      {} as Browser.runtime.MessageSender,
       vi.fn(),
     )
 
@@ -447,7 +446,7 @@ describe('handleExtLogin', () => {
 
     await handleExtLogin(
       makeMessage(),
-      {} as chrome.runtime.MessageSender,
+      {} as Browser.runtime.MessageSender,
       vi.fn(),
     )
 
@@ -469,7 +468,7 @@ describe('handleExtLogin', () => {
 
     await handleExtLogin(
       makeMessage(),
-      {} as chrome.runtime.MessageSender,
+      {} as Browser.runtime.MessageSender,
       vi.fn(),
     )
 
@@ -488,7 +487,7 @@ describe('handleExtLogin', () => {
 
     await handleExtLogin(
       makeMessage(),
-      {} as chrome.runtime.MessageSender,
+      {} as Browser.runtime.MessageSender,
       vi.fn(),
     )
 

--- a/apps/extension/src/lib/background/handlers/auth/__tests__/webUnlock.test.ts
+++ b/apps/extension/src/lib/background/handlers/auth/__tests__/webUnlock.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Browser } from 'wxt/browser'
 import type { WebUnlockMessage } from '@/lib/background/types'
 import { handleWebUnlock } from '../webUnlock'
 
@@ -63,7 +64,7 @@ describe('handleWebUnlock', () => {
     mockEnsureMessageId.mockReturnValueOnce('ensured-id')
     await handleWebUnlock(
       makeMessage({ id: 'original-id' }),
-      {} as chrome.runtime.MessageSender,
+      {} as Browser.runtime.MessageSender,
       vi.fn(),
     )
 
@@ -77,7 +78,7 @@ describe('handleWebUnlock', () => {
   it('stores the JWT without sending to tab when tabId is absent', async () => {
     await handleWebUnlock(
       makeMessage({ tabId: undefined }),
-      {} as chrome.runtime.MessageSender,
+      {} as Browser.runtime.MessageSender,
       vi.fn(),
     )
 
@@ -91,7 +92,7 @@ describe('handleWebUnlock', () => {
 
     await handleWebUnlock(
       makeMessage({ id: 'original-id' }),
-      {} as chrome.runtime.MessageSender,
+      {} as Browser.runtime.MessageSender,
       vi.fn(),
     )
 
@@ -107,7 +108,7 @@ describe('handleWebUnlock', () => {
 
     await handleWebUnlock(
       makeMessage({ tabId: undefined }),
-      {} as chrome.runtime.MessageSender,
+      {} as Browser.runtime.MessageSender,
       vi.fn(),
     )
 
@@ -120,7 +121,7 @@ describe('handleWebUnlock', () => {
 
     await handleWebUnlock(
       makeMessage({ id: 'original-id' }),
-      {} as chrome.runtime.MessageSender,
+      {} as Browser.runtime.MessageSender,
       vi.fn(),
     )
 

--- a/apps/extension/src/lib/background/handlers/auth/authHelpers.ts
+++ b/apps/extension/src/lib/background/handlers/auth/authHelpers.ts
@@ -89,7 +89,9 @@ export function sendExtensionAuthSuccess(id: string, jwt: JwtResponse): void {
     type: AuthMessageTypes.AUTH_SUCCESS,
     token,
   }
-  browser.runtime.sendMessage(message)
+  // Fire-and-forget to the popup; browser.runtime.sendMessage rejects when no
+  // extension page is listening (e.g. popup closed), which is expected here.
+  void browser.runtime.sendMessage(message).catch(() => {})
 }
 
 export function sendDappConnectSuccessToTab(
@@ -116,11 +118,14 @@ export function sendDappConnectSuccessToTab(
 }
 
 export function sendAuthError(id: string, error: unknown): void {
-  browser.runtime.sendMessage({
-    id,
-    type: 'auth_error',
-    error,
-  })
+  // Fire-and-forget to the popup; ignore rejection when nothing is listening.
+  void browser.runtime
+    .sendMessage({
+      id,
+      type: 'auth_error',
+      error,
+    })
+    .catch(() => {})
 }
 
 export function extractEmailFromJwt(jwt: JwtResponse): string {

--- a/apps/extension/src/lib/background/handlers/auth/authHelpers.ts
+++ b/apps/extension/src/lib/background/handlers/auth/authHelpers.ts
@@ -10,6 +10,7 @@ import { CONTEXT_STORAGE_KEY, createLogger } from '@evevault/shared/utils'
 import type { SuiChain } from '@mysten/wallet-standard'
 import { decodeJwt } from 'jose'
 import type { IdTokenClaims } from 'oidc-client-ts'
+import { browser } from 'wxt/browser'
 import { sendToTab } from '@/lib/background/messaging/tabMessaging'
 import type { MessageWithId } from '@/lib/background/types'
 
@@ -51,31 +52,26 @@ export function getCurrentChain(): SuiChain {
  * state when storing JWTs during OAuth callbacks.
  */
 export async function getCurrentChainFromStorage(): Promise<SuiChain> {
-  return new Promise((resolve) => {
-    chrome.storage.local.get([CONTEXT_STORAGE_KEY], (result) => {
-      try {
-        const stored = result[CONTEXT_STORAGE_KEY]
-        if (stored) {
-          const parsed =
-            typeof stored === 'string' ? JSON.parse(stored) : stored
-          if (parsed?.state?.chain) {
-            log.debug('Read chain from storage', {
-              chain: parsed.state.chain,
-            })
-            resolve(parsed.state.chain)
-            return
-          }
-        }
-      } catch (error) {
-        log.error('Error reading chain from storage', error)
+  try {
+    const result = await browser.storage.local.get([CONTEXT_STORAGE_KEY])
+    const stored = result[CONTEXT_STORAGE_KEY]
+    if (stored) {
+      const parsed = typeof stored === 'string' ? JSON.parse(stored) : stored
+      if (parsed?.state?.chain) {
+        log.debug('Read chain from storage', {
+          chain: parsed.state.chain,
+        })
+        return parsed.state.chain
       }
-      const fallbackChain = getCurrentChain()
-      log.debug('Using fallback chain from Zustand', {
-        chain: fallbackChain,
-      })
-      resolve(fallbackChain)
-    })
+    }
+  } catch (error) {
+    log.error('Error reading chain from storage', error)
+  }
+  const fallbackChain = getCurrentChain()
+  log.debug('Using fallback chain from Zustand', {
+    chain: fallbackChain,
   })
+  return fallbackChain
 }
 
 export function extractAuthCode(responseUrl: string): string | null {
@@ -93,7 +89,7 @@ export function sendExtensionAuthSuccess(id: string, jwt: JwtResponse): void {
     type: AuthMessageTypes.AUTH_SUCCESS,
     token,
   }
-  chrome.runtime.sendMessage(message)
+  browser.runtime.sendMessage(message)
 }
 
 export function sendDappConnectSuccessToTab(
@@ -120,7 +116,7 @@ export function sendDappConnectSuccessToTab(
 }
 
 export function sendAuthError(id: string, error: unknown): void {
-  chrome.runtime.sendMessage({
+  browser.runtime.sendMessage({
     id,
     type: 'auth_error',
     error,

--- a/apps/extension/src/lib/background/handlers/auth/dappLogin.ts
+++ b/apps/extension/src/lib/background/handlers/auth/dappLogin.ts
@@ -13,6 +13,7 @@ import {
 } from '@evevault/shared/types'
 import { createLogger, toErrorMessage } from '@evevault/shared/utils'
 import { Ed25519PublicKey } from '@mysten/sui/keypairs/ed25519'
+import { type Browser, browser } from 'wxt/browser'
 import { sendToTab } from '@/lib/background/messaging/tabMessaging'
 import {
   getDappRequestContext,
@@ -403,11 +404,13 @@ async function ensureNonce(
   return nonce
 }
 
-// Processes the redirect URL from chrome.identity.launchWebAuthFlow: exchanges
+// Processes the redirect URL from browser.identity.launchWebAuthFlow: exchanges
 // the auth code for a JWT, stores it, and sends auth_success to the originating tab.
+// `error` carries a launchWebAuthFlow rejection (user-cancel, no redirect).
 async function handleOAuthCallback(
   responseUrl: string | undefined,
   ctx: OAuthCallbackContext,
+  error?: unknown,
 ): Promise<void> {
   const {
     id,
@@ -425,12 +428,12 @@ async function handleOAuthCallback(
   // the same, or the dApp's connect request hangs until it times out.
   const ids = [id, ...additionalIds]
 
-  if (chrome.runtime.lastError || !responseUrl) {
-    log.error('Auth flow returned no response', chrome.runtime.lastError)
+  if (!responseUrl) {
+    log.error('Auth flow returned no response', error)
     sendAuthErrorToTabIds(
       tabId,
       ids,
-      chrome.runtime.lastError?.message ??
+      (error instanceof Error ? error.message : undefined) ??
         'Sign-in did not complete. Please try again.',
     )
     return
@@ -483,7 +486,7 @@ async function handleOAuthCallback(
 
 export async function handleDappLogin(
   message: MessageWithId,
-  sender: chrome.runtime.MessageSender,
+  sender: Browser.runtime.MessageSender,
   _sendResponse: (response?: unknown) => void,
   tabId?: number,
 ): Promise<void> {
@@ -532,25 +535,25 @@ export async function handleDappLogin(
   const nonce = await ensureNonce(chain, id, tabId)
   if (!nonce) return
 
-  const chromeRedirectUri = chrome.identity.getRedirectURL()
+  const chromeRedirectUri = browser.identity.getRedirectURL()
   const { authUrl, codeVerifier, state } = await getAuthRequest({
     tenantId: tenant,
     nonce,
   })
-  chrome.identity.launchWebAuthFlow(
-    { url: authUrl.toString(), interactive: true },
-    (responseUrl) =>
-      handleOAuthCallback(responseUrl, {
-        id,
-        additionalIds,
-        chain,
-        chromeRedirectUri,
-        tenant,
-        codeVerifier,
-        state,
-        nonce,
-        tabId,
-        dappContext,
-      }),
-  )
+  const ctx: OAuthCallbackContext = {
+    id,
+    additionalIds,
+    chain,
+    chromeRedirectUri,
+    tenant,
+    codeVerifier,
+    state,
+    nonce,
+    tabId,
+    dappContext,
+  }
+  void browser.identity
+    .launchWebAuthFlow({ url: authUrl.toString(), interactive: true })
+    .then((responseUrl) => handleOAuthCallback(responseUrl, ctx))
+    .catch((error) => handleOAuthCallback(undefined, ctx, error))
 }

--- a/apps/extension/src/lib/background/handlers/auth/extLogin.ts
+++ b/apps/extension/src/lib/background/handlers/auth/extLogin.ts
@@ -7,6 +7,7 @@ import {
 } from '@evevault/shared/stores'
 import { createLogger } from '@evevault/shared/utils'
 import { Ed25519PublicKey } from '@mysten/sui/keypairs/ed25519'
+import { type Browser, browser } from 'wxt/browser'
 import { getAuthRequest } from '@/lib/background/services/oauthService'
 import { openPopupWindow } from '@/lib/background/services/popupWindow'
 import type { MessageWithId } from '@/lib/background/types'
@@ -43,7 +44,7 @@ const KEEPER_RETRY_DELAYS_MS = [
  */
 export async function handleExtLogin(
   message: MessageWithId,
-  _sender: chrome.runtime.MessageSender,
+  _sender: Browser.runtime.MessageSender,
   _sendResponse: (response?: unknown) => void,
 ): Promise<void> {
   const id = ensureMessageId(message)
@@ -280,11 +281,6 @@ async function handleOAuthResponse({
   currentChain: StoredChain
   tenantId: TenantId
 }) {
-  if (chrome.runtime.lastError) {
-    sendAuthError(id, chrome.runtime.lastError)
-    return
-  }
-
   if (!responseUrl) {
     sendAuthError(id, { message: 'No response URL received' })
     return
@@ -304,7 +300,7 @@ async function handleOAuthResponse({
 
     const jwtResponse = await exchangeCodeForToken(
       authCode,
-      chrome.identity.getRedirectURL(),
+      browser.identity.getRedirectURL(),
       tenantId,
       { codeVerifier, nonce },
     )
@@ -334,8 +330,8 @@ async function handleOAuthResponse({
 }
 
 /**
- * Starts Chrome's web auth flow and delegates async response handling without
- * returning a promise to the Chrome callback API.
+ * Starts the browser web auth flow and delegates async response handling.
+ * Rejections (user-cancel, no redirect) surface via sendAuthError.
  */
 function launchOAuthLogin({
   id,
@@ -354,9 +350,9 @@ function launchOAuthLogin({
   currentChain: StoredChain
   tenantId: TenantId
 }) {
-  chrome.identity.launchWebAuthFlow(
-    { url: authUrl.toString(), interactive: true },
-    (responseUrl) => {
+  browser.identity
+    .launchWebAuthFlow({ url: authUrl.toString(), interactive: true })
+    .then((responseUrl) => {
       void handleOAuthResponse({
         id,
         responseUrl,
@@ -366,6 +362,8 @@ function launchOAuthLogin({
         currentChain,
         tenantId,
       })
-    },
-  )
+    })
+    .catch((error) => {
+      sendAuthError(id, error)
+    })
 }

--- a/apps/extension/src/lib/background/handlers/auth/keeperHelpers.ts
+++ b/apps/extension/src/lib/background/handlers/auth/keeperHelpers.ts
@@ -5,6 +5,7 @@ import type {
 } from '@evevault/shared/types'
 import { KeeperMessageTypes } from '@evevault/shared/types'
 import { createLogger, DEVICE_STORAGE_KEY } from '@evevault/shared/utils'
+import { browser } from 'wxt/browser'
 import { ensureOffscreen } from '@/lib/background/services/offscreenService'
 
 const log = createLogger()
@@ -15,16 +16,13 @@ const log = createLogger()
  * hasn't rehydrated yet when setState is called.
  */
 export async function getEphemeralKeyPairSecretKeyFromStorage(): Promise<StoredSecretKey | null> {
-  if (typeof chrome === 'undefined' || !chrome.storage) {
+  if (!browser?.storage) {
     return null
   }
 
   try {
-    const stored = await new Promise<unknown>((resolve) => {
-      chrome.storage.local.get([DEVICE_STORAGE_KEY], (result) => {
-        resolve(result[DEVICE_STORAGE_KEY] || null)
-      })
-    })
+    const result = await browser.storage.local.get([DEVICE_STORAGE_KEY])
+    const stored = result[DEVICE_STORAGE_KEY] || null
 
     if (!stored) {
       return null
@@ -63,26 +61,17 @@ export async function checkKeeperUnlocked(): Promise<{
 }> {
   try {
     await ensureOffscreen(true)
-    return new Promise((resolve) => {
-      chrome.runtime.sendMessage(
-        { type: KeeperMessageTypes.GET_PUBLIC_KEY, target: 'KEEPER' },
-        (response) => {
-          if (chrome.runtime.lastError) {
-            log.error('Error checking keeper', chrome.runtime.lastError)
-            resolve({ unlocked: false })
-            return
-          }
-          if (response?.ok === true && response?.publicKeyBytes) {
-            resolve({
-              unlocked: true,
-              publicKeyBytes: response.publicKeyBytes,
-            })
-          } else {
-            resolve({ unlocked: false })
-          }
-        },
-      )
+    const response = await browser.runtime.sendMessage({
+      type: KeeperMessageTypes.GET_PUBLIC_KEY,
+      target: 'KEEPER',
     })
+    if (response?.ok === true && response?.publicKeyBytes) {
+      return {
+        unlocked: true,
+        publicKeyBytes: response.publicKeyBytes,
+      }
+    }
+    return { unlocked: false }
   } catch (error) {
     log.error('Failed to check keeper status', error)
     return { unlocked: false }

--- a/apps/extension/src/lib/background/handlers/auth/webUnlock.ts
+++ b/apps/extension/src/lib/background/handlers/auth/webUnlock.ts
@@ -1,5 +1,6 @@
 import { storeJwt } from '@evevault/shared'
 import { createLogger } from '@evevault/shared/utils'
+import type { Browser } from 'wxt/browser'
 import { sendToTab } from '@/lib/background/messaging/tabMessaging'
 import type { WebUnlockMessage } from '@/lib/background/types'
 import { ensureMessageId } from './authHelpers'
@@ -8,7 +9,7 @@ const log = createLogger()
 
 export async function handleWebUnlock(
   message: WebUnlockMessage,
-  _sender: chrome.runtime.MessageSender,
+  _sender: Browser.runtime.MessageSender,
   _sendResponse: (response?: unknown) => void,
 ): Promise<void> {
   log.info('Evefrontier web unlock request')

--- a/apps/extension/src/lib/background/handlers/authHandlers.ts
+++ b/apps/extension/src/lib/background/handlers/authHandlers.ts
@@ -1,4 +1,5 @@
 import { createLogger } from '@evevault/shared/utils'
+import { type Browser, browser } from 'wxt/browser'
 import type { MessageWithId } from '@/lib/background/types'
 import { handleDappLogin } from './auth/dappLogin'
 import { handleExtLogin } from './auth/extLogin'
@@ -12,8 +13,8 @@ import { handleWebUnlock } from './auth/webUnlock'
 
 const log = createLogger()
 
-if (typeof chrome !== 'undefined' && chrome.windows?.onRemoved) {
-  chrome.windows.onRemoved.addListener((removedWindowId) => {
+if (browser?.windows?.onRemoved) {
+  browser.windows.onRemoved.addListener((removedWindowId) => {
     const pending = getPending()
     if (pending?.windowId === removedWindowId) {
       clearPendingAuth()
@@ -32,7 +33,7 @@ export function checkPendingAuthAfterUnlock(): void {
         id: pending.id,
         ...(pending.tenantId && { tenantId: pending.tenantId }),
       } as MessageWithId,
-      undefined as unknown as chrome.runtime.MessageSender,
+      undefined as unknown as Browser.runtime.MessageSender,
       () => {},
     ).catch((error) => {
       log.error('Failed to resume extension login after unlock', error)
@@ -44,7 +45,7 @@ export function checkPendingAuthAfterUnlock(): void {
         id: pending.id,
         additionalIds: pending.additionalIds,
       } as MessageWithId,
-      { tab: { id: pending.tabId } } as chrome.runtime.MessageSender,
+      { tab: { id: pending.tabId } } as Browser.runtime.MessageSender,
       () => {},
       pending.tabId,
     ).catch((error) => {

--- a/apps/extension/src/lib/background/handlers/localVaultHandlers.ts
+++ b/apps/extension/src/lib/background/handlers/localVaultHandlers.ts
@@ -1,5 +1,6 @@
 import { KeeperMessageTypes } from '@evevault/shared/types'
 
+import type { Browser } from 'wxt/browser'
 import type { VaultMessage } from '@/lib/background/types'
 import { writeEncryptedLocalnetKey } from './localnetDeviceStorage'
 import { sendToKeeper } from './vaultHandlers'
@@ -8,7 +9,7 @@ import { sendToKeeper } from './vaultHandlers'
 
 export function _handleLocalnetSetKeypair(
   message: VaultMessage,
-  _sender: chrome.runtime.MessageSender,
+  _sender: Browser.runtime.MessageSender,
   sendResponse: (response?: unknown) => void,
 ): boolean {
   ;(async () => {
@@ -43,7 +44,7 @@ export function _handleLocalnetSetKeypair(
 
 export async function _handleLocalnetGetAddress(
   _message: VaultMessage,
-  _sender: chrome.runtime.MessageSender,
+  _sender: Browser.runtime.MessageSender,
   sendResponse: (response?: unknown) => void,
 ): Promise<boolean> {
   try {
@@ -59,7 +60,7 @@ export async function _handleLocalnetGetAddress(
 
 export async function _handleLocalnetSignBytes(
   message: VaultMessage,
-  _sender: chrome.runtime.MessageSender,
+  _sender: Browser.runtime.MessageSender,
   sendResponse: (response?: unknown) => void,
 ): Promise<boolean> {
   const { msgBytes, scope } = message

--- a/apps/extension/src/lib/background/handlers/localnetDeviceStorage.ts
+++ b/apps/extension/src/lib/background/handlers/localnetDeviceStorage.ts
@@ -1,5 +1,6 @@
 import type { HashedData } from '@evevault/shared'
 import { DEVICE_STORAGE_KEY } from '@evevault/shared/utils/storageKeys'
+import { browser } from 'wxt/browser'
 
 type DeviceStorage = {
   state?: {
@@ -86,7 +87,7 @@ function parseDeviceStorage(raw: unknown): DeviceStorage {
  * unrelated persisted device state.
  */
 async function readDeviceStorage(): Promise<DeviceStorage> {
-  const result = await chrome.storage.local.get([DEVICE_STORAGE_KEY])
+  const result = await browser.storage.local.get([DEVICE_STORAGE_KEY])
   return parseDeviceStorage(result[DEVICE_STORAGE_KEY])
 }
 
@@ -95,7 +96,7 @@ async function readDeviceStorage(): Promise<DeviceStorage> {
  * representation used elsewhere in the extension.
  */
 async function writeDeviceStorage(device: DeviceStorage): Promise<void> {
-  await chrome.storage.local.set({
+  await browser.storage.local.set({
     [DEVICE_STORAGE_KEY]: JSON.stringify(device),
   })
 }

--- a/apps/extension/src/lib/background/handlers/messageHandler.ts
+++ b/apps/extension/src/lib/background/handlers/messageHandler.ts
@@ -1,5 +1,6 @@
 import { VaultMessageTypes, WalletStandardMessageTypes } from '@evevault/shared'
 import { createLogger, redactSensitive } from '@evevault/shared/utils'
+import { type Browser, browser } from 'wxt/browser'
 import { sendToTab } from '@/lib/background/messaging/tabMessaging'
 import { isDappSender, isExtensionSender } from '@/lib/background/senderGuard'
 import { revokeDappPermission } from '@/lib/background/services/dappPermissions'
@@ -35,7 +36,7 @@ import { handleApprovePopup } from './walletHandlers'
 
 const log = createLogger()
 
-type MsgSender = chrome.runtime.MessageSender
+type MsgSender = Browser.runtime.MessageSender
 type SendResponse = (response?: unknown) => void
 type RouteField = 'action' | 'type'
 type RouteAccess = 'dapp' | 'extension'
@@ -301,7 +302,7 @@ function hasRequiredSender(sender: MsgSender, access: RouteAccess): boolean {
  */
 function broadcastChangeEvent(payload: unknown): void {
   log.info('Broadcasting chain change event', payload)
-  chrome.tabs.query({}, (tabs) => {
+  void browser.tabs.query({}).then((tabs) => {
     tabs.forEach((tab) => {
       if (tab.id) {
         sendToTab(tab.id, {
@@ -316,7 +317,7 @@ function broadcastChangeEvent(payload: unknown): void {
 
 export function handleMessage(
   message: BackgroundMessage,
-  sender: chrome.runtime.MessageSender,
+  sender: Browser.runtime.MessageSender,
   sendResponse: (response?: unknown) => void,
 ) {
   const route = findRoute(message)

--- a/apps/extension/src/lib/background/handlers/portHandlers.ts
+++ b/apps/extension/src/lib/background/handlers/portHandlers.ts
@@ -1,12 +1,13 @@
 import { createLogger } from '@evevault/shared/utils'
+import { type Browser, browser } from 'wxt/browser'
 
 const log = createLogger()
 
-function handlePortConnection(port: chrome.runtime.Port) {
+function handlePortConnection(port: Browser.runtime.Port) {
   log.info('Port connected', { name: port.name })
 
   // Listen for logout requests
-  chrome.runtime.onMessage.addListener((message, _sender, _sendResponse) => {
+  browser.runtime.onMessage.addListener((message, _sender, _sendResponse) => {
     if (message.action === 'logout') {
       port.postMessage({ action: 'logout' })
     }

--- a/apps/extension/src/lib/background/handlers/signingPermissions.ts
+++ b/apps/extension/src/lib/background/handlers/signingPermissions.ts
@@ -1,11 +1,12 @@
 import type { SuiChain } from '@mysten/wallet-standard'
+import type { Browser } from 'wxt/browser'
 import {
   type DappPermissionResult,
   requireDappPermission,
 } from '@/lib/background/services/dappPermissions'
 
 export function requireSigningPermission(
-  sender: chrome.runtime.MessageSender,
+  sender: Browser.runtime.MessageSender,
   chain?: SuiChain,
 ): Promise<DappPermissionResult> {
   return requireDappPermission(sender, chain)

--- a/apps/extension/src/lib/background/handlers/sponsoredTransactionHandler.ts
+++ b/apps/extension/src/lib/background/handlers/sponsoredTransactionHandler.ts
@@ -11,6 +11,7 @@ import {
 } from '@evevault/shared'
 import { getApiContext, getJwt, getStoredChain } from '@evevault/shared/auth'
 import { createLogger } from '@evevault/shared/utils'
+import { type Browser, browser } from 'wxt/browser'
 import { sendToTab } from '@/lib/background/messaging/tabMessaging'
 import { openPopupWindow } from '@/lib/background/services/popupWindow'
 import type { EveFrontierSponsoredTransactionMessage } from '@/lib/background/types'
@@ -97,7 +98,7 @@ async function executeSponsoredTx({
 
 async function handleSponsoredTransaction(
   message: EveFrontierSponsoredTransactionMessage,
-  sender: chrome.runtime.MessageSender,
+  sender: Browser.runtime.MessageSender,
   _sendResponse: (response?: unknown) => void,
 ): Promise<boolean> {
   const senderTabId = sender.tab?.id
@@ -180,22 +181,33 @@ async function handleSponsoredTransaction(
       metadata,
     }
 
-    await chrome.storage.local.set({ pendingAction })
+    await browser.storage.local.set({ pendingAction })
 
     let timeoutId: ReturnType<typeof setTimeout>
     let registeredListener: (changes: {
-      [key: string]: chrome.storage.StorageChange
+      [key: string]: Browser.storage.StorageChange
     }) => void
 
     const detachSponsoredListener = () => {
       clearTimeout(timeoutId)
-      chrome.storage.onChanged.removeListener(registeredListener)
+      browser.storage.onChanged.removeListener(registeredListener)
     }
 
     const coreListener = (changes: {
-      [key: string]: chrome.storage.StorageChange
+      [key: string]: Browser.storage.StorageChange
     }) => {
-      const result = changes.transactionResult?.newValue
+      // newValue is untyped storage; describe the popup result shape this
+      // listener reads so field access stays checked.
+      const result = changes.transactionResult?.newValue as
+        | {
+            windowId?: number
+            requestId?: string
+            status?: string
+            zkSignature?: string | null
+            preparationId?: string | null
+            error?: string
+          }
+        | undefined
       if (
         !result ||
         result.windowId !== windowId ||
@@ -204,7 +216,7 @@ async function handleSponsoredTransaction(
         return
 
       detachSponsoredListener()
-      chrome.storage.local.remove(['pendingAction', 'transactionResult'])
+      browser.storage.local.remove(['pendingAction', 'transactionResult'])
 
       if (
         result.status === 'signed' &&
@@ -231,7 +243,7 @@ async function handleSponsoredTransaction(
     }
 
     registeredListener = (changes: {
-      [key: string]: chrome.storage.StorageChange
+      [key: string]: Browser.storage.StorageChange
     }) => {
       clearTimeout(timeoutId)
       coreListener(changes)
@@ -240,13 +252,13 @@ async function handleSponsoredTransaction(
     timeoutId = setTimeout(
       () => {
         detachSponsoredListener()
-        chrome.storage.local.remove(['pendingAction', 'transactionResult'])
+        browser.storage.local.remove(['pendingAction', 'transactionResult'])
         log.warn('Sponsored transaction approval timed out', { senderTabId })
       },
       10 * 60 * 1000,
     )
 
-    chrome.storage.onChanged.addListener(registeredListener)
+    browser.storage.onChanged.addListener(registeredListener)
 
     return true
   } catch (error) {

--- a/apps/extension/src/lib/background/handlers/vaultHandlers.ts
+++ b/apps/extension/src/lib/background/handlers/vaultHandlers.ts
@@ -1,4 +1,5 @@
 import { createLogger, KeeperMessageTypes } from '@evevault/shared'
+import { type Browser, browser } from 'wxt/browser'
 import { ensureOffscreen } from '@/lib/background/services/offscreenService'
 import type { VaultMessage } from '@/lib/background/types'
 import { checkPendingAuthAfterUnlock } from './authHandlers'
@@ -20,35 +21,25 @@ const log = createLogger()
 export async function sendToKeeper(message: any, retries = 3): Promise<any> {
   await ensureOffscreen(true)
 
-  return new Promise((resolve, reject) => {
-    const attemptSend = (attempt: number) => {
-      chrome.runtime.sendMessage(
-        { ...message, target: 'KEEPER' },
-        (response) => {
-          if (chrome.runtime.lastError) {
-            const error = chrome.runtime.lastError.message
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await browser.runtime.sendMessage({ ...message, target: 'KEEPER' })
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err)
 
-            // If port closed and we have retries left, wait and retry
-            if (error?.includes('port closed') && attempt < retries) {
-              log.info(
-                `Keeper not ready yet, retrying... (attempt ${
-                  attempt + 1
-                }/${retries})`,
-              )
-              setTimeout(() => attemptSend(attempt + 1), 200 * attempt) // Exponential backoff
-              return
-            }
+      // If port closed and we have retries left, wait and retry
+      if (error?.includes('port closed') && attempt < retries) {
+        log.info(
+          `Keeper not ready yet, retrying... (attempt ${
+            attempt + 1
+          }/${retries})`,
+        )
+        continue
+      }
 
-            reject(new Error(error))
-            return
-          }
-          resolve(response)
-        },
-      )
+      throw new Error(error)
     }
-
-    attemptSend(1)
-  })
+  }
 }
 
 // Higher-level wrapper over sendToKeeper: maps the keeper response to a
@@ -75,7 +66,7 @@ async function forwardToKeeper(
  */
 export async function handleUnlockVault(
   message: VaultMessage,
-  _sender: chrome.runtime.MessageSender,
+  _sender: Browser.runtime.MessageSender,
   sendResponse: (response?: unknown) => void,
 ): Promise<boolean | undefined> {
   const { hashedSecretKey, pin } = message
@@ -130,7 +121,7 @@ export async function handleUnlockVault(
  */
 export function handleLock(
   _message: VaultMessage,
-  _sender: chrome.runtime.MessageSender,
+  _sender: Browser.runtime.MessageSender,
   sendResponse: (response?: unknown) => void,
 ): Promise<boolean> {
   return forwardToKeeper(
@@ -145,7 +136,7 @@ export function handleLock(
 
 export function _handleCreateKeypair(
   message: VaultMessage,
-  _sender: chrome.runtime.MessageSender,
+  _sender: Browser.runtime.MessageSender,
   sendResponse: (response?: unknown) => void,
 ): Promise<boolean> {
   const { pin } = message
@@ -165,7 +156,7 @@ export function _handleCreateKeypair(
 
 export function _handleRotateKeypair(
   _message: VaultMessage,
-  _sender: chrome.runtime.MessageSender,
+  _sender: Browser.runtime.MessageSender,
   sendResponse: (response?: unknown) => void,
 ): Promise<boolean> {
   return forwardToKeeper(
@@ -192,7 +183,7 @@ export function _handleRotateKeypair(
  */
 export function _handleGetPublicKey(
   _message: VaultMessage,
-  _sender: chrome.runtime.MessageSender,
+  _sender: Browser.runtime.MessageSender,
   sendResponse: (response?: unknown) => void,
 ): Promise<boolean> {
   return forwardToKeeper(
@@ -210,7 +201,7 @@ export function _handleGetPublicKey(
  */
 export function _handleGetUnlockRemaining(
   _message: VaultMessage,
-  _sender: chrome.runtime.MessageSender,
+  _sender: Browser.runtime.MessageSender,
   sendResponse: (response?: unknown) => void,
 ): Promise<boolean> {
   return forwardToKeeper(
@@ -222,7 +213,7 @@ export function _handleGetUnlockRemaining(
 
 export function _handleZkEphSignBytes(
   message: VaultMessage,
-  _sender: chrome.runtime.MessageSender,
+  _sender: Browser.runtime.MessageSender,
   sendResponse: (response?: unknown) => void,
 ): Promise<boolean> {
   const { msgBytes, scope, zkProofData } = message
@@ -255,7 +246,7 @@ export function _handleZkEphSignBytes(
  */
 export function _handleSetZkProof(
   message: VaultMessage,
-  _sender: chrome.runtime.MessageSender,
+  _sender: Browser.runtime.MessageSender,
   sendResponse: (response?: unknown) => void,
 ): Promise<boolean> {
   const { chain, zkProof } = message
@@ -274,7 +265,7 @@ export function _handleSetZkProof(
  */
 export function _handleGetZkProof(
   message: VaultMessage,
-  _sender: chrome.runtime.MessageSender,
+  _sender: Browser.runtime.MessageSender,
   sendResponse: (response?: unknown) => void,
 ): Promise<boolean> {
   const { chain } = message
@@ -297,7 +288,7 @@ export function _handleGetZkProof(
  */
 export function _handleClearZkProof(
   _message: VaultMessage,
-  _sender: chrome.runtime.MessageSender,
+  _sender: Browser.runtime.MessageSender,
   sendResponse: (response?: unknown) => void,
 ): Promise<boolean> {
   return forwardToKeeper(

--- a/apps/extension/src/lib/background/handlers/vaultHandlers.ts
+++ b/apps/extension/src/lib/background/handlers/vaultHandlers.ts
@@ -34,6 +34,7 @@ export async function sendToKeeper(message: any, retries = 3): Promise<any> {
             attempt + 1
           }/${retries})`,
         )
+        await new Promise((r) => setTimeout(r, 200 * attempt)) // Exponential backoff
         continue
       }
 

--- a/apps/extension/src/lib/background/handlers/walletHandlers.ts
+++ b/apps/extension/src/lib/background/handlers/walletHandlers.ts
@@ -1,6 +1,7 @@
 import { WalletStandardMessageTypes } from '@evevault/shared'
 import { createLogger, isRecord, toErrorMessage } from '@evevault/shared/utils'
 import type { SuiChain } from '@mysten/wallet-standard'
+import { type Browser, browser } from 'wxt/browser'
 import {
   type SigningErrorType,
   sendToTab,
@@ -136,7 +137,7 @@ function sendApprovalError(
 
 async function handleApprovePopup(
   message: WalletActionMessage,
-  sender: chrome.runtime.MessageSender,
+  sender: Browser.runtime.MessageSender,
   sendResponse: (response?: unknown) => void,
 ): Promise<boolean> {
   const { action } = message
@@ -172,7 +173,7 @@ async function handleApprovePopup(
 
     const requestId = crypto.randomUUID()
 
-    await chrome.storage.local.set({
+    await browser.storage.local.set({
       pendingAction: {
         ...message,
         windowId,
@@ -188,16 +189,16 @@ async function handleApprovePopup(
 
     let timeoutId: ReturnType<typeof setTimeout>
     let registeredListener: (changes: {
-      [key: string]: chrome.storage.StorageChange
+      [key: string]: Browser.storage.StorageChange
     }) => void
 
     const detachApprovalListener = () => {
       clearTimeout(timeoutId)
-      chrome.storage.onChanged.removeListener(registeredListener)
+      browser.storage.onChanged.removeListener(registeredListener)
     }
 
     const coreListener = (changes: {
-      [key: string]: chrome.storage.StorageChange
+      [key: string]: Browser.storage.StorageChange
     }) => {
       const result = changes.transactionResult?.newValue
       if (!isApprovalResultForRequest(result, windowId, requestId)) return
@@ -207,7 +208,7 @@ async function handleApprovePopup(
 
       if (isSuccess && typeof senderTabId === 'number') {
         sendApprovalSuccess(result, isSignAndExecute, senderTabId, message.id)
-        chrome.storage.local.remove(['pendingAction', 'transactionResult'])
+        browser.storage.local.remove(['pendingAction', 'transactionResult'])
         detachApprovalListener()
       } else if (result?.status === 'error') {
         sendApprovalError(
@@ -217,13 +218,13 @@ async function handleApprovePopup(
           action,
           message.id,
         )
-        chrome.storage.local.remove(['pendingAction', 'transactionResult'])
+        browser.storage.local.remove(['pendingAction', 'transactionResult'])
         detachApprovalListener()
       }
     }
 
     registeredListener = (changes: {
-      [key: string]: chrome.storage.StorageChange
+      [key: string]: Browser.storage.StorageChange
     }) => {
       clearTimeout(timeoutId)
       coreListener(changes)
@@ -232,13 +233,13 @@ async function handleApprovePopup(
     timeoutId = setTimeout(
       () => {
         detachApprovalListener()
-        chrome.storage.local.remove(['pendingAction', 'transactionResult'])
+        browser.storage.local.remove(['pendingAction', 'transactionResult'])
         log.warn('Transaction approval timed out', { action, senderTabId })
       },
       10 * 60 * 1000,
     )
 
-    chrome.storage.onChanged.addListener(registeredListener)
+    browser.storage.onChanged.addListener(registeredListener)
 
     return true
   } catch (error) {

--- a/apps/extension/src/lib/background/messaging/__tests__/tabMessaging.test.ts
+++ b/apps/extension/src/lib/background/messaging/__tests__/tabMessaging.test.ts
@@ -13,20 +13,20 @@ vi.mock('@evevault/shared/utils', async (importOriginal) => {
   }
 })
 
-function installChromeMock(rejectSend = false) {
-  vi.stubGlobal('chrome', {
+function installBrowserMock(rejectSend = false) {
+  vi.stubGlobal('browser', {
     tabs: {
       sendMessage: rejectSend
         ? vi.fn(() => Promise.reject(new Error('Tab closed')))
         : vi.fn(() => Promise.resolve()),
     },
-  } as unknown as typeof chrome)
+  } as unknown as typeof browser)
 }
 
 import { sendToTab } from '../tabMessaging'
 
 beforeEach(() => {
-  installChromeMock()
+  installBrowserMock()
   vi.clearAllMocks()
 })
 
@@ -38,7 +38,7 @@ describe('sendToTab', () => {
   it('delivers a safe message to the target tab', () => {
     sendToTab(42, { type: 'auth_error', id: 'msg-1' })
 
-    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
+    expect(browser.tabs.sendMessage).toHaveBeenCalledWith(42, {
       type: 'auth_error',
       id: 'msg-1',
     })
@@ -52,11 +52,11 @@ describe('sendToTab', () => {
       address: '0xabc',
     }
     sendToTab(99, msg)
-    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(99, msg)
+    expect(browser.tabs.sendMessage).toHaveBeenCalledWith(99, msg)
   })
 
-  it('logs an error when chrome.tabs.sendMessage rejects', async () => {
-    installChromeMock(true)
+  it('logs an error when browser.tabs.sendMessage rejects', async () => {
+    installBrowserMock(true)
 
     sendToTab(7, { type: 'auth_error', id: 'err-msg' })
 
@@ -87,6 +87,6 @@ describe('sendToTab', () => {
       'Blocked tab-bound message containing token material',
       { type: 'auth_error' },
     )
-    expect(chrome.tabs.sendMessage).not.toHaveBeenCalled()
+    expect(browser.tabs.sendMessage).not.toHaveBeenCalled()
   })
 })

--- a/apps/extension/src/lib/background/messaging/tabMessaging.ts
+++ b/apps/extension/src/lib/background/messaging/tabMessaging.ts
@@ -4,6 +4,7 @@ import {
   hasNoTokenMaterial,
   type TokenMaterialField,
 } from '@evevault/shared/utils'
+import { browser } from 'wxt/browser'
 
 const log = createLogger()
 
@@ -105,7 +106,7 @@ export function sendToTab<M extends TabBoundMessage>(
     return
   }
 
-  void chrome.tabs.sendMessage(tabId, message).catch((err: unknown) => {
+  void browser.tabs.sendMessage(tabId, message).catch((err: unknown) => {
     log.error('Failed to send message to tab', { tabId, err })
   })
 }

--- a/apps/extension/src/lib/background/senderGuard.ts
+++ b/apps/extension/src/lib/background/senderGuard.ts
@@ -1,4 +1,6 @@
-type MsgSender = chrome.runtime.MessageSender
+import { type Browser, browser } from 'wxt/browser'
+
+type MsgSender = Browser.runtime.MessageSender
 
 /**
  * Identifies messages that originate from this extension rather than a web
@@ -8,7 +10,7 @@ type MsgSender = chrome.runtime.MessageSender
  */
 export function isExtensionSender(sender: MsgSender): boolean {
   const senderUrls = [sender.origin, sender.url, sender.tab?.url]
-  const extensionId = chrome.runtime?.id
+  const extensionId = browser.runtime?.id
   const isOwnExtensionUrl = (url: string | undefined) => {
     if (!url) return false
     if (!extensionId) return url.startsWith('chrome-extension://')

--- a/apps/extension/src/lib/background/services/__tests__/dappPermissions.test.ts
+++ b/apps/extension/src/lib/background/services/__tests__/dappPermissions.test.ts
@@ -1,6 +1,7 @@
 import { DAPP_PERMISSIONS_STORAGE_KEY } from '@evevault/shared/utils'
 import { SUI_DEVNET_CHAIN, SUI_TESTNET_CHAIN } from '@mysten/wallet-standard'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Browser } from 'wxt/browser'
 import {
   getDappRequestContext,
   grantDappPermission,
@@ -13,7 +14,7 @@ describe('dappPermissions', () => {
 
   beforeEach(() => {
     storage = {}
-    globalThis.chrome = {
+    vi.stubGlobal('browser', {
       storage: {
         local: {
           get: vi.fn(async (key: string | string[]) => {
@@ -25,7 +26,7 @@ describe('dappPermissions', () => {
           }),
         },
       },
-    } as unknown as typeof chrome
+    } as unknown as typeof browser)
   })
 
   afterEach(() => {
@@ -40,7 +41,7 @@ describe('dappPermissions', () => {
         title: 'Example App',
         favIconUrl: 'https://app.example/favicon.ico',
       },
-    } as chrome.runtime.MessageSender)
+    } as Browser.runtime.MessageSender)
 
     expect(context).toEqual({
       origin: 'https://app.example',
@@ -54,7 +55,7 @@ describe('dappPermissions', () => {
     const context = getDappRequestContext({
       origin: 'chrome-extension://extension-id',
       url: 'chrome-extension://extension-id/page.html',
-    } as chrome.runtime.MessageSender)
+    } as Browser.runtime.MessageSender)
 
     expect(context).toBeNull()
   })
@@ -72,7 +73,7 @@ describe('dappPermissions', () => {
         {
           origin: 'https://app.example',
           url: 'https://app.example/inventory',
-        } as chrome.runtime.MessageSender,
+        } as Browser.runtime.MessageSender,
         SUI_TESTNET_CHAIN,
       ),
     ).resolves.toMatchObject({
@@ -126,7 +127,7 @@ describe('dappPermissions', () => {
 
     await revokeDappPermission({
       origin: 'https://app.example',
-    } as chrome.runtime.MessageSender)
+    } as Browser.runtime.MessageSender)
 
     expect(storage[DAPP_PERMISSIONS_STORAGE_KEY]).toMatchObject({
       'https://other.example': {
@@ -220,7 +221,7 @@ describe('dappPermissions', () => {
     await expect(
       requireDappPermission({
         origin: 'https://unknown.example',
-      } as chrome.runtime.MessageSender),
+      } as Browser.runtime.MessageSender),
     ).resolves.toEqual({
       allowed: false,
       context: { origin: 'https://unknown.example' },
@@ -236,7 +237,7 @@ describe('dappPermissions', () => {
 
     await expect(
       requireDappPermission(
-        { origin: 'https://app.example' } as chrome.runtime.MessageSender,
+        { origin: 'https://app.example' } as Browser.runtime.MessageSender,
         SUI_DEVNET_CHAIN,
       ),
     ).resolves.toEqual({
@@ -255,7 +256,7 @@ describe('dappPermissions', () => {
     await expect(
       revokeDappPermission({
         origin: 'https://app.example',
-      } as chrome.runtime.MessageSender),
+      } as Browser.runtime.MessageSender),
     ).resolves.toEqual({
       ok: true,
       context: { origin: 'https://app.example' },
@@ -266,7 +267,7 @@ describe('dappPermissions', () => {
     await expect(
       requireDappPermission({
         origin: 'https://app.example',
-      } as chrome.runtime.MessageSender),
+      } as Browser.runtime.MessageSender),
     ).resolves.toMatchObject({
       allowed: false,
       error: 'Connect this site to EVE Vault before requesting a signature.',
@@ -277,7 +278,7 @@ describe('dappPermissions', () => {
     await expect(
       revokeDappPermission({
         origin: 'https://app.example',
-      } as chrome.runtime.MessageSender),
+      } as Browser.runtime.MessageSender),
     ).resolves.toEqual({
       ok: true,
       context: { origin: 'https://app.example' },
@@ -289,7 +290,7 @@ describe('dappPermissions', () => {
     await expect(
       revokeDappPermission({
         origin: 'chrome-extension://extension-id',
-      } as chrome.runtime.MessageSender),
+      } as Browser.runtime.MessageSender),
     ).resolves.toEqual({
       ok: false,
       error: 'Disconnect requests must come from a valid web page origin.',

--- a/apps/extension/src/lib/background/services/__tests__/oauthService.test.ts
+++ b/apps/extension/src/lib/background/services/__tests__/oauthService.test.ts
@@ -19,13 +19,13 @@ describe('getAuthRequest', () => {
       serverUrl: 'https://auth.example.com/',
     })
 
-    globalThis.chrome = {
+    vi.stubGlobal('browser', {
       identity: {
         getRedirectURL: vi.fn(
           () => 'https://extension.chromiumapp.org/callback',
         ),
       },
-    } as unknown as typeof chrome
+    } as unknown as typeof browser)
   })
 
   afterEach(() => {

--- a/apps/extension/src/lib/background/services/dappPermissions.ts
+++ b/apps/extension/src/lib/background/services/dappPermissions.ts
@@ -1,6 +1,7 @@
 import type { DappRequestContext } from '@evevault/shared/types'
 import { DAPP_PERMISSIONS_STORAGE_KEY, isRecord } from '@evevault/shared/utils'
 import { SUI_CHAINS, type SuiChain } from '@mysten/wallet-standard'
+import { type Browser, browser } from 'wxt/browser'
 
 type DappPermissionRecord = DappRequestContext & {
   chains: SuiChain[]
@@ -43,13 +44,13 @@ function normalizePageUrl(value: unknown): URL | null {
 }
 
 function getSenderUrl(
-  sender: chrome.runtime.MessageSender,
+  sender: Browser.runtime.MessageSender,
 ): string | undefined {
   return sender.url ?? sender.tab?.url
 }
 
 export function getDappRequestContext(
-  sender: chrome.runtime.MessageSender,
+  sender: Browser.runtime.MessageSender,
 ): DappRequestContext | null {
   const originUrl =
     normalizePageUrl(sender.origin) ??
@@ -116,7 +117,7 @@ function sanitizePermissionStore(value: unknown): DappPermissionStore {
 }
 
 async function readPermissionStore(): Promise<DappPermissionStore> {
-  const result = await chrome.storage.local.get(DAPP_PERMISSIONS_STORAGE_KEY)
+  const result = await browser.storage.local.get(DAPP_PERMISSIONS_STORAGE_KEY)
   return sanitizePermissionStore(result[DAPP_PERMISSIONS_STORAGE_KEY])
 }
 
@@ -126,7 +127,7 @@ async function updatePermissionStore<T>(
   const nextUpdate = permissionStoreUpdateQueue.then(async () => {
     const permissions = await readPermissionStore()
     const { store, result } = update(permissions)
-    await chrome.storage.local.set({ [DAPP_PERMISSIONS_STORAGE_KEY]: store })
+    await browser.storage.local.set({ [DAPP_PERMISSIONS_STORAGE_KEY]: store })
     return result
   })
 
@@ -179,7 +180,7 @@ export async function grantDappPermission(
 }
 
 export async function requireDappPermission(
-  sender: chrome.runtime.MessageSender,
+  sender: Browser.runtime.MessageSender,
   chain?: SuiChain,
 ): Promise<DappPermissionResult> {
   const context = getDappRequestContext(sender)
@@ -218,7 +219,7 @@ export async function requireDappPermission(
 }
 
 export async function revokeDappPermission(
-  sender: chrome.runtime.MessageSender,
+  sender: Browser.runtime.MessageSender,
 ): Promise<DappPermissionRevocationResult> {
   const context = getDappRequestContext(sender)
   if (!context) {

--- a/apps/extension/src/lib/background/services/oauthService.ts
+++ b/apps/extension/src/lib/background/services/oauthService.ts
@@ -1,6 +1,7 @@
 import type { TenantId } from '@evefrontier/wallet-core/tenant'
 import { getTenantConfig } from '@evevault/shared'
 import { sha256 } from '@evevault/shared/utils'
+import { browser } from 'wxt/browser'
 import { base64UrlEncode } from '@/lib/util/b64UrlEncode'
 
 async function createPkcePair(): Promise<{
@@ -31,7 +32,7 @@ function getAuthUrl(params: {
   const tenantConfig = getTenantConfig(params.tenantId)
 
   const clientId = tenantConfig.clientId
-  const redirectUri = chrome.identity.getRedirectURL()
+  const redirectUri = browser.identity.getRedirectURL()
 
   const url = new URL(
     `${tenantConfig.serverUrl.replace(/\/$/, '')}/oauth2/authorize`,

--- a/apps/extension/src/lib/background/services/offscreenService.ts
+++ b/apps/extension/src/lib/background/services/offscreenService.ts
@@ -1,12 +1,11 @@
-/// <reference types="chrome"/>
-
 import { createLogger } from '@evevault/shared/utils'
+import { browser } from 'wxt/browser'
 
 const log = createLogger()
 
 let keeperReady = false
 const keeperReadyPromise = new Promise<void>((resolve) => {
-  chrome.runtime.onMessage.addListener((message) => {
+  browser.runtime.onMessage.addListener((message) => {
     if (message.type === 'KEEPER_READY') {
       keeperReady = true
       resolve()
@@ -22,9 +21,9 @@ const keeperReadyPromise = new Promise<void>((resolve) => {
  */
 export async function ensureOffscreen(waitForReady = false): Promise<void> {
   try {
-    const hasDoc = await chrome.offscreen.hasDocument()
+    const hasDoc = await browser.offscreen.hasDocument()
     if (!hasDoc) {
-      await chrome.offscreen.createDocument({
+      await browser.offscreen.createDocument({
         url: 'keeper.html',
         reasons: ['LOCAL_STORAGE', 'DOM_SCRAPING'],
         justification: 'Hold ephemeral key in RAM only.',

--- a/apps/extension/src/lib/background/services/popupWindow.ts
+++ b/apps/extension/src/lib/background/services/popupWindow.ts
@@ -1,4 +1,5 @@
 import { createLogger } from '@evevault/shared/utils'
+import { browser } from 'wxt/browser'
 
 const log = createLogger()
 
@@ -11,9 +12,13 @@ export async function openPopupWindow(
   url: string,
 ): Promise<number | undefined> {
   try {
-    const popupUrl = chrome.runtime.getURL(`${url}.html`)
+    // WXT types runtime.getURL to statically-known public paths; the page name
+    // is built dynamically here, so widen to the getURL parameter type.
+    const popupUrl = browser.runtime.getURL(
+      `/${url}.html` as Parameters<typeof browser.runtime.getURL>[0],
+    )
 
-    const window = await chrome.windows.create({
+    const window = await browser.windows.create({
       url: popupUrl,
       type: 'popup',
       width: 500,
@@ -21,7 +26,7 @@ export async function openPopupWindow(
       focused: true,
     })
 
-    return window.id
+    return window?.id
   } catch (error) {
     log.error('Failed to open popup', error)
     return undefined

--- a/apps/extension/vitest.browser-mock.ts
+++ b/apps/extension/vitest.browser-mock.ts
@@ -1,0 +1,15 @@
+// Test-only replacement for `wxt/browser`, wired in via `test.alias` in
+// vitest.config.ts. The real module resolves `browser` once at import time
+// (`globalThis.browser ?? globalThis.chrome`), which would go stale as tests
+// swap the global with `vi.stubGlobal('browser', ...)` per test. This proxy
+// instead reads `globalThis.browser` live on every access, so each test's stub
+// is what source code sees.
+// biome-ignore lint/suspicious/noExplicitAny: test shim over the untyped global
+export const browser: any = new Proxy(
+  {},
+  {
+    get(_target, prop) {
+      return (globalThis as any).browser?.[prop]
+    },
+  },
+)

--- a/apps/extension/vitest.browser-mock.ts
+++ b/apps/extension/vitest.browser-mock.ts
@@ -4,7 +4,7 @@
 // swap the global with `vi.stubGlobal('browser', ...)` per test. This proxy
 // instead reads `globalThis.browser` live on every access, so each test's stub
 // is what source code sees.
-// biome-ignore lint/suspicious/noExplicitAny: test shim over the untyped global
+// biome-ignore-all lint/suspicious/noExplicitAny: test shim over the untyped global
 export const browser: any = new Proxy(
   {},
   {

--- a/apps/extension/vitest.config.ts
+++ b/apps/extension/vitest.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url'
 import react from '@vitejs/plugin-react'
 import tsconfigPaths from 'vite-tsconfig-paths'
 import { defineConfig } from 'vitest/config'
@@ -17,7 +18,14 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     include: ['src/**/*.test.{ts,tsx}', 'entrypoints/**/*.test.{ts,tsx}'],
-    setupFiles: ['../../vitest.setup.ts', './vitest.browser-shim.ts'],
+    setupFiles: ['../../vitest.setup.ts'],
+    // Tests drive the extension APIs by stubbing `globalThis.browser`; route
+    // `wxt/browser` to a live proxy over it (see vitest.browser-mock.ts).
+    alias: {
+      'wxt/browser': fileURLToPath(
+        new URL('./vitest.browser-mock.ts', import.meta.url),
+      ),
+    },
     server: {
       deps: {
         inline: ['@evefrontier/wallet-core'],

--- a/apps/extension/vitest.config.ts
+++ b/apps/extension/vitest.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     include: ['src/**/*.test.{ts,tsx}', 'entrypoints/**/*.test.{ts,tsx}'],
-    setupFiles: ['../../vitest.setup.ts'],
+    setupFiles: ['../../vitest.setup.ts', './vitest.browser-shim.ts'],
     server: {
       deps: {
         inline: ['@evefrontier/wallet-core'],

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -92,15 +92,24 @@ export default defineConfig(() => {
     manifestVersion: 3,
     srcDir: 'src',
     entrypointsDir: '../entrypoints',
-    // Only configure webExt if Chrome path is found
-    // If Chrome is not found, WXT will build the extension but won't auto-launch
-    // User can manually load the extension from .output/chrome-mv3-dev
-    ...(chromePath && {
-      webExt: {
-        chromiumExecutablePath: chromePath,
-        executablePath: chromePath,
+    // WXT owns the dev-server port here (not vite.server.port). Chrome dev uses
+    // 3000; the Firefox dev script overrides with `--port 3002` so both
+    // extension targets can run at once. Web app is on 3005.
+    dev: {
+      server: {
+        port: 3000,
       },
-    }),
+    },
+    // WXT reads binaries[<target browser>] for the chromium binary and
+    // binaries.firefox for Firefox. (The old chromiumExecutablePath/
+    // executablePath keys are not valid webExt options and were ignored.)
+    // Firefox is auto-discovered by web-ext when installed; Chrome is pinned to
+    // the detected path so dev auto-launches when it isn't on PATH.
+    webExt: {
+      binaries: {
+        ...(chromePath && { chrome: chromePath }),
+      },
+    },
     vite: () => ({
       plugins: [
         appVersionPlugin(version),
@@ -110,10 +119,6 @@ export default defineConfig(() => {
         tanstackRouter({ quoteStyle: 'double' }),
         tailwindcss(),
       ],
-      server: {
-        port: 3000, // Extension dev server port (web app uses 3001)
-        strictPort: true, // Don't auto-switch ports
-      },
       // Configure Vite to load env vars from monorepo root
       envDir: rootDir,
       optimizeDeps: {
@@ -154,11 +159,23 @@ export default defineConfig(() => {
       // WXT adds `scripting` in dev for HMR content-script registration but
       // uses a static content_scripts entry in production. Strip it from
       // release builds only so the Web Store doesn't flag it as unused.
-      'build:manifestGenerated'(_wxt, manifest) {
+      'build:manifestGenerated'(wxt, manifest) {
         if (process.env.NODE_ENV !== 'development') {
           manifest.permissions = manifest.permissions?.filter(
             (p) => p !== 'scripting',
           )
+        }
+        // Firefox MV3 refuses to load an extension without an explicit gecko id
+        // (it also fixes the moz-extension:// origin, which the OAuth redirect
+        // URL derives from). Chrome ignores browser_specific_settings, so scope
+        // it to the Firefox build.
+        if (wxt.config.browser === 'firefox') {
+          manifest.browser_specific_settings = {
+            gecko: {
+              id: 'evevault@eve.is',
+              strict_min_version: '128.0',
+            },
+          }
         }
       },
     },

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -172,7 +172,7 @@ export default defineConfig(() => {
         if (wxt.config.browser === 'firefox') {
           manifest.browser_specific_settings = {
             gecko: {
-              id: 'evevault@eve.is',
+              id: 'evevault@evefrontier.com',
               strict_min_version: '128.0',
             },
           }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -79,7 +79,7 @@ export default defineConfig({
     }),
   ],
   server: {
-    port: 3001, // Web app port (extension uses 3000)
+    port: 3005,
     strictPort: true, // Don't auto-switch ports
   },
   // Configure Vite to load env vars from monorepo root

--- a/bun.lock
+++ b/bun.lock
@@ -46,7 +46,6 @@
       "devDependencies": {
         "@tailwindcss/vite": "^4.3.0",
         "@tanstack/router-plugin": "^1.168.13",
-        "@types/chrome": "^0.0.280",
         "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
         "@wxt-dev/module-react": "^1.2.2",
@@ -793,8 +792,6 @@
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
-
-    "@types/chrome": ["@types/chrome@0.0.280", "", { "dependencies": { "@types/filesystem": "*", "@types/har-format": "*" } }, "sha512-AotSmZrL9bcZDDmSI1D9dE7PGbhOur5L0cKxXd7IqbVizQWCY4gcvupPUVsQ4FfDj3V2tt/iOpomT9EY0s+w1g=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 

--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
   ],
   "packageManager": "bun@1.3.13",
   "scripts": {
-    "dev": "turbo run dev",
+    "dev": "turbo run dev dev:firefox",
+    "dev:chrome": "turbo run dev",
     "dev:ext": "turbo run dev --filter=@evevault/extension",
+    "dev:ext:firefox": "turbo run dev:firefox --filter=@evevault/extension",
     "dev:ext:direct": "bun --cwd apps/extension run dev",
     "dev:web": "turbo run dev --filter=@evevault/web",
     "build": "turbo run build",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,32 +1,34 @@
-import { defineConfig, devices } from "@playwright/test";
+import { defineConfig, devices } from '@playwright/test'
 
 /**
  * Playwright configuration for E2E smoke tests.
  * This file intentionally ships without test files—add them per feature once flows are ready.
  */
 export default defineConfig({
-  testDir: "./tests/e2e",
+  testDir: './tests/e2e',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: "html",
+  reporter: 'html',
   use: {
-    baseURL: "http://localhost:3001",
-    trace: "on-first-retry",
-    screenshot: "only-on-failure",
-    video: "retain-on-failure",
+    // TODO: web dev port moved to 3005; update this and webServer.url
+    // to 3005 (currently no e2e test files exist, so this is dormant).
+    baseURL: 'http://localhost:3001',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
   },
   projects: [
     {
-      name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
     },
   ],
   webServer: {
-    command: "bun run dev:web",
-    url: "http://localhost:3001",
+    command: 'bun run dev:web',
+    url: 'http://localhost:3001',
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
   },
-});
+})

--- a/turbo.json
+++ b/turbo.json
@@ -13,6 +13,11 @@
       "persistent": true,
       "env": ["VITE_*", "EXTENSION_ID"]
     },
+    "dev:firefox": {
+      "cache": false,
+      "persistent": true,
+      "env": ["VITE_*", "EXTENSION_ID"]
+    },
     "typecheck": {
       "dependsOn": ["^build"],
       "outputs": []


### PR DESCRIPTION
Groundwork for Firefox support. Moves `apps/extension` off the Chrome-only `chrome.*` global onto WXT's cross-browser `browser` API, makes the test suite browser-native, and wires up a Firefox dev workflow — so the extension compiles, builds, tests, and dev-runs on **both Chrome and Firefox**.

Behaviour-preserving on Chrome. This does **not** yet make Firefox functional end-to-end.

## Changes

**Browser API migration**
- Replace all `chrome.*` value calls with `browser.*` (`wxt/browser`) and the `MessageSender` / `Port` / `storage.StorageChange` types with `Browser.*`; remove the `/// <reference types="chrome">` directives.
- Convert callback-style APIs to promises/`await` — required because Firefox's `browser` is promise-only: `sendToKeeper` retry loop, storage reads, and `launchWebAuthFlow` in ext/dapp login (rejections now route through `sendAuthError`); `lastError` checks become `try/catch`.
- Adjust for stricter webextension-polyfill types: shape-cast `StorageChange.newValue`, guard `windows.create`'s optional result.

**Browser-native tests**
- Alias `wxt/browser` to a live proxy over `globalThis.browser` (`vitest.browser-mock.ts`) so per-test `vi.stubGlobal('browser', …)` works despite the module's import-time snapshot.
- Convert all mocks/assertions from `chrome` to `browser`; drop the now-unused `@types/chrome` dependency.

**Firefox build & dev**
- Add `browser_specific_settings.gecko.id` (Firefox-only, via manifest hook) — Firefox MV3 won't load an extension without it.
- Fix `webExt` config to use WXT's real `binaries` map (the old `chromiumExecutablePath` / `executablePath` keys were silently ignored).
- `bun run dev` now runs web + Chrome ext + Firefox ext together (`turbo run dev dev:firefox`); ports: Chrome 3000, Firefox 3002 (`--port`), web 3005. Added `dev:chrome` (Chrome-only) and `dev:ext:firefox`.