### PR TITLE
refactor(extension): scheme-parameter sender guard

### DIFF
--- a/apps/extension/src/lib/background/__tests__/senderGuard.test.ts
+++ b/apps/extension/src/lib/background/__tests__/senderGuard.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Browser } from 'wxt/browser'
+import { isDappSender, isExtensionSender } from '@/lib/background/senderGuard'
+
+type MsgSender = Browser.runtime.MessageSender
+
+const CHROME_ID = 'abcdefghabcdefghabcdefghabcdefgh'
+const FIREFOX_UUID = '11111111-2222-3333-4444-555555555555'
+
+/**
+ * Stub `browser.runtime.getURL` to model a given extension origin. Passing
+ * `undefined` models a context where getURL is unavailable (the fallback path).
+ */
+function stubOwnOrigin(origin: string | undefined) {
+  vi.stubGlobal('browser', {
+    runtime: origin ? { getURL: (path: string) => `${origin}${path}` } : {},
+  } as unknown as typeof browser)
+}
+
+function sender(overrides: Partial<MsgSender>): MsgSender {
+  return overrides as MsgSender
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('isExtensionSender', () => {
+  describe('Chrome (chrome-extension://)', () => {
+    const own = `chrome-extension://${CHROME_ID}`
+
+    it('trusts a page URL under its own origin', () => {
+      stubOwnOrigin(own)
+      expect(isExtensionSender(sender({ url: `${own}/popup.html` }))).toBe(true)
+    })
+
+    it('trusts a bare origin equal to its own origin', () => {
+      stubOwnOrigin(own)
+      expect(isExtensionSender(sender({ origin: own }))).toBe(true)
+    })
+
+    it('trusts a match found on the tab URL', () => {
+      stubOwnOrigin(own)
+      expect(
+        isExtensionSender(
+          sender({
+            origin: 'https://dapp.example',
+            tab: { id: 3, url: `${own}/sign.html` } as Browser.tabs.Tab,
+          }),
+        ),
+      ).toBe(true)
+    })
+  })
+
+  describe('Firefox (moz-extension://)', () => {
+    // Firefox's extension-URL host is a per-install UUID, not runtime.id — so
+    // only a getURL-derived origin can match it.
+    const own = `moz-extension://${FIREFOX_UUID}`
+
+    it('trusts a page URL under its own moz-extension origin', () => {
+      stubOwnOrigin(own)
+      expect(isExtensionSender(sender({ url: `${own}/popup.html` }))).toBe(true)
+    })
+
+    it('trusts a bare moz-extension origin', () => {
+      stubOwnOrigin(own)
+      expect(isExtensionSender(sender({ origin: own }))).toBe(true)
+    })
+  })
+
+  describe('fails closed', () => {
+    const own = `chrome-extension://${CHROME_ID}`
+
+    it('rejects a sender with no identifying metadata', () => {
+      stubOwnOrigin(own)
+      expect(isExtensionSender(sender({}))).toBe(false)
+    })
+
+    it('rejects a web (https) dApp sender', () => {
+      stubOwnOrigin(own)
+      expect(
+        isExtensionSender(
+          sender({
+            origin: 'https://dapp.example',
+            url: 'https://dapp.example/app',
+          }),
+        ),
+      ).toBe(false)
+    })
+
+    it('rejects another extension with a different id', () => {
+      stubOwnOrigin(own)
+      expect(
+        isExtensionSender(
+          sender({ url: `chrome-extension://${'z'.repeat(32)}/popup.html` }),
+        ),
+      ).toBe(false)
+    })
+
+    it('rejects a lookalike host that prefix-matches its own id', () => {
+      stubOwnOrigin(own)
+      expect(
+        isExtensionSender(sender({ url: `${own}-evil.example/popup.html` })),
+      ).toBe(false)
+    })
+
+    it('rejects a moz-extension sender when running under Chrome', () => {
+      stubOwnOrigin(own)
+      expect(
+        isExtensionSender(
+          sender({ url: `moz-extension://${FIREFOX_UUID}/popup.html` }),
+        ),
+      ).toBe(false)
+    })
+  })
+
+  describe('fallback when getURL is unavailable', () => {
+    it('best-effort trusts a chrome-extension URL', () => {
+      stubOwnOrigin(undefined)
+      expect(
+        isExtensionSender(sender({ url: 'chrome-extension://any/popup.html' })),
+      ).toBe(true)
+    })
+
+    it('best-effort trusts a moz-extension URL', () => {
+      stubOwnOrigin(undefined)
+      expect(
+        isExtensionSender(sender({ url: 'moz-extension://any/popup.html' })),
+      ).toBe(true)
+    })
+
+    it('still rejects a web sender', () => {
+      stubOwnOrigin(undefined)
+      expect(
+        isExtensionSender(sender({ url: 'https://dapp.example/app' })),
+      ).toBe(false)
+    })
+  })
+})
+
+describe('isDappSender', () => {
+  const own = `chrome-extension://${CHROME_ID}`
+
+  it('trusts a web page tab sender', () => {
+    stubOwnOrigin(own)
+    expect(
+      isDappSender(
+        sender({
+          origin: 'https://dapp.example',
+          tab: { id: 42, url: 'https://dapp.example/app' } as Browser.tabs.Tab,
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('rejects a sender with no tab (e.g. background/extension page)', () => {
+    stubOwnOrigin(own)
+    expect(isDappSender(sender({ url: 'https://dapp.example/app' }))).toBe(
+      false,
+    )
+  })
+
+  it('rejects an extension UI tab so it cannot reach dApp-only routes', () => {
+    stubOwnOrigin(own)
+    expect(
+      isDappSender(
+        sender({
+          origin: own,
+          tab: { id: 7, url: `${own}/sign.html` } as Browser.tabs.Tab,
+        }),
+      ),
+    ).toBe(false)
+  })
+})

--- a/apps/extension/src/lib/background/handlers/__tests__/messageHandler.test.ts
+++ b/apps/extension/src/lib/background/handlers/__tests__/messageHandler.test.ts
@@ -81,6 +81,7 @@ function installBrowserMock() {
   vi.stubGlobal('browser', {
     runtime: {
       id: 'extension-id',
+      getURL: (path: string) => `chrome-extension://extension-id${path}`,
     },
     tabs: {
       query: vi.fn(async () => [{ id: 1 }, { id: 2 }]),

--- a/apps/extension/src/lib/background/handlers/__tests__/messageHandler.test.ts
+++ b/apps/extension/src/lib/background/handlers/__tests__/messageHandler.test.ts
@@ -457,3 +457,65 @@ describe('handleMessage route policy', () => {
     expect(sendResponse).not.toHaveBeenCalled()
   })
 })
+
+// Firefox's extension-URL host is a per-install UUID (not runtime.id) under the
+// moz-extension:// scheme, so the guard must gate routes off the getURL-derived
+// origin. These drive that end-to-end through handleMessage, not just the guard.
+const FIREFOX_ORIGIN = 'moz-extension://11111111-2222-3333-4444-555555555555'
+
+function installFirefoxBrowserMock() {
+  vi.stubGlobal('browser', {
+    runtime: {
+      id: 'eve@evefrontier',
+      getURL: (path: string) => `${FIREFOX_ORIGIN}${path}`,
+    },
+    tabs: {
+      query: vi.fn(async () => [{ id: 1 }, { id: 2 }]),
+      sendMessage: vi.fn(async () => undefined),
+    },
+  } as unknown as typeof browser)
+}
+
+describe('handleMessage route policy — Firefox (moz-extension)', () => {
+  beforeEach(() => {
+    installFirefoxBrowserMock()
+    vi.clearAllMocks()
+  })
+
+  it('allows vault messages from a moz-extension sender', () => {
+    const sendResponse = vi.fn()
+    const sender: Browser.runtime.MessageSender = {
+      url: `${FIREFOX_ORIGIN}/popup.html`,
+    }
+
+    const result = handleMessage(
+      { type: VaultMessageTypes.LOCK },
+      sender,
+      sendResponse,
+    )
+
+    expect(result).toBe(true)
+    expect(mocks.handleLock).toHaveBeenCalledWith(
+      { type: VaultMessageTypes.LOCK },
+      sender,
+      sendResponse,
+    )
+  })
+
+  it('rejects a chrome-extension sender when running under a Firefox origin', () => {
+    const sendResponse = vi.fn()
+
+    const result = handleMessage(
+      { type: VaultMessageTypes.LOCK },
+      { url: 'chrome-extension://extension-id/popup.html' },
+      sendResponse,
+    )
+
+    expect(result).toBe(false)
+    expect(mocks.handleLock).not.toHaveBeenCalled()
+    expect(sendResponse).toHaveBeenCalledWith({
+      type: 'auth_error',
+      error: { message: 'Unauthorized message sender' },
+    })
+  })
+})

--- a/apps/extension/src/lib/background/senderGuard.ts
+++ b/apps/extension/src/lib/background/senderGuard.ts
@@ -21,10 +21,11 @@ function getOwnOrigin(): string | undefined {
 }
 
 /**
- * Identifies messages that originate from this extension rather than a web
- * page. Fails closed: a sender is trusted only when it carries a URL under this
- * extension's own origin. Senders with no identifying metadata are NOT trusted,
- * so the privileged extension-only routes can't be reached without provenance.
+ * Identifies messages from this extension rather than a web page. Fails closed:
+ * trusted only when the sender URL is under this extension's own origin; no
+ * metadata → rejected. When the own origin is unknown (no `getURL`), falls back
+ * to any `chrome-extension://` / `moz-extension://` URL — a degraded path not
+ * reached from the background, where routes are actually gated.
  */
 export function isExtensionSender(sender: MsgSender): boolean {
   const ownOrigin = getOwnOrigin()

--- a/apps/extension/src/lib/background/senderGuard.ts
+++ b/apps/extension/src/lib/background/senderGuard.ts
@@ -3,21 +3,45 @@ import { type Browser, browser } from 'wxt/browser'
 type MsgSender = Browser.runtime.MessageSender
 
 /**
+ * This extension's own origin (`chrome-extension://<id>` on Chrome,
+ * `moz-extension://<uuid>` on Firefox), derived from `runtime.getURL` so the
+ * scheme and host are whatever the current browser actually uses. Trailing
+ * slash stripped so it matches both a bare origin and a full page URL.
+ * Returns undefined outside an extension context (no `getURL`).
+ */
+function getOwnOrigin(): string | undefined {
+  // WXT types getURL to statically-known public paths; widen to a plain string
+  // signature since we only need the origin prefix.
+  const getURL = browser.runtime?.getURL as
+    | ((path: string) => string)
+    | undefined
+  const base = getURL?.('/')
+  if (!base) return undefined
+  return base.endsWith('/') ? base.slice(0, -1) : base
+}
+
+/**
  * Identifies messages that originate from this extension rather than a web
  * page. Fails closed: a sender is trusted only when it carries a URL under this
  * extension's own origin. Senders with no identifying metadata are NOT trusted,
  * so the privileged extension-only routes can't be reached without provenance.
  */
 export function isExtensionSender(sender: MsgSender): boolean {
-  const senderUrls = [sender.origin, sender.url, sender.tab?.url]
-  const extensionId = browser.runtime?.id
+  const ownOrigin = getOwnOrigin()
   const isOwnExtensionUrl = (url: string | undefined) => {
     if (!url) return false
-    if (!extensionId) return url.startsWith('chrome-extension://')
-
-    return url.startsWith(`chrome-extension://${extensionId}/`)
+    if (ownOrigin) {
+      // Boundary match so a lookalike host (`…-evil`) can't prefix-escape.
+      return url === ownOrigin || url.startsWith(`${ownOrigin}/`)
+    }
+    // No getURL (non-extension context): best-effort allow of extension schemes.
+    return (
+      url.startsWith('chrome-extension://') ||
+      url.startsWith('moz-extension://')
+    )
   }
 
+  const senderUrls = [sender.origin, sender.url, sender.tab?.url]
   return senderUrls.some(isOwnExtensionUrl)
 }
 


### PR DESCRIPTION
Hardens `isExtensionSender` (the fail-closed access guard behind every `extension`-only message route) to work on Firefox as well as Chrome, and adds test coverage. No behavior change on Chrome — the
guard still fails closed everywhere it did before; the only new trust is "URL under this browser's real own-origin," so the boundary check and the `getURL`-absent fallback are the parts worth a close read.

## Why

Every privileged route is gated by `hasRequiredSender` → `isExtensionSender`, which trusts a sender only if its URL starts with `chrome-extension://${browser.runtime.id}/`. On Firefox both the scheme (`moz-extension://`) and the host (a per-install UUID, not `runtime.id`) differ, so no extension sender matches and the guard rejects the extension's own pages. This isolates that fix ahead of the additive Firefox changes.

## Changes

- **`senderGuard.ts`** — derive the extension's own origin from `browser.runtime.getURL('/')` (the canonical scheme+host on both browsers: `chrome-extension://<id>` / `moz-extension://<uuid>`) instead of rebuilding it from `runtime.id`. Match sender URLs against that origin with a **boundary check** (`=== base || startsWith(base + '/')`) so a lookalike host (`…-evil`) can't prefix-escape. Fail-closed preserved: no metadata → `false`; when `getURL` is unavailable (non-extension context) it falls back to a best-effort extension-scheme allow, matching the previous degraded-path semantics. `isDappSender` unchanged.
- **New `__tests__/senderGuard.test.ts`** (16 tests). Chrome match, Firefox `moz-extension` match, the full fail-closed matrix (no metadata, `https` dApp, other-extension id, prefix-escape lookalike, moz-under-Chrome), and the `getURL`-unavailable fallback.
- **`messageHandler.test.ts`** — added `getURL` to its browser mock so the existing route-policy suite exercises the real origin-matching path rather than the fallback.