### PR TITLE
feat(extension): Firefox async messaging fixes

### DIFF
--- a/apps/extension/entrypoints/__tests__/content.test.ts
+++ b/apps/extension/entrypoints/__tests__/content.test.ts
@@ -468,6 +468,30 @@ describe('content bridge message validation', () => {
     )
   })
 
+  it('forwards a sponsored sign_success carrying digest and executionStatus but no effects', () => {
+    const postMessage = vi
+      .spyOn(window, 'postMessage')
+      .mockImplementation(() => undefined)
+
+    content.forwardToPage({
+      id: 'sponsored-id',
+      type: 'sign_success',
+      digest: '0xdigest',
+      executionStatus: 'success',
+    })
+
+    expect(postMessage).toHaveBeenCalledWith(
+      {
+        __from: 'Eve Vault',
+        id: 'sponsored-id',
+        type: 'sign_success',
+        digest: '0xdigest',
+        executionStatus: 'success',
+      },
+      window.location.origin,
+    )
+  })
+
   it('blocks sign_success missing both bytes and digest', () => {
     const postMessage = vi
       .spyOn(window, 'postMessage')

--- a/apps/extension/entrypoints/__tests__/content.test.ts
+++ b/apps/extension/entrypoints/__tests__/content.test.ts
@@ -492,6 +492,20 @@ describe('content bridge message validation', () => {
     )
   })
 
+  it('blocks a sponsored sign_success missing executionStatus', () => {
+    const postMessage = vi
+      .spyOn(window, 'postMessage')
+      .mockImplementation(() => undefined)
+
+    content.forwardToPage({
+      id: 'sponsored-id',
+      type: 'sign_success',
+      digest: '0xdigest',
+    })
+
+    expect(postMessage).not.toHaveBeenCalled()
+  })
+
   it('blocks sign_success missing both bytes and digest', () => {
     const postMessage = vi
       .spyOn(window, 'postMessage')

--- a/apps/extension/entrypoints/content.ts
+++ b/apps/extension/entrypoints/content.ts
@@ -182,14 +182,14 @@ function isSignatureSuccess(data: Record<string, unknown>): boolean {
 
 // Sponsored transactions resolve with a digest (the txid) and an execution
 // status; unlike sign/personal-message success they carry no bytes/signature or
-// effects, so they need their own validator.
+// effects, so they need their own validator. Both fields are required because
+// the consumer (#signEveFrontierSponsoredTransaction) reads them as strings.
 function isSponsoredSuccess(data: Record<string, unknown>): boolean {
   return (
     hasStringIdAndType(data) &&
     data.type === 'sign_success' &&
     typeof data.digest === 'string' &&
-    (data.executionStatus === undefined ||
-      typeof data.executionStatus === 'string')
+    typeof data.executionStatus === 'string'
   )
 }
 

--- a/apps/extension/entrypoints/content.ts
+++ b/apps/extension/entrypoints/content.ts
@@ -180,6 +180,19 @@ function isSignatureSuccess(data: Record<string, unknown>): boolean {
   )
 }
 
+// Sponsored transactions resolve with a digest (the txid) and an execution
+// status; unlike sign/personal-message success they carry no bytes/signature or
+// effects, so they need their own validator.
+function isSponsoredSuccess(data: Record<string, unknown>): boolean {
+  return (
+    hasStringIdAndType(data) &&
+    data.type === 'sign_success' &&
+    typeof data.digest === 'string' &&
+    (data.executionStatus === undefined ||
+      typeof data.executionStatus === 'string')
+  )
+}
+
 function isSignAndExecuteSuccess(data: Record<string, unknown>): boolean {
   return (
     hasStringIdAndType(data) &&
@@ -223,6 +236,7 @@ const PUBLIC_EXTENSION_MESSAGE_VALIDATORS: readonly PageMessageValidator[] = [
   isPublicAuthSuccess,
   isPublicAuthError,
   isSignatureSuccess,
+  isSponsoredSuccess,
   isSignAndExecuteSuccess,
   isPublicSigningError,
   isPublicDisconnectResponse,

--- a/apps/extension/src/lib/adapters/SuiWallet/__tests__/index.test.ts
+++ b/apps/extension/src/lib/adapters/SuiWallet/__tests__/index.test.ts
@@ -498,12 +498,12 @@ describe('EveVaultWallet', () => {
     dispatchVaultMessage({
       type: 'sign_success',
       digest: 'digest',
-      effects: 'effects',
+      executionStatus: 'success',
     })
 
     await expect(promise).resolves.toEqual({
       digest: 'digest',
-      effects: 'effects',
+      executionStatus: 'success',
     })
   })
 
@@ -532,12 +532,12 @@ describe('EveVaultWallet', () => {
     dispatchVaultMessage({
       type: 'sign_success',
       digest: 'digest',
-      effects: 'effects',
+      executionStatus: 'success',
     })
 
     await expect(promise).resolves.toEqual({
       digest: 'digest',
-      effects: 'effects',
+      executionStatus: 'success',
     })
   })
 
@@ -560,12 +560,12 @@ describe('EveVaultWallet', () => {
     dispatchVaultMessage({
       type: 'sign_success',
       digest: 'digest',
-      effects: 'effects',
+      executionStatus: 'success',
     })
 
     await expect(promise).resolves.toEqual({
       digest: 'digest',
-      effects: 'effects',
+      executionStatus: 'success',
     })
   })
 })

--- a/apps/extension/src/lib/adapters/SuiWallet/index.ts
+++ b/apps/extension/src/lib/adapters/SuiWallet/index.ts
@@ -378,7 +378,10 @@ export class EveVaultWallet implements Wallet {
       },
       mapSuccess: (m) => ({
         digest: m.digest as string,
-        effects: m.effects as string,
+        executionStatus: m.executionStatus as string,
+        ...(typeof m.executionErrorMessage === 'string' && {
+          executionErrorMessage: m.executionErrorMessage,
+        }),
       }),
       timeoutMessage: 'Sponsored transaction timed out',
     })

--- a/apps/extension/src/lib/background/handlers/__tests__/messageHandler.test.ts
+++ b/apps/extension/src/lib/background/handlers/__tests__/messageHandler.test.ts
@@ -152,7 +152,7 @@ describe('handleMessage route policy', () => {
       sender,
       sendResponse,
     )
-    expect(result).toBe(true)
+    expect(result).toBeUndefined()
     expect(mocks.handleDappLogin).toHaveBeenCalledWith(
       { type: 'connect', id: 'connect-id' },
       sender,
@@ -313,7 +313,7 @@ describe('handleMessage route policy', () => {
     expect(sendResponse).not.toHaveBeenCalled()
   })
 
-  it('routes sponsored signing actions through the async route wrapper', () => {
+  it('routes sponsored signing actions through the out-of-band route wrapper', () => {
     const sendResponse = vi.fn()
     const sender = dappSender()
     const message = {
@@ -321,7 +321,8 @@ describe('handleMessage route policy', () => {
       id: 'sponsored-id',
       message: { action: 'mine', assembly: '1', assemblyType: 'type' },
     }
-    expect(handleMessage(message, sender, sendResponse)).toBe(true)
+    // Sponsored results are sent to the tab out-of-band, not via sendResponse.
+    expect(handleMessage(message, sender, sendResponse)).toBeUndefined()
     expect(mocks.handleSponsoredTransaction).toHaveBeenCalledWith(
       message,
       sender,

--- a/apps/extension/src/lib/background/handlers/__tests__/messageHandler.test.ts
+++ b/apps/extension/src/lib/background/handlers/__tests__/messageHandler.test.ts
@@ -345,6 +345,55 @@ describe('handleMessage route policy', () => {
     })
   })
 
+  it('skips the auth_error fallback when a throwing ext_login has no id', async () => {
+    const sendResponse = vi.fn()
+    mocks.handleExtLogin.mockRejectedValueOnce(new Error('boom'))
+
+    handleMessage({ action: 'ext_login' }, extensionSender(), sendResponse)
+
+    // No id means the popup listener could not correlate a response anyway.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(mocks.sendAuthError).not.toHaveBeenCalled()
+  })
+
+  it('routes sign_personal_message and sign_and_execute actions from tab senders', () => {
+    const sendResponse = vi.fn()
+    const sender = dappSender()
+
+    for (const action of [
+      WalletStandardMessageTypes.SIGN_PERSONAL_MESSAGE,
+      WalletStandardMessageTypes.SIGN_AND_EXECUTE_TRANSACTION,
+    ]) {
+      mocks.handleApprovePopup.mockClear()
+      expect(
+        handleMessage({ action, id: 'sign-id' }, sender, sendResponse),
+      ).toBe(true)
+      expect(mocks.handleApprovePopup).toHaveBeenCalledWith(
+        { action, id: 'sign-id' },
+        sender,
+        sendResponse,
+      )
+    }
+  })
+
+  it('routes web_unlock from extension senders through the out-of-band wrapper', () => {
+    const sendResponse = vi.fn()
+    const sender = extensionSender()
+
+    const result = handleMessage(
+      { action: 'web_unlock', id: 'web-id' },
+      sender,
+      sendResponse,
+    )
+
+    expect(result).toBeUndefined()
+    expect(mocks.handleWebUnlock).toHaveBeenCalledWith(
+      { action: 'web_unlock', id: 'web-id' },
+      sender,
+      sendResponse,
+    )
+  })
+
   it('routes sponsored signing actions through the out-of-band route wrapper', () => {
     const sendResponse = vi.fn()
     const sender = dappSender()

--- a/apps/extension/src/lib/background/handlers/__tests__/messageHandler.test.ts
+++ b/apps/extension/src/lib/background/handlers/__tests__/messageHandler.test.ts
@@ -31,6 +31,7 @@ const { logger, mocks } = vi.hoisted(() => ({
     handleLocalnetSetKeypair: vi.fn(),
     handleLocalnetGetAddress: vi.fn(),
     handleLocalnetSignBytes: vi.fn(),
+    sendAuthError: vi.fn(),
   },
 }))
 
@@ -52,6 +53,17 @@ vi.mock('@/lib/background/handlers/authHandlers', () => ({
   handleExtLogin: mocks.handleExtLogin,
   handleWebUnlock: mocks.handleWebUnlock,
 }))
+
+vi.mock(
+  '@/lib/background/handlers/auth/authHelpers',
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import('@/lib/background/handlers/auth/authHelpers')
+      >()
+    return { ...actual, sendAuthError: mocks.sendAuthError }
+  },
+)
 
 vi.mock('@/lib/background/handlers/walletHandlers', () => ({
   handleApprovePopup: mocks.handleApprovePopup,
@@ -311,6 +323,26 @@ describe('handleMessage route policy', () => {
     )
     expect(mocks.getDappRequestContext).not.toHaveBeenCalled()
     expect(sendResponse).not.toHaveBeenCalled()
+  })
+
+  it('sends a correlated auth_error when ext_login throws unexpectedly', async () => {
+    const sendResponse = vi.fn()
+    mocks.handleExtLogin.mockRejectedValueOnce(new Error('boom'))
+
+    const result = handleMessage(
+      { action: 'ext_login', id: 'ext-id' },
+      extensionSender(),
+      sendResponse,
+    )
+
+    // Channel closes immediately; the failure is reported out-of-band so the
+    // popup listener (which has no timeout) still settles.
+    expect(result).toBeUndefined()
+    await vi.waitFor(() => {
+      expect(mocks.sendAuthError).toHaveBeenCalledWith('ext-id', {
+        message: 'boom',
+      })
+    })
   })
 
   it('routes sponsored signing actions through the out-of-band route wrapper', () => {

--- a/apps/extension/src/lib/background/handlers/messageHandler.ts
+++ b/apps/extension/src/lib/background/handlers/messageHandler.ts
@@ -11,6 +11,7 @@ import type {
   WalletActionMessage,
   WebUnlockMessage,
 } from '@/lib/background/types'
+import { sendAuthError } from './auth/authHelpers'
 import {
   handleDappLogin,
   handleExtLogin,
@@ -174,7 +175,15 @@ const MESSAGE_ROUTES: Record<string, MessageRoute> = {
   [routeKey('action', 'ext_login')]: {
     access: 'extension',
     handle: (m, s, sr) =>
-      runOutOfBandRoute('handleExtLogin', handleExtLogin(m, s, sr)),
+      runOutOfBandRoute('handleExtLogin', handleExtLogin(m, s, sr), (error) => {
+        // The channel is already closed, so an unexpected throw before the
+        // handler sends its own auth_success/auth_error would hang the popup
+        // (extensionLogin has no timeout). Send a correlated auth_error so the
+        // waiting listener settles.
+        if (typeof m.id === 'string') {
+          sendAuthError(m.id, { message: getErrorMessage(error) })
+        }
+      }),
   },
   // Wallet Standard connect arrives as type='connect', not action='connect'.
   [routeKey('type', 'connect')]: {

--- a/apps/extension/src/lib/background/handlers/messageHandler.ts
+++ b/apps/extension/src/lib/background/handlers/messageHandler.ts
@@ -180,7 +180,7 @@ const MESSAGE_ROUTES: Record<string, MessageRoute> = {
   [routeKey('type', 'connect')]: {
     access: 'dapp',
     handle: (m, s, sr, tabId) =>
-      runAsyncRoute('handleDappLogin', handleDappLogin(m, s, sr, tabId)),
+      runOutOfBandRoute('handleDappLogin', handleDappLogin(m, s, sr, tabId)),
   },
   [routeKey('type', WalletStandardMessageTypes.DISCONNECT)]: {
     access: 'dapp',
@@ -199,7 +199,7 @@ const MESSAGE_ROUTES: Record<string, MessageRoute> = {
   [routeKey('action', 'web_unlock')]: {
     access: 'extension',
     handle: (m, s, sr) =>
-      runAsyncRoute(
+      runOutOfBandRoute(
         'handleWebUnlock',
         handleWebUnlock(m as WebUnlockMessage, s, sr),
       ),
@@ -223,7 +223,7 @@ const MESSAGE_ROUTES: Record<string, MessageRoute> = {
   )]: {
     access: 'dapp',
     handle: (m, s, sr) =>
-      runAsyncRoute(
+      runOutOfBandRoute(
         'handleSponsoredTransaction',
         handleSponsoredTransaction(
           m as EveFrontierSponsoredTransactionMessage,

--- a/apps/extension/src/lib/background/handlers/messageHandler.ts
+++ b/apps/extension/src/lib/background/handlers/messageHandler.ts
@@ -84,6 +84,24 @@ function runAsyncRoute(
 }
 
 /**
+ * Starts an async route whose result is delivered out-of-band via a separate
+ * runtime.sendMessage, so it returns undefined to close the message channel
+ * immediately. Firefox rejects the sender's sendMessage when a listener claims
+ * an async response by returning true but never calls sendResponse.
+ */
+function runOutOfBandRoute(
+  name: string,
+  task: Promise<unknown>,
+  onError?: (error: unknown) => void,
+): undefined {
+  void task.catch((error) => {
+    log.error(`${name} failed`, error)
+    onError?.(error)
+  })
+  return undefined
+}
+
+/**
  * Sends a disconnect result through the immediate runtime response and, when
  * the request came from a tab, mirrors it back through the content-script path.
  */
@@ -156,7 +174,7 @@ const MESSAGE_ROUTES: Record<string, MessageRoute> = {
   [routeKey('action', 'ext_login')]: {
     access: 'extension',
     handle: (m, s, sr) =>
-      runAsyncRoute('handleExtLogin', handleExtLogin(m, s, sr)),
+      runOutOfBandRoute('handleExtLogin', handleExtLogin(m, s, sr)),
   },
   // Wallet Standard connect arrives as type='connect', not action='connect'.
   [routeKey('type', 'connect')]: {

--- a/apps/extension/src/lib/background/handlers/sponsoredTransactionHandler.ts
+++ b/apps/extension/src/lib/background/handlers/sponsoredTransactionHandler.ts
@@ -65,7 +65,7 @@ function sendSponsoredError(
 }
 
 // POSTs the signed sponsored transaction to the backend execute endpoint and
-// forwards the digest/effects back to the originating tab on success.
+// forwards the digest/executionStatus back to the originating tab on success.
 async function executeSponsoredTx({
   apiBaseUrl,
   tenant,
@@ -76,14 +76,14 @@ async function executeSponsoredTx({
   messageId,
 }: ExecuteSponsoredTxOptions): Promise<void> {
   try {
-    const { digest, effects } = await executeSponsoredTransaction(
+    const { digest, executionStatus } = await executeSponsoredTransaction(
       { preparationId, userSignatureB64Bytes: zkSignature },
       sponsoredApiContext(apiBaseUrl, tenant, idToken),
     )
     sendToTab(senderTabId, {
       type: 'sign_success',
       digest,
-      effects,
+      executionStatus,
       id: messageId,
     })
   } catch (err) {

--- a/apps/extension/src/lib/background/messaging/tabMessaging.ts
+++ b/apps/extension/src/lib/background/messaging/tabMessaging.ts
@@ -28,6 +28,7 @@ type SignSuccessMessage = {
   signature?: string
   digest?: string
   effects?: string
+  executionStatus?: string
 }
 type SignAndExecuteSuccessMessage = {
   type: 'sign_and_execute_transaction_success'

--- a/packages/shared/src/auth/stores/authStore.ts
+++ b/packages/shared/src/auth/stores/authStore.ts
@@ -86,14 +86,27 @@ export const useAuthStore = create<AuthState>()(
             }
 
             const id = crypto.randomUUID()
+
+            // The id-correlated listener is the source of truth: the background
+            // delivers the result out-of-band via a separate sendMessage. Settle
+            // once so a send-dispatch rejection can't clobber a delivered result.
+            let settled = false
             const authSuccessListener = createExtensionAuthListener(
               id,
-              resolve,
-              reject,
+              (value) => {
+                settled = true
+                resolve(value)
+              },
+              (reason) => {
+                settled = true
+                reject(reason)
+              },
             )
             runtime.onMessage?.addListener(authSuccessListener)
 
-            // Reject on send failure so the caller doesn't hang; drop the listener.
+            // A send-dispatch failure means the background never received the
+            // request, so reject to avoid hanging. Skip if the listener already
+            // settled us: Firefox can reject the send even when delivery succeeded.
             Promise.resolve(
               runtime.sendMessage({
                 action: 'ext_login',
@@ -101,6 +114,7 @@ export const useAuthStore = create<AuthState>()(
                 tenantId: getCurrentTenantId(),
               }),
             ).catch((error) => {
+              if (settled) return
               runtime.onMessage?.removeListener(authSuccessListener)
               reject(error)
             })


### PR DESCRIPTION
Firefox has no offscreen API and rejects `onMessage` listeners that claim an async response but never send one — both required changes to the keeper and background messaging layers.

## Changes
- **Out-of-band message routes** — routes that reply via a separate message (`ext_login`, `connect`, sponsored, `web_unlock`) now close the channel instead of returning `true`, fixing Firefox's `Promised response … went out of scope` rejection (surfaced as an `AuthError`). `ext_login` reports unexpected failures out-of-band so the popup can't hang.
- **Login listener** — the id-correlated `extensionLogin` listener is now authoritative over a spurious send rejection.
- **Sponsored tx digest** — wallet-core 0.0.7 dropped `effects` from the execute result, so the content-script guard silently dropped `sign_success` and the digest never reached the dapp. Forward `{ digest, executionStatus }` end to end.