### PR TITLE
feat: add simulate transaction to approval popup

### DIFF
--- a/apps/extension/CHANGELOG.md
+++ b/apps/extension/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @evevault/extension
 
+## 0.0.17
+
+### Patch Changes
+
+- add transaction simulation to extension approval
+- Updated dependencies
+  - @evevault/shared@0.0.17
+
 ## 0.0.16
 
 ### Patch Changes

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evevault/extension",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "type": "module",
   "scripts": {
     "dev": "wxt",

--- a/apps/extension/src/features/wallet/components/ApprovalTabs.tsx
+++ b/apps/extension/src/features/wallet/components/ApprovalTabs.tsx
@@ -24,8 +24,8 @@ export function ApprovalTabs({
   const active = tabs.find((tab) => tab.id === activeId) ?? tabs[0]
 
   return (
-    <div className="w-[80vw] max-w-full border border-[var(--matter-05)]">
-      <div role="tablist" className="flex border-b border-[var(--matter-05)]">
+    <div className="w-[80vw] max-w-full border border-(--matter-05)">
+      <div role="tablist" className="flex border-b border-(--matter-05)">
         {tabs.map((tab) => {
           const isActive = tab.id === active?.id
           const tone =

--- a/apps/extension/src/features/wallet/components/ApprovalTabs.tsx
+++ b/apps/extension/src/features/wallet/components/ApprovalTabs.tsx
@@ -1,0 +1,56 @@
+import { type ReactNode, useState } from 'react'
+
+export type ApprovalTab = {
+  id: string
+  label: string
+  /** `danger` tints the tab label so warnings stay noticeable when not front. */
+  tone?: 'default' | 'danger'
+  content: ReactNode
+}
+
+/**
+ * Compact tabbed container for the approval popup. Only the active tab's body
+ * is mounted, so the popup stays a fixed, short height regardless of how much
+ * the simulation or payload returns.
+ */
+export function ApprovalTabs({
+  tabs,
+  initialId,
+}: {
+  tabs: ApprovalTab[]
+  initialId?: string
+}) {
+  const [activeId, setActiveId] = useState(initialId ?? tabs[0]?.id)
+  const active = tabs.find((tab) => tab.id === activeId) ?? tabs[0]
+
+  return (
+    <div className="w-[80vw] max-w-full border border-[var(--matter-05)]">
+      <div role="tablist" className="flex border-b border-[var(--matter-05)]">
+        {tabs.map((tab) => {
+          const isActive = tab.id === active?.id
+          const tone =
+            tab.tone === 'danger' ? 'text-(--error)' : 'text-(--grey-neutral)'
+          return (
+            <button
+              key={tab.id}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => setActiveId(tab.id)}
+              className={`-mb-px flex-1 border-b-2 px-2 py-1.5 text-[11px] uppercase tracking-wide transition-colors ${
+                isActive
+                  ? 'border-(--neutral) text-(--neutral)'
+                  : `border-transparent ${tone}`
+              }`}
+            >
+              {tab.label}
+            </button>
+          )
+        })}
+      </div>
+      <div role="tabpanel" className="max-h-60 overflow-y-auto p-2 text-left">
+        {active?.content}
+      </div>
+    </div>
+  )
+}

--- a/apps/extension/src/features/wallet/components/SignSponsoredTransaction.tsx
+++ b/apps/extension/src/features/wallet/components/SignSponsoredTransaction.tsx
@@ -3,13 +3,18 @@ import Json from '@evevault/shared/components/Json'
 import type { PendingSponsoredTransaction } from '@evevault/shared/types'
 import { createLogger, parseTransactionBytes } from '@evevault/shared/utils'
 import { useWalletSigningContext } from '@evevault/shared/wallet'
-import { usePendingSignAction } from '@/features/wallet/hooks'
+import {
+  usePendingSignAction,
+  useTransactionSimulation,
+} from '@/features/wallet/hooks'
 import {
   requiresAcknowledgement,
   reviewTransaction,
 } from '../transactionRiskReview'
+import { type ApprovalTab, ApprovalTabs } from './ApprovalTabs'
 import { SignRequestView } from './SignRequestView'
 import { TransactionRiskPanel } from './TransactionRiskPanel'
+import { TransactionSimulationPanel } from './TransactionSimulationPanel'
 
 const log = createLogger()
 
@@ -75,7 +80,14 @@ function SponsoredDetail({
 }
 
 function SignSponsoredTransaction() {
-  const { isLocalnet, sign } = useWalletSigningContext()
+  const {
+    isLocalnet,
+    sign,
+    suiClient,
+    chain,
+    getSenderAddress,
+    senderAddress,
+  } = useWalletSigningContext()
   const {
     pending,
     loading,
@@ -137,6 +149,55 @@ function SignSponsoredTransaction() {
 
   const riskFindings = pending ? reviewTransaction(pending.reviewValue) : []
 
+  // The sponsored bytes are already fully built (sender + sponsor gas), so
+  // simulate them as-is rather than rebuilding, which would drop the sponsor.
+  const simulation = useTransactionSimulation({
+    payload: pending?.sponsoredTxB64 ?? null,
+    mode: 'bytes',
+    suiClient,
+    chain,
+    getSenderAddress,
+    fallbackSender: senderAddress ?? undefined,
+  })
+
+  const predictedFailure =
+    simulation?.status === 'ready' && simulation.simulation.status === 'failure'
+  const needsRiskAck = requiresAcknowledgement(riskFindings)
+
+  const tabs: ApprovalTab[] = [
+    {
+      id: 'outcome',
+      label: 'Outcome',
+      content: (
+        <TransactionSimulationPanel
+          state={simulation}
+          senderAddress={senderAddress ?? undefined}
+        />
+      ),
+    },
+    ...(riskFindings.length > 0
+      ? [
+          {
+            id: 'warnings',
+            label: `Warnings (${riskFindings.length})`,
+            tone: needsRiskAck ? ('danger' as const) : ('default' as const),
+            content: <TransactionRiskPanel findings={riskFindings} />,
+          },
+        ]
+      : []),
+    ...(pending?.displayValue
+      ? [
+          {
+            id: 'payload',
+            label: 'Payload',
+            content: (
+              <Json value={pending.displayValue} className="max-h-52 text-xs" />
+            ),
+          },
+        ]
+      : []),
+  ]
+
   return (
     <SignRequestView
       auth={auth}
@@ -148,7 +209,7 @@ function SignSponsoredTransaction() {
       chain={pending?.chain}
       dapp={pending?.dapp}
       requestKind="Sponsored transaction"
-      requireAcknowledgement={requiresAcknowledgement(riskFindings)}
+      requireAcknowledgement={needsRiskAck || predictedFailure}
       onApprove={handleApprove}
       onReject={handleReject}
     >
@@ -175,16 +236,7 @@ function SignSponsoredTransaction() {
           </div>
         </div>
 
-        <TransactionRiskPanel findings={riskFindings} />
-
-        {pending?.displayValue && (
-          <>
-            <Text size="small" color="grey-neutral">
-              Transaction payload
-            </Text>
-            <Json value={pending.displayValue} className="max-h-36 text-xs" />
-          </>
-        )}
+        {pending && <ApprovalTabs tabs={tabs} />}
       </div>
     </SignRequestView>
   )

--- a/apps/extension/src/features/wallet/components/SignSponsoredTransaction.tsx
+++ b/apps/extension/src/features/wallet/components/SignSponsoredTransaction.tsx
@@ -8,6 +8,7 @@ import {
   useTransactionSimulation,
 } from '@/features/wallet/hooks'
 import {
+  PREDICTED_FAILURE_ACKNOWLEDGEMENT,
   requiresAcknowledgement,
   reviewTransaction,
 } from '../transactionRiskReview'
@@ -172,6 +173,7 @@ function SignSponsoredTransaction() {
         <TransactionSimulationPanel
           state={simulation}
           senderAddress={senderAddress ?? undefined}
+          gasPaidBySponsor
         />
       ),
     },
@@ -210,6 +212,11 @@ function SignSponsoredTransaction() {
       dapp={pending?.dapp}
       requestKind="Sponsored transaction"
       requireAcknowledgement={needsRiskAck || predictedFailure}
+      acknowledgementLabel={
+        predictedFailure && !needsRiskAck
+          ? PREDICTED_FAILURE_ACKNOWLEDGEMENT
+          : undefined
+      }
       onApprove={handleApprove}
       onReject={handleReject}
     >

--- a/apps/extension/src/features/wallet/components/SignTransactionFlow.tsx
+++ b/apps/extension/src/features/wallet/components/SignTransactionFlow.tsx
@@ -1,6 +1,9 @@
-import { Text } from '@evevault/shared/components'
 import Json from '@evevault/shared/components/Json'
-import { useTransactionSigning } from '@/features/wallet/hooks'
+import { useWalletSigningContext } from '@evevault/shared/wallet'
+import {
+  useTransactionSigning,
+  useTransactionSimulation,
+} from '@/features/wallet/hooks'
 import type {
   SignResult,
   StoreResult,
@@ -9,18 +12,25 @@ import {
   requiresAcknowledgement,
   reviewTransaction,
 } from '../transactionRiskReview'
+import { type ApprovalTab, ApprovalTabs } from './ApprovalTabs'
 import { SignRequestView } from './SignRequestView'
 import { TransactionRiskPanel } from './TransactionRiskPanel'
+import { TransactionSimulationPanel } from './TransactionSimulationPanel'
 
 interface SignTransactionFlowProps {
   title: string
   onSign: (result: SignResult, storeResult: StoreResult) => Promise<void>
 }
 
+const PREDICTED_FAILURE_ACKNOWLEDGEMENT =
+  'This transaction is expected to fail on-chain. I understand and want to approve anyway.'
+
 export function SignTransactionFlow({
   title,
   onSign,
 }: SignTransactionFlowProps) {
+  const { suiClient, chain, getSenderAddress, senderAddress } =
+    useWalletSigningContext()
   const {
     pendingTransaction,
     loading,
@@ -31,10 +41,62 @@ export function SignTransactionFlow({
     storeResult,
   } = useTransactionSigning()
 
+  const simulation = useTransactionSimulation({
+    payload: pendingTransaction?.transaction ?? null,
+    mode: 'build',
+    suiClient,
+    chain,
+    getSenderAddress,
+    fallbackSender: pendingTransaction?.account?.address,
+  })
+
   const handleApprove = () =>
     withSigning((result) => onSign(result, storeResult))
   const riskFindings = pendingTransaction
     ? reviewTransaction(pendingTransaction.reviewValue)
+    : []
+
+  // A simulated on-chain failure is a danger signal in its own right, so gate
+  // approval behind the acknowledgement even when the static review is clean.
+  const predictedFailure =
+    simulation?.status === 'ready' && simulation.simulation.status === 'failure'
+  const needsRiskAck = requiresAcknowledgement(riskFindings)
+
+  const tabs: ApprovalTab[] = pendingTransaction
+    ? [
+        {
+          id: 'outcome',
+          label: 'Outcome',
+          content: (
+            <TransactionSimulationPanel
+              state={simulation}
+              senderAddress={
+                senderAddress ?? pendingTransaction.account?.address
+              }
+            />
+          ),
+        },
+        ...(riskFindings.length > 0
+          ? [
+              {
+                id: 'warnings',
+                label: `Warnings (${riskFindings.length})`,
+                tone: needsRiskAck ? ('danger' as const) : ('default' as const),
+                content: <TransactionRiskPanel findings={riskFindings} />,
+              },
+            ]
+          : []),
+        {
+          id: 'payload',
+          label: 'Payload',
+          content: (
+            <Json
+              value={pendingTransaction.displayValue}
+              className="max-h-52 text-xs"
+            />
+          ),
+        },
+      ]
     : []
 
   return (
@@ -47,22 +109,20 @@ export function SignTransactionFlow({
       loadingMessage="Loading transaction..."
       chain={pendingTransaction?.chain}
       dapp={pendingTransaction?.dapp}
-      accountAddress={pendingTransaction?.account.address}
+      accountAddress={senderAddress ?? pendingTransaction?.account?.address}
       requestKind={title}
-      requireAcknowledgement={requiresAcknowledgement(riskFindings)}
+      requireAcknowledgement={needsRiskAck || predictedFailure}
+      acknowledgementLabel={
+        predictedFailure && !needsRiskAck
+          ? PREDICTED_FAILURE_ACKNOWLEDGEMENT
+          : undefined
+      }
       onApprove={handleApprove}
       onReject={handleReject}
     >
       {pendingTransaction && (
         <div className="flex w-full flex-col items-center gap-2">
-          <TransactionRiskPanel findings={riskFindings} />
-          <Text size="small" color="grey-neutral">
-            Transaction payload
-          </Text>
-          <Json
-            value={pendingTransaction.displayValue}
-            className="max-h-36 text-xs"
-          />
+          <ApprovalTabs tabs={tabs} />
         </div>
       )}
     </SignRequestView>

--- a/apps/extension/src/features/wallet/components/SignTransactionFlow.tsx
+++ b/apps/extension/src/features/wallet/components/SignTransactionFlow.tsx
@@ -9,6 +9,7 @@ import type {
   StoreResult,
 } from '@/features/wallet/hooks/useTransactionSigning'
 import {
+  PREDICTED_FAILURE_ACKNOWLEDGEMENT,
   requiresAcknowledgement,
   reviewTransaction,
 } from '../transactionRiskReview'
@@ -21,9 +22,6 @@ interface SignTransactionFlowProps {
   title: string
   onSign: (result: SignResult, storeResult: StoreResult) => Promise<void>
 }
-
-const PREDICTED_FAILURE_ACKNOWLEDGEMENT =
-  'This transaction is expected to fail on-chain. I understand and want to approve anyway.'
 
 export function SignTransactionFlow({
   title,

--- a/apps/extension/src/features/wallet/components/TransactionRiskPanel.tsx
+++ b/apps/extension/src/features/wallet/components/TransactionRiskPanel.tsx
@@ -9,32 +9,27 @@ export function TransactionRiskPanel({
   if (findings.length === 0) return null
 
   return (
-    <div className="w-[80vw] max-h-32 overflow-y-auto border border-[var(--matter-05)] p-2 text-left">
-      <Text size="small" color="grey-neutral">
-        Transaction warnings
-      </Text>
-      <div className="mt-2 flex flex-col gap-2">
-        {[...findings]
-          .sort(
-            (a, b) =>
-              (a.severity === 'danger' ? 0 : 1) -
-              (b.severity === 'danger' ? 0 : 1),
-          )
-          .map((finding) => (
-            <div key={`${finding.severity}:${finding.title}`}>
-              <Text
-                size="small"
-                variant="bold"
-                color={finding.severity === 'danger' ? 'error' : 'neutral'}
-              >
-                {finding.title}
-              </Text>
-              <Text size="xsmall" color="grey-neutral">
-                {finding.detail}
-              </Text>
-            </div>
-          ))}
-      </div>
+    <div className="flex flex-col gap-2">
+      {[...findings]
+        .sort(
+          (a, b) =>
+            (a.severity === 'danger' ? 0 : 1) -
+            (b.severity === 'danger' ? 0 : 1),
+        )
+        .map((finding) => (
+          <div key={`${finding.severity}:${finding.title}`}>
+            <Text
+              size="small"
+              variant="bold"
+              color={finding.severity === 'danger' ? 'error' : 'neutral'}
+            >
+              {finding.title}
+            </Text>
+            <Text size="xsmall" color="grey-neutral">
+              {finding.detail}
+            </Text>
+          </div>
+        ))}
     </div>
   )
 }

--- a/apps/extension/src/features/wallet/components/TransactionSimulationPanel.tsx
+++ b/apps/extension/src/features/wallet/components/TransactionSimulationPanel.tsx
@@ -1,6 +1,6 @@
 import { Text } from '@evevault/shared/components'
 import Json from '@evevault/shared/components/Json'
-import { formatAddress } from '@evevault/shared/utils'
+import { formatAddress, formatDisplayAmount } from '@evevault/shared/utils'
 import type {
   SimulatedBalanceChange,
   SimulatedEvent,
@@ -45,7 +45,7 @@ function BalanceChangeRow({ change }: { change: SimulatedBalanceChange }) {
       color={change.isDebit ? 'neutral' : 'success'}
     >
       {sign}
-      {change.amount} {change.symbol}
+      {formatDisplayAmount(change.amount, 9)} {change.symbol}
     </Text>
   )
 }
@@ -165,7 +165,7 @@ function OutcomeBody({
       )}
       <InfoRow
         label="Gas fee"
-        value={`${simulation.gas.net} SUI${
+        value={`${formatDisplayAmount(simulation.gas.net, 9)} SUI${
           gasPaidBySponsor ? ' · paid by sponsor' : ''
         }`}
       />

--- a/apps/extension/src/features/wallet/components/TransactionSimulationPanel.tsx
+++ b/apps/extension/src/features/wallet/components/TransactionSimulationPanel.tsx
@@ -111,7 +111,21 @@ function ObjectChangeRow({
   )
 }
 
+// Decoded Move struct data can contain bigints (u64/u128) that plain
+// JSON.stringify throws on; coerce them to strings and swallow any residual
+// serialization failure so one odd event can't crash the whole panel.
+function safeJson(value: unknown): string | null {
+  try {
+    return JSON.stringify(value, (_, v) =>
+      typeof v === 'bigint' ? v.toString() : v,
+    )
+  } catch {
+    return null
+  }
+}
+
 function EventRow({ event }: { event: SimulatedEvent }) {
+  const json = event.json != null ? safeJson(event.json) : null
   return (
     <div className="flex flex-col gap-0.5">
       <span
@@ -120,12 +134,7 @@ function EventRow({ event }: { event: SimulatedEvent }) {
       >
         {event.label}
       </span>
-      {event.json != null && (
-        <Json
-          value={JSON.stringify(event.json)}
-          className="max-h-24 text-[10px]"
-        />
-      )}
+      {json && <Json value={json} className="max-h-24 text-[10px]" />}
     </div>
   )
 }
@@ -133,9 +142,11 @@ function EventRow({ event }: { event: SimulatedEvent }) {
 function OutcomeBody({
   simulation,
   senderAddress,
+  gasPaidBySponsor,
 }: {
   simulation: TransactionSimulation
   senderAddress?: string
+  gasPaidBySponsor?: boolean
 }) {
   const failed = simulation.status === 'failure'
   return (
@@ -152,7 +163,12 @@ function OutcomeBody({
       {simulation.digest && (
         <InfoRow label="Digest" value={simulation.digest} />
       )}
-      <InfoRow label="Gas fee" value={`${simulation.gas.net} SUI`} />
+      <InfoRow
+        label="Gas fee"
+        value={`${simulation.gas.net} SUI${
+          gasPaidBySponsor ? ' · paid by sponsor' : ''
+        }`}
+      />
 
       {!failed && (
         <div className="flex flex-col gap-1">
@@ -202,9 +218,11 @@ function OutcomeBody({
 export function TransactionSimulationPanel({
   state,
   senderAddress,
+  gasPaidBySponsor,
 }: {
   state: SimulationState | null
   senderAddress?: string
+  gasPaidBySponsor?: boolean
 }) {
   if (!state || state.status === 'loading') {
     return (
@@ -236,6 +254,7 @@ export function TransactionSimulationPanel({
       <OutcomeBody
         simulation={state.simulation}
         senderAddress={senderAddress}
+        gasPaidBySponsor={gasPaidBySponsor}
       />
     </PanelShell>
   )

--- a/apps/extension/src/features/wallet/components/TransactionSimulationPanel.tsx
+++ b/apps/extension/src/features/wallet/components/TransactionSimulationPanel.tsx
@@ -1,0 +1,242 @@
+import { Text } from '@evevault/shared/components'
+import Json from '@evevault/shared/components/Json'
+import { formatAddress } from '@evevault/shared/utils'
+import type {
+  SimulatedBalanceChange,
+  SimulatedEvent,
+  SimulatedObjectChange,
+  TransactionSimulation,
+} from '@evevault/shared/wallet'
+import type { SimulationState } from '@/features/wallet/hooks'
+
+// The tab that hosts this content supplies the border and heading, so the
+// panel itself is just a vertical stack.
+function PanelShell({ children }: { children: React.ReactNode }) {
+  return <div className="flex flex-col gap-2">{children}</div>
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <Text size="xsmall" color="grey-neutral">
+      {children}
+    </Text>
+  )
+}
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="grid grid-cols-[72px_minmax(0,1fr)] gap-2 items-baseline">
+      <span className="text-[10px] uppercase text-(--grey-neutral)">
+        {label}
+      </span>
+      <span className="text-xs leading-4 text-(--neutral) break-all">
+        {value}
+      </span>
+    </div>
+  )
+}
+
+function BalanceChangeRow({ change }: { change: SimulatedBalanceChange }) {
+  const sign = change.isDebit ? '−' : '+'
+  return (
+    <Text
+      size="small"
+      variant="bold"
+      color={change.isDebit ? 'neutral' : 'success'}
+    >
+      {sign}
+      {change.amount} {change.symbol}
+    </Text>
+  )
+}
+
+// Turns an owner display token (address | shared | immutable | object:0x…)
+// into a short label, showing "you" for the signing account.
+function formatOwner(
+  token: string | undefined,
+  senderAddress?: string,
+): string | undefined {
+  if (!token) return undefined
+  if (token === 'shared' || token === 'immutable') return token
+  if (token.startsWith('object:')) {
+    return `object ${formatAddress(token.slice('object:'.length), 6, 4)}`
+  }
+  if (senderAddress && token.toLowerCase() === senderAddress.toLowerCase()) {
+    return 'you'
+  }
+  return formatAddress(token, 6, 4)
+}
+
+function ownerTransition(
+  change: SimulatedObjectChange,
+  senderAddress?: string,
+): string | undefined {
+  const before = formatOwner(change.ownerBefore, senderAddress)
+  const after = formatOwner(change.ownerAfter, senderAddress)
+  if (before && after) return `${before} → ${after}`
+  if (after) return `owner: ${after}`
+  return undefined
+}
+
+// Renders "0x12ab… · struct" plus, when meaningful, the ownership transition.
+function ObjectChangeRow({
+  change,
+  senderAddress,
+}: {
+  change: SimulatedObjectChange
+  senderAddress?: string
+}) {
+  const shortType = change.objectType?.split('::').pop()
+  const owner = ownerTransition(change, senderAddress)
+  return (
+    <div className="grid grid-cols-[64px_minmax(0,1fr)] gap-2 items-baseline">
+      <span className="text-[10px] uppercase text-(--grey-neutral)">
+        {change.kind}
+      </span>
+      <div className="flex flex-col gap-0.5 min-w-0">
+        <span
+          className="text-xs leading-4 text-(--neutral) truncate"
+          title={`${change.objectId}${change.objectType ? `\n${change.objectType}` : ''}`}
+        >
+          {formatAddress(change.objectId, 6, 4)}
+          {shortType ? ` · ${shortType}` : ''}
+        </span>
+        {owner && (
+          <span className="text-[10px] leading-3 text-(--grey-neutral) truncate">
+            {owner}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function EventRow({ event }: { event: SimulatedEvent }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span
+        className="text-xs leading-4 text-(--neutral) truncate"
+        title={event.type}
+      >
+        {event.label}
+      </span>
+      {event.json != null && (
+        <Json
+          value={JSON.stringify(event.json)}
+          className="max-h-24 text-[10px]"
+        />
+      )}
+    </div>
+  )
+}
+
+function OutcomeBody({
+  simulation,
+  senderAddress,
+}: {
+  simulation: TransactionSimulation
+  senderAddress?: string
+}) {
+  const failed = simulation.status === 'failure'
+  return (
+    <>
+      <Text size="small" variant="bold" color={failed ? 'error' : 'success'}>
+        {failed ? 'Expected to fail' : 'Expected to succeed'}
+      </Text>
+      {failed && simulation.error && (
+        <Text size="xsmall" color="grey-neutral">
+          {simulation.error}
+        </Text>
+      )}
+
+      {simulation.digest && (
+        <InfoRow label="Digest" value={simulation.digest} />
+      )}
+      <InfoRow label="Gas fee" value={`${simulation.gas.net} SUI`} />
+
+      {!failed && (
+        <div className="flex flex-col gap-1">
+          <SectionLabel>Balance changes</SectionLabel>
+          {simulation.balanceChanges.length === 0 ? (
+            <Text size="small" color="neutral">
+              None
+            </Text>
+          ) : (
+            simulation.balanceChanges.map((change) => (
+              <BalanceChangeRow
+                key={`${change.coinType}:${change.isDebit}:${change.amount}`}
+                change={change}
+              />
+            ))
+          )}
+        </div>
+      )}
+
+      {simulation.changedObjects.length > 0 && (
+        <div className="flex flex-col gap-1">
+          <SectionLabel>
+            Changed objects ({simulation.changedObjects.length})
+          </SectionLabel>
+          {simulation.changedObjects.map((change) => (
+            <ObjectChangeRow
+              key={change.objectId}
+              change={change}
+              senderAddress={senderAddress}
+            />
+          ))}
+        </div>
+      )}
+
+      {simulation.events.length > 0 && (
+        <div className="flex flex-col gap-1">
+          <SectionLabel>Events ({simulation.events.length})</SectionLabel>
+          {simulation.events.map((event, i) => (
+            <EventRow key={`${event.type}:${i}`} event={event} />
+          ))}
+        </div>
+      )}
+    </>
+  )
+}
+
+export function TransactionSimulationPanel({
+  state,
+  senderAddress,
+}: {
+  state: SimulationState | null
+  senderAddress?: string
+}) {
+  if (!state || state.status === 'loading') {
+    return (
+      <PanelShell>
+        <Text size="small" color="grey-neutral">
+          Simulating transaction…
+        </Text>
+      </PanelShell>
+    )
+  }
+
+  if (state.status === 'unavailable') {
+    return (
+      <PanelShell>
+        <Text size="small" color="error">
+          Could not simulate this transaction. Approve with caution.
+        </Text>
+        {state.reason && (
+          <Text size="xsmall" color="grey-neutral">
+            {state.reason}
+          </Text>
+        )}
+      </PanelShell>
+    )
+  }
+
+  return (
+    <PanelShell>
+      <OutcomeBody
+        simulation={state.simulation}
+        senderAddress={senderAddress}
+      />
+    </PanelShell>
+  )
+}

--- a/apps/extension/src/features/wallet/components/__tests__/SignExecuteTransaction.test.tsx
+++ b/apps/extension/src/features/wallet/components/__tests__/SignExecuteTransaction.test.tsx
@@ -13,11 +13,16 @@ const {
 
 vi.mock('@/features/wallet/hooks', () => ({
   useTransactionSigning: mockUseTransactionSigning,
+  useTransactionSimulation: () => null,
 }))
 
 vi.mock('@evevault/shared/wallet', () => ({
   useWalletSigningContext: mockUseWalletSigningContext,
   ADDRESS_ALIAS_MODULE: mockAddressAliasModule,
+}))
+
+vi.mock('@/features/wallet/components/TransactionSimulationPanel', () => ({
+  TransactionSimulationPanel: () => null,
 }))
 
 vi.mock('@tanstack/react-query', () => ({
@@ -93,6 +98,7 @@ beforeEach(() => {
     suiClient: defaultSuiClient,
     isLocalnet: false,
     sign: vi.fn(),
+    chain: 'sui:testnet',
   })
   mockUseTransactionSigning.mockReturnValue({
     pendingTransaction: null,
@@ -132,6 +138,7 @@ describe('SignAndExecuteTransaction', () => {
       suiClient: execSuiClient,
       isLocalnet: false,
       sign: vi.fn(),
+      chain: 'sui:testnet',
     })
     const withSigning = vi.fn().mockImplementation(async (cb) => {
       await cb({ bytes: 'b64', signature: 'sig', txb: {}, windowId: 1 })
@@ -177,6 +184,7 @@ describe('SignAndExecuteTransaction', () => {
       suiClient: execSuiClient,
       isLocalnet: false,
       sign: vi.fn(),
+      chain: 'sui:testnet',
     })
     let capturedCb:
       | ((result: Record<string, unknown>) => Promise<void>)

--- a/apps/extension/src/features/wallet/components/__tests__/SignSponsoredTransaction.test.tsx
+++ b/apps/extension/src/features/wallet/components/__tests__/SignSponsoredTransaction.test.tsx
@@ -8,16 +8,18 @@ import {
 const {
   mockUsePendingSignAction,
   mockUseWalletSigningContext,
+  mockUseTransactionSimulation,
   mockAddressAliasModule,
 } = vi.hoisted(() => ({
   mockUsePendingSignAction: vi.fn(),
   mockUseWalletSigningContext: vi.fn(),
+  mockUseTransactionSimulation: vi.fn(),
   mockAddressAliasModule: '0xaddress_alias_module',
 }))
 
 vi.mock('@/features/wallet/hooks', () => ({
   usePendingSignAction: mockUsePendingSignAction,
-  useTransactionSimulation: () => null,
+  useTransactionSimulation: mockUseTransactionSimulation,
 }))
 
 vi.mock('@/features/wallet/components/TransactionSimulationPanel', () => ({
@@ -53,6 +55,7 @@ vi.mock('@/features/wallet/components/SignRequestView', () => ({
     loadingMessage,
     error,
     requireAcknowledgement,
+    acknowledgementLabel,
     onApprove,
     onReject,
   }: {
@@ -61,6 +64,7 @@ vi.mock('@/features/wallet/components/SignRequestView', () => ({
     loadingMessage: string
     error: string | null
     requireAcknowledgement?: boolean
+    acknowledgementLabel?: string
     onApprove?: () => void
     onReject?: () => void
   }) => (
@@ -69,6 +73,9 @@ vi.mock('@/features/wallet/components/SignRequestView', () => ({
       {error && <span data-testid="error">{error}</span>}
       {requireAcknowledgement && (
         <span data-testid="ack-required">ack-required</span>
+      )}
+      {acknowledgementLabel && (
+        <span data-testid="ack-label">{acknowledgementLabel}</span>
       )}
       <button data-testid="approve-btn" type="button" onClick={onApprove}>
         Approve
@@ -126,6 +133,7 @@ beforeEach(() => {
     isLocalnet: false,
     sign: vi.fn(),
   })
+  mockUseTransactionSimulation.mockReturnValue(null)
 })
 
 afterEach(() => {
@@ -207,6 +215,46 @@ describe('SignSponsoredTransaction', () => {
     })
     await renderSignSponsored()
     expect(screen.queryByTestId('ack-required')).not.toBeInTheDocument()
+  })
+
+  it('gates on a predicted on-chain failure with the failure-specific label when the static review is clean', async () => {
+    mockUseTransactionSimulation.mockReturnValue({
+      status: 'ready',
+      simulation: { status: 'failure' },
+    })
+    stubPending({
+      windowId: 1,
+      requestId: 'req-5',
+      sponsoredTxB64: btoa('bytes'),
+      preparationId: 'prep-5',
+      reviewValue: { commands: [], inputs: [] },
+      chain: 'sui:testnet',
+    })
+    await renderSignSponsored()
+    expect(screen.getByTestId('ack-required')).toBeInTheDocument()
+    expect(screen.getByTestId('ack-label')).toHaveTextContent(
+      'expected to fail on-chain',
+    )
+  })
+
+  it('keeps the default acknowledgement label when the static review already requires it', async () => {
+    mockUseTransactionSimulation.mockReturnValue({
+      status: 'ready',
+      simulation: { status: 'failure' },
+    })
+    stubPending({
+      windowId: 1,
+      requestId: 'req-6',
+      sponsoredTxB64: btoa('bytes'),
+      preparationId: 'prep-6',
+      // undefined reviewValue → unverified danger finding → needsRiskAck
+      reviewValue: undefined,
+      chain: 'sui:testnet',
+    })
+    await renderSignSponsored()
+    expect(screen.getByTestId('ack-required')).toBeInTheDocument()
+    // predictedFailure && !needsRiskAck is false, so no failure-specific label.
+    expect(screen.queryByTestId('ack-label')).not.toBeInTheDocument()
   })
 })
 

--- a/apps/extension/src/features/wallet/components/__tests__/SignSponsoredTransaction.test.tsx
+++ b/apps/extension/src/features/wallet/components/__tests__/SignSponsoredTransaction.test.tsx
@@ -17,6 +17,11 @@ const {
 
 vi.mock('@/features/wallet/hooks', () => ({
   usePendingSignAction: mockUsePendingSignAction,
+  useTransactionSimulation: () => null,
+}))
+
+vi.mock('@/features/wallet/components/TransactionSimulationPanel', () => ({
+  TransactionSimulationPanel: () => null,
 }))
 
 vi.mock('@evevault/shared/wallet', () => ({

--- a/apps/extension/src/features/wallet/components/__tests__/SignTransaction.test.tsx
+++ b/apps/extension/src/features/wallet/components/__tests__/SignTransaction.test.tsx
@@ -7,6 +7,15 @@ const { mockUseTransactionSigning } = vi.hoisted(() => ({
 
 vi.mock('@/features/wallet/hooks', () => ({
   useTransactionSigning: mockUseTransactionSigning,
+  useTransactionSimulation: () => null,
+}))
+
+vi.mock('@evevault/shared/wallet', () => ({
+  useWalletSigningContext: () => ({ suiClient: {}, chain: 'sui:testnet' }),
+}))
+
+vi.mock('@/features/wallet/components/TransactionSimulationPanel', () => ({
+  TransactionSimulationPanel: () => null,
 }))
 
 vi.mock('@/features/wallet/components/SignRequestView', () => ({

--- a/apps/extension/src/features/wallet/components/__tests__/SignTransactionFlow.test.tsx
+++ b/apps/extension/src/features/wallet/components/__tests__/SignTransactionFlow.test.tsx
@@ -1,12 +1,26 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockUseTransactionSigning } = vi.hoisted(() => ({
-  mockUseTransactionSigning: vi.fn(),
-}))
+const { mockUseTransactionSigning, mockUseTransactionSimulation } = vi.hoisted(
+  () => ({
+    mockUseTransactionSigning: vi.fn(),
+    mockUseTransactionSimulation: vi.fn(),
+  }),
+)
 
 vi.mock('@/features/wallet/hooks', () => ({
   useTransactionSigning: mockUseTransactionSigning,
+  useTransactionSimulation: mockUseTransactionSimulation,
+}))
+
+vi.mock('@evevault/shared/wallet', () => ({
+  useWalletSigningContext: () => ({ suiClient: {}, chain: 'sui:testnet' }),
+}))
+
+vi.mock('@/features/wallet/components/TransactionSimulationPanel', () => ({
+  TransactionSimulationPanel: ({ state }: { state: unknown }) => (
+    <div data-testid="simulation-panel">{JSON.stringify(state)}</div>
+  ),
 }))
 
 vi.mock('@/features/wallet/components/SignRequestView', () => ({
@@ -79,6 +93,7 @@ function stubSigning(overrides: Record<string, unknown> = {}) {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  mockUseTransactionSimulation.mockReturnValue(null)
 })
 
 describe('SignTransactionFlow', () => {
@@ -88,12 +103,12 @@ describe('SignTransactionFlow', () => {
     expect(screen.getByText('Loading transaction...')).toBeInTheDocument()
   })
 
-  it('shows the risk panel and payload label when a transaction is pending', () => {
+  it('renders Outcome and Payload tabs, Outcome active, when pending', () => {
     stubSigning({
       pendingTransaction: {
         windowId: 1,
         requestId: 'r1',
-        reviewValue: { commands: [], inputs: [] },
+        reviewValue: { commands: [], inputs: [] }, // no findings → no Warnings tab
         displayValue: '{"test":true}',
         chain: 'sui:testnet',
         dapp: undefined,
@@ -101,8 +116,33 @@ describe('SignTransactionFlow', () => {
       },
     })
     render(<SignTransactionFlow title="Sign Transaction" onSign={vi.fn()} />)
+    expect(screen.getByRole('tab', { name: 'Outcome' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Payload' })).toBeInTheDocument()
+    expect(
+      screen.queryByRole('tab', { name: /Warnings/ }),
+    ).not.toBeInTheDocument()
+    // Outcome is the default tab, so its content is mounted.
+    expect(screen.getByTestId('simulation-panel')).toBeInTheDocument()
+  })
+
+  it('adds a Warnings tab that reveals the risk panel when there are findings', () => {
+    stubSigning({
+      pendingTransaction: {
+        windowId: 1,
+        requestId: 'r1',
+        reviewValue: { commands: [{ MoveCall: {} }], inputs: [] }, // warning finding
+        displayValue: '{}',
+        chain: 'sui:testnet',
+        account: { address: '0xabc' },
+      },
+    })
+    render(<SignTransactionFlow title="Sign Transaction" onSign={vi.fn()} />)
+    const warningsTab = screen.getByRole('tab', { name: /Warnings/ })
+    expect(warningsTab).toBeInTheDocument()
+    // Risk panel lives in the (inactive) Warnings tab until it's selected.
+    expect(screen.queryByTestId('risk-panel')).not.toBeInTheDocument()
+    fireEvent.click(warningsTab)
     expect(screen.getByTestId('risk-panel')).toBeInTheDocument()
-    expect(screen.getByText('Transaction payload')).toBeInTheDocument()
   })
 
   it('requires acknowledgement for danger-class findings', () => {
@@ -129,6 +169,59 @@ describe('SignTransactionFlow', () => {
         displayValue: '{}',
         chain: 'sui:testnet',
         account: { address: '0xabc' },
+      },
+    })
+    render(<SignTransactionFlow title="Sign Transaction" onSign={vi.fn()} />)
+    expect(screen.queryByTestId('ack-required')).not.toBeInTheDocument()
+  })
+
+  it('requires acknowledgement when the simulation predicts failure', () => {
+    stubSigning({
+      pendingTransaction: {
+        windowId: 1,
+        requestId: 'r1',
+        reviewValue: { commands: [], inputs: [] }, // clean static review
+        displayValue: '{}',
+        chain: 'sui:testnet',
+        account: { address: '0xabc' },
+      },
+    })
+    mockUseTransactionSimulation.mockReturnValue({
+      status: 'ready',
+      simulation: {
+        status: 'failure',
+        error: 'MoveAbort',
+        digest: 'd',
+        gas: { computation: '0', storage: '0', rebate: '0', net: '0.001' },
+        balanceChanges: [],
+        changedObjects: [],
+        events: [],
+      },
+    })
+    render(<SignTransactionFlow title="Sign Transaction" onSign={vi.fn()} />)
+    expect(screen.getByTestId('ack-required')).toBeInTheDocument()
+  })
+
+  it('does not require acknowledgement when the simulation succeeds', () => {
+    stubSigning({
+      pendingTransaction: {
+        windowId: 1,
+        requestId: 'r1',
+        reviewValue: { commands: [], inputs: [] },
+        displayValue: '{}',
+        chain: 'sui:testnet',
+        account: { address: '0xabc' },
+      },
+    })
+    mockUseTransactionSimulation.mockReturnValue({
+      status: 'ready',
+      simulation: {
+        status: 'success',
+        digest: 'd',
+        gas: { computation: '0', storage: '0', rebate: '0', net: '0.001' },
+        balanceChanges: [],
+        changedObjects: [],
+        events: [],
       },
     })
     render(<SignTransactionFlow title="Sign Transaction" onSign={vi.fn()} />)

--- a/apps/extension/src/features/wallet/components/__tests__/TransactionRiskPanel.test.tsx
+++ b/apps/extension/src/features/wallet/components/__tests__/TransactionRiskPanel.test.tsx
@@ -57,13 +57,14 @@ describe('TransactionRiskPanel', () => {
     ])
   })
 
-  it('renders the panel header for non-empty findings', () => {
+  it('renders findings without a standalone header (the tab supplies it)', () => {
     const findings: TransactionRiskFinding[] = [
       { severity: 'warning', title: 'Calls Move code', detail: 'detail' },
     ]
 
     render(<TransactionRiskPanel findings={findings} />)
 
-    expect(screen.getByText('Transaction warnings')).toBeInTheDocument()
+    expect(screen.getByText('Calls Move code')).toBeInTheDocument()
+    expect(screen.queryByText('Transaction warnings')).not.toBeInTheDocument()
   })
 })

--- a/apps/extension/src/features/wallet/hooks/__tests__/useTransactionSimulation.test.ts
+++ b/apps/extension/src/features/wallet/hooks/__tests__/useTransactionSimulation.test.ts
@@ -1,0 +1,189 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useTransactionSimulation } from '@/features/wallet/hooks/useTransactionSimulation'
+
+const {
+  mockBuildTransactionBytes,
+  mockSimulateTransactionOutcome,
+  mockClassifyBuildFailure,
+  mockCreateSuiGraphQLClient,
+} = vi.hoisted(() => ({
+  mockBuildTransactionBytes: vi.fn(),
+  mockSimulateTransactionOutcome: vi.fn(),
+  mockClassifyBuildFailure: vi.fn(),
+  mockCreateSuiGraphQLClient: vi.fn(() => ({})),
+}))
+
+vi.mock('@evefrontier/wallet-core/crypto', () => ({
+  buildTransactionBytes: mockBuildTransactionBytes,
+}))
+
+vi.mock('@mysten/sui/transactions', () => ({
+  Transaction: { from: vi.fn((payload: string) => ({ payload })) },
+}))
+
+vi.mock('@evevault/shared/sui', () => ({
+  createSuiGraphQLClient: mockCreateSuiGraphQLClient,
+}))
+
+vi.mock('@evevault/shared/wallet', () => ({
+  simulateTransactionOutcome: mockSimulateTransactionOutcome,
+  classifyBuildFailure: mockClassifyBuildFailure,
+}))
+
+vi.mock('@evevault/shared/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@evevault/shared/utils')>()
+  return {
+    ...actual,
+    createLogger: () => ({
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    }),
+  }
+})
+
+const SUCCESS_SIMULATION = {
+  status: 'success' as const,
+  digest: 'd1',
+  gas: { computation: '0', storage: '0', rebate: '0', net: '0' },
+  balanceChanges: [],
+  changedObjects: [],
+  events: [],
+}
+
+const FAILURE_SIMULATION = {
+  status: 'failure' as const,
+  error: 'MoveAbort',
+  digest: 'd2',
+  gas: { computation: '0', storage: '0', rebate: '0', net: '0' },
+  balanceChanges: [],
+  changedObjects: [],
+  events: [],
+}
+
+function makeParams(overrides: Record<string, unknown> = {}) {
+  return {
+    payload: 'base64tx',
+    mode: 'build' as const,
+    suiClient: {} as never,
+    chain: 'sui:testnet' as never,
+    getSenderAddress: vi.fn(() => Promise.resolve('0xabc')),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  mockCreateSuiGraphQLClient.mockReturnValue({})
+})
+
+describe('useTransactionSimulation', () => {
+  it('resolves to a ready/success state on a normal simulation', async () => {
+    mockBuildTransactionBytes.mockResolvedValue(new Uint8Array([1]))
+    mockSimulateTransactionOutcome.mockResolvedValue(SUCCESS_SIMULATION)
+
+    const { result } = renderHook((p) => useTransactionSimulation(p), {
+      initialProps: makeParams(),
+    })
+
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        status: 'ready',
+        simulation: SUCCESS_SIMULATION,
+      }),
+    )
+  })
+
+  it('resolves to a ready/failure state when the real simulate call predicts failure', async () => {
+    mockBuildTransactionBytes.mockResolvedValue(new Uint8Array([1]))
+    mockSimulateTransactionOutcome.mockResolvedValue(FAILURE_SIMULATION)
+
+    const { result } = renderHook((p) => useTransactionSimulation(p), {
+      initialProps: makeParams(),
+    })
+
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        status: 'ready',
+        simulation: FAILURE_SIMULATION,
+      }),
+    )
+    expect(mockClassifyBuildFailure).not.toHaveBeenCalled()
+  })
+
+  it('reclassifies a build-time SimulationError as a predicted failure', async () => {
+    const buildError = new Error(
+      'Transaction resolution failed: InsufficientCoinBalance',
+    )
+    mockBuildTransactionBytes.mockRejectedValue(buildError)
+    mockClassifyBuildFailure.mockReturnValue(FAILURE_SIMULATION)
+
+    const { result } = renderHook((p) => useTransactionSimulation(p), {
+      initialProps: makeParams(),
+    })
+
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        status: 'ready',
+        simulation: FAILURE_SIMULATION,
+      }),
+    )
+    expect(mockClassifyBuildFailure).toHaveBeenCalledWith(buildError)
+    expect(mockSimulateTransactionOutcome).not.toHaveBeenCalled()
+  })
+
+  it('reclassifies an insufficient-gas-coins error as a predicted failure', async () => {
+    const gasError = new Error('No valid gas coins found for the transaction.')
+    mockBuildTransactionBytes.mockRejectedValue(gasError)
+    mockClassifyBuildFailure.mockReturnValue(FAILURE_SIMULATION)
+
+    const { result } = renderHook((p) => useTransactionSimulation(p), {
+      initialProps: makeParams(),
+    })
+
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        status: 'ready',
+        simulation: FAILURE_SIMULATION,
+      }),
+    )
+  })
+
+  it('falls back to unavailable for an unrecognized error', async () => {
+    const networkError = new Error('network timeout')
+    mockBuildTransactionBytes.mockRejectedValue(networkError)
+    mockClassifyBuildFailure.mockReturnValue(null)
+
+    const { result } = renderHook((p) => useTransactionSimulation(p), {
+      initialProps: makeParams(),
+    })
+
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        status: 'unavailable',
+        reason: 'network timeout',
+      }),
+    )
+  })
+
+  it('reports unavailable, not a misclassified failure, when no sender address resolves', async () => {
+    mockClassifyBuildFailure.mockReturnValue(null)
+
+    const { result } = renderHook((p) => useTransactionSimulation(p), {
+      initialProps: makeParams({
+        getSenderAddress: vi.fn(() => Promise.resolve(null)),
+        fallbackSender: undefined,
+      }),
+    })
+
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        status: 'unavailable',
+        reason: 'No sender address available',
+      }),
+    )
+    expect(mockBuildTransactionBytes).not.toHaveBeenCalled()
+  })
+})

--- a/apps/extension/src/features/wallet/hooks/index.ts
+++ b/apps/extension/src/features/wallet/hooks/index.ts
@@ -4,3 +4,7 @@ export { usePendingSignAction } from './usePendingSignAction'
 export { usePendingTransaction } from './usePendingTransaction'
 export { useSignPopupAuth } from './useSignPopupAuth'
 export { useTransactionSigning } from './useTransactionSigning'
+export {
+  type SimulationState,
+  useTransactionSimulation,
+} from './useTransactionSimulation'

--- a/apps/extension/src/features/wallet/hooks/useTransactionSimulation.ts
+++ b/apps/extension/src/features/wallet/hooks/useTransactionSimulation.ts
@@ -2,6 +2,7 @@ import { buildTransactionBytes } from '@evefrontier/wallet-core/crypto'
 import { createSuiGraphQLClient } from '@evevault/shared/sui'
 import { createLogger } from '@evevault/shared/utils'
 import {
+  classifyBuildFailure,
   simulateTransactionOutcome,
   type TransactionSimulation,
 } from '@evevault/shared/wallet'
@@ -16,7 +17,7 @@ const log = createLogger()
 export type SimulationState =
   | { status: 'loading' }
   | { status: 'ready'; simulation: TransactionSimulation }
-  | { status: 'unavailable'; reason?: string } // // Transport/build failure — outcome unknown
+  | { status: 'unavailable'; reason?: string } // Transport/build failure — outcome unknown
 
 type SimulationParams = {
   /**
@@ -89,13 +90,18 @@ export function useTransactionSimulation({
           setState({ status: 'ready', simulation })
         }
       } catch (err) {
-        log.warn('Transaction simulation failed', err)
-        if (runId === runIdRef.current) {
-          setState({
-            status: 'unavailable',
-            reason: err instanceof Error ? err.message : String(err),
-          })
+        if (runId !== runIdRef.current) return
+
+        const classified = classifyBuildFailure(err)
+        if (classified) {
+          setState({ status: 'ready', simulation: classified })
+          return
         }
+        log.warn('Transaction simulation failed', err)
+        setState({
+          status: 'unavailable',
+          reason: err instanceof Error ? err.message : String(err),
+        })
       }
     }
 

--- a/apps/extension/src/features/wallet/hooks/useTransactionSimulation.ts
+++ b/apps/extension/src/features/wallet/hooks/useTransactionSimulation.ts
@@ -16,9 +16,7 @@ const log = createLogger()
 export type SimulationState =
   | { status: 'loading' }
   | { status: 'ready'; simulation: TransactionSimulation }
-  // Transport/build failure — the outcome is unknown, distinct from a
-  // transaction that simulates cleanly as a predicted on-chain failure.
-  | { status: 'unavailable'; reason?: string }
+  | { status: 'unavailable'; reason?: string } // // Transport/build failure — outcome unknown
 
 type SimulationParams = {
   /**

--- a/apps/extension/src/features/wallet/hooks/useTransactionSimulation.ts
+++ b/apps/extension/src/features/wallet/hooks/useTransactionSimulation.ts
@@ -1,0 +1,112 @@
+import { buildTransactionBytes } from '@evefrontier/wallet-core/crypto'
+import { createSuiGraphQLClient } from '@evevault/shared/sui'
+import { createLogger } from '@evevault/shared/utils'
+import {
+  simulateTransactionOutcome,
+  type TransactionSimulation,
+} from '@evevault/shared/wallet'
+import type { SuiGrpcClient } from '@mysten/sui/grpc'
+import { Transaction } from '@mysten/sui/transactions'
+import { fromBase64 } from '@mysten/sui/utils'
+import type { SuiChain } from '@mysten/wallet-standard'
+import { useEffect, useRef, useState } from 'react'
+
+const log = createLogger()
+
+export type SimulationState =
+  | { status: 'loading' }
+  | { status: 'ready'; simulation: TransactionSimulation }
+  // Transport/build failure — the outcome is unknown, distinct from a
+  // transaction that simulates cleanly as a predicted on-chain failure.
+  | { status: 'unavailable'; reason?: string }
+
+type SimulationParams = {
+  /**
+   * The transaction payload to simulate, or null when nothing is pending.
+   * - `build`: a serialized `Transaction` that still needs sender + gas
+   *   resolved (the dApp sign / sign-and-execute path).
+   * - `bytes`: base64 BCS `TransactionData` that is already fully built,
+   *   including gas payment (the sponsored path — rebuilding would drop the
+   *   sponsor's gas).
+   */
+  payload: string | null
+  mode: 'build' | 'bytes'
+  suiClient: SuiGrpcClient
+  chain: SuiChain
+  getSenderAddress: () => Promise<string | null>
+  /** Used only to filter balance changes if `getSenderAddress` returns null. */
+  fallbackSender?: string
+}
+
+async function resolveBytes(
+  mode: 'build' | 'bytes',
+  payload: string,
+  sender: string,
+  suiClient: SuiGrpcClient,
+): Promise<Uint8Array> {
+  if (mode === 'bytes') return fromBase64(payload)
+  return buildTransactionBytes(Transaction.from(payload), sender, suiClient)
+}
+
+/**
+ * Simulates the pending transaction as soon as it is decoded, re-running when
+ * the selected network changes. Resolves the sender the same way the signing
+ * path does (`getSenderAddress`) rather than from the dApp payload, whose
+ * `account.address` does not survive the storage round-trip into the popup.
+ */
+export function useTransactionSimulation({
+  payload,
+  mode,
+  suiClient,
+  chain,
+  getSenderAddress,
+  fallbackSender,
+}: SimulationParams): SimulationState | null {
+  const [state, setState] = useState<SimulationState | null>(null)
+  const runIdRef = useRef(0)
+
+  useEffect(() => {
+    if (!payload) {
+      setState(null)
+      return
+    }
+
+    const runId = ++runIdRef.current
+    setState({ status: 'loading' })
+
+    const run = async () => {
+      try {
+        const sender = (await getSenderAddress()) ?? fallbackSender
+        if (!sender) {
+          throw new Error('No sender address available')
+        }
+        const bytes = await resolveBytes(mode, payload, sender, suiClient)
+        const simulation = await simulateTransactionOutcome({
+          transactionBytes: bytes,
+          sender,
+          suiClient,
+          graphqlClient: createSuiGraphQLClient(chain),
+        })
+        if (runId === runIdRef.current) {
+          setState({ status: 'ready', simulation })
+        }
+      } catch (err) {
+        log.warn('Transaction simulation failed', err)
+        if (runId === runIdRef.current) {
+          setState({
+            status: 'unavailable',
+            reason: err instanceof Error ? err.message : String(err),
+          })
+        }
+      }
+    }
+
+    void run()
+    // Discard this run's result if a newer one starts (e.g. network switch).
+    return () => {
+      runIdRef.current++
+    }
+  }, [payload, mode, suiClient, chain, getSenderAddress, fallbackSender])
+
+  return state
+}

--- a/apps/extension/src/features/wallet/transactionRiskReview.ts
+++ b/apps/extension/src/features/wallet/transactionRiskReview.ts
@@ -9,6 +9,11 @@ export type TransactionRiskFinding = {
   detail: string
 }
 
+// Acknowledgement copy shown when a simulation predicts an on-chain failure but
+// the static review is otherwise clean. Shared by every signing path.
+export const PREDICTED_FAILURE_ACKNOWLEDGEMENT =
+  'This transaction is expected to fail on-chain. I understand and want to approve anyway.'
+
 // Single catalog of every user-facing risk finding. The three review paths
 // below (per-command, per-input, and payload-level) all reference entries here.
 const FINDINGS = {

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @evevault/web
 
+## 0.0.17
+
+### Patch Changes
+
+- Updated dependencies
+  - @evevault/shared@0.0.17
+
 ## 0.0.16
 
 ### Patch Changes

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evevault/web",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,7 @@
     },
     "apps/extension": {
       "name": "@evevault/extension",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@evevault/shared": "workspace:*",
         "@mysten/sui": "^2.17.0",
@@ -56,7 +56,7 @@
     },
     "apps/web": {
       "name": "@evevault/web",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@evevault/shared": "workspace:*",
         "@tanstack/react-query": "^5.100.9",
@@ -81,7 +81,7 @@
     },
     "packages/shared": {
       "name": "@evevault/shared",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@mysten/signers": "^1.0.5",
         "@wxt-dev/browser": "0.2.5",
@@ -106,21 +106,12 @@
     },
   },
   "overrides": {
-    "@mysten/sui": "^2.22.1",
     "adm-zip": "^0.6.0",
     "axios": "^1.16.0",
-    "brace-expansion": "^5.0.8",
     "esbuild": "^0.28.1",
-    "fast-uri": "^3.1.4",
-    "js-yaml": "^4.3.0",
-    "nanoid": "^3.3.18",
-    "postcss": "^8.5.18",
-    "protobufjs": "^7.6.5",
     "shell-quote": "^1.8.5",
     "tmp": "^0.2.6",
-    "uuid": ">=11.1.1",
-    "valibot": "^1.4.2",
-    "vite": "^7.3.3",
+    "uuid": "^11.1.1",
   },
   "packages": {
     "@0no-co/graphql.web": ["@0no-co/graphql.web@1.3.3", "", { "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0" }, "optionalPeers": ["graphql"] }, "sha512-4gFGBdyaFmQ6n9euhp5JtIGS4ZeivwDr1tCPENUxTvy5wyv532yOtFCr9zzYAJh1s6uibgC+TRXUcay+mxzCoQ=="],
@@ -605,6 +596,8 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
+    "@oxc-project/types": ["@oxc-project/types@0.146.0", "", {}, "sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA=="],
+
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
     "@playwright/test": ["@playwright/test@1.62.1", "", { "dependencies": { "playwright": "1.62.1" }, "bin": { "playwright": "cli.js" } }, "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ=="],
@@ -640,6 +633,36 @@
     "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.2", "", {}, "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug=="],
+
+    "@rolldown/binding-android-arm-eabi": ["@rolldown/binding-android-arm-eabi@1.2.5", "", { "os": "android", "cpu": "arm" }, "sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA=="],
+
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.2.5", "", { "os": "android", "cpu": "arm64" }, "sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.2.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.2.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.2.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.2.5", "", { "os": "linux", "cpu": "arm" }, "sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.2.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.2.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.2.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.2.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.2.5", "", { "os": "linux", "cpu": "x64" }, "sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.2.5", "", { "os": "linux", "cpu": "x64" }, "sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.2.5", "", { "os": "none", "cpu": "arm64" }, "sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.2.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.2.5", "", { "os": "win32", "cpu": "x64" }, "sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
 
@@ -931,7 +954,7 @@
 
     "babel-plugin-polyfill-regenerator": ["babel-plugin-polyfill-regenerator@0.6.8", "", { "dependencies": { "@babel/helper-define-polyfill-provider": "^0.6.8" }, "peerDependencies": { "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0" } }, "sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg=="],
 
-    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
@@ -949,7 +972,7 @@
 
     "boxen": ["boxen@8.0.1", "", { "dependencies": { "ansi-align": "^3.0.1", "camelcase": "^8.0.0", "chalk": "^5.3.0", "cli-boxes": "^3.0.0", "string-width": "^7.2.0", "type-fest": "^4.21.0", "widest-line": "^5.0.0", "wrap-ansi": "^9.0.0" } }, "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw=="],
 
-    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
+    "brace-expansion": ["brace-expansion@1.1.18", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -1008,6 +1031,8 @@
     "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "common-tags": ["common-tags@1.8.2", "", {}, "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
     "concat-stream": ["concat-stream@1.6.2", "", { "dependencies": { "buffer-from": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^2.2.2", "typedarray": "^0.0.6" } }, "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw=="],
 
@@ -1158,6 +1183,8 @@
     "escape-goat": ["escape-goat@4.0.0", "", {}, "sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg=="],
 
     "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
+    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
@@ -1821,6 +1848,8 @@
 
     "rimraf": ["rimraf@5.0.10", "", { "dependencies": { "glob": "^10.3.7" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ=="],
 
+    "rolldown": ["rolldown@1.2.5", "", { "dependencies": { "@oxc-project/types": "=0.146.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm-eabi": "1.2.5", "@rolldown/binding-android-arm64": "1.2.5", "@rolldown/binding-darwin-arm64": "1.2.5", "@rolldown/binding-darwin-x64": "1.2.5", "@rolldown/binding-freebsd-x64": "1.2.5", "@rolldown/binding-linux-arm-gnueabihf": "1.2.5", "@rolldown/binding-linux-arm64-gnu": "1.2.5", "@rolldown/binding-linux-arm64-musl": "1.2.5", "@rolldown/binding-linux-ppc64-gnu": "1.2.5", "@rolldown/binding-linux-s390x-gnu": "1.2.5", "@rolldown/binding-linux-x64-gnu": "1.2.5", "@rolldown/binding-linux-x64-musl": "1.2.5", "@rolldown/binding-openharmony-arm64": "1.2.5", "@rolldown/binding-win32-arm64-msvc": "1.2.5", "@rolldown/binding-win32-x64-msvc": "1.2.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA=="],
+
     "rollup": ["rollup@4.62.4", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@napi-rs/lzma-linux-x64-gnu": "1.5.1", "@rollup/rollup-android-arm-eabi": "4.62.4", "@rollup/rollup-android-arm64": "4.62.4", "@rollup/rollup-darwin-arm64": "4.62.4", "@rollup/rollup-darwin-x64": "4.62.4", "@rollup/rollup-freebsd-arm64": "4.62.4", "@rollup/rollup-freebsd-x64": "4.62.4", "@rollup/rollup-linux-arm-gnueabihf": "4.62.4", "@rollup/rollup-linux-arm-musleabihf": "4.62.4", "@rollup/rollup-linux-arm64-gnu": "4.62.4", "@rollup/rollup-linux-arm64-musl": "4.62.4", "@rollup/rollup-linux-loong64-gnu": "4.62.4", "@rollup/rollup-linux-loong64-musl": "4.62.4", "@rollup/rollup-linux-ppc64-gnu": "4.62.4", "@rollup/rollup-linux-ppc64-musl": "4.62.4", "@rollup/rollup-linux-riscv64-gnu": "4.62.4", "@rollup/rollup-linux-riscv64-musl": "4.62.4", "@rollup/rollup-linux-s390x-gnu": "4.62.4", "@rollup/rollup-linux-x64-gnu": "4.62.4", "@rollup/rollup-linux-x64-musl": "4.62.4", "@rollup/rollup-openbsd-x64": "4.62.4", "@rollup/rollup-openharmony-arm64": "4.62.4", "@rollup/rollup-win32-arm64-msvc": "4.62.4", "@rollup/rollup-win32-ia32-msvc": "4.62.4", "@rollup/rollup-win32-x64-gnu": "4.62.4", "@rollup/rollup-win32-x64-msvc": "4.62.4", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg=="],
 
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
@@ -1914,6 +1943,8 @@
     "split": ["split@1.0.1", "", { "dependencies": { "through": "2" } }, "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg=="],
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
+    "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
@@ -2069,7 +2100,7 @@
 
     "utility-types": ["utility-types@3.11.0", "", {}, "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw=="],
 
-    "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
+    "uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
 
     "valibot": ["valibot@1.4.2", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg=="],
 
@@ -2333,9 +2364,13 @@
 
     "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
+    "read-yaml-file/js-yaml": ["js-yaml@3.15.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag=="],
+
     "read-yaml-file/strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
     "rimraf/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
+    "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 
     "safe-array-concat/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
@@ -2356,6 +2391,10 @@
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "unimport/magic-string": ["magic-string@1.1.0", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-kS3VHe0nEPST2saQV4Rbkchcd3UBRkVTQHo1D3h/ZTwFDhai/mfKkmtPAtD129EOI7K3HlHIsFOt0WrI2/oU9g=="],
+
+    "vite-node/vite": ["vite@8.2.2", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.26", "rolldown": "~1.2.4", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0 || ^0.5.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q=="],
+
+    "vitest/vite": ["vite@8.2.2", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.26", "rolldown": "~1.2.4", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0 || ^0.5.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q=="],
 
     "web-ext-run/@babel/runtime": ["@babel/runtime@7.28.2", "", {}, "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA=="],
 
@@ -2378,6 +2417,8 @@
     "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "wxt/vite": ["vite@8.2.2", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.26", "rolldown": "~1.2.4", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0 || ^0.5.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q=="],
 
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -2403,11 +2444,15 @@
 
     "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
+    "filelist/minimatch/brace-expansion": ["brace-expansion@2.1.4", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg=="],
+
     "firefox-profile/fs-extra/jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
 
     "firefox-profile/fs-extra/universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
     "fx-runner/which/isexe": ["isexe@1.1.2", "", {}, "sha512-d2eJzK691yZwPHcv1LbeAOa91yMJ9QmfTgSO1oXB65ezVhXQsxBac2vEB4bMVms9cGzaA99n6V2viHMq82VLDw=="],
+
+    "glob/minimatch/brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
     "htmlparser2/domutils/dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
@@ -2419,6 +2464,8 @@
 
     "publish-browser-extension/listr2/wrap-ansi": ["wrap-ansi@10.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "string-width": "^8.2.0", "strip-ansi": "^7.1.2" } }, "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ=="],
 
+    "read-yaml-file/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+
     "rimraf/glob/jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
     "rimraf/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
@@ -2426,6 +2473,14 @@
     "rimraf/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
     "string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "vite-node/vite/lightningcss": ["lightningcss@1.33.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.33.0", "lightningcss-darwin-arm64": "1.33.0", "lightningcss-darwin-x64": "1.33.0", "lightningcss-freebsd-x64": "1.33.0", "lightningcss-linux-arm-gnueabihf": "1.33.0", "lightningcss-linux-arm64-gnu": "1.33.0", "lightningcss-linux-arm64-musl": "1.33.0", "lightningcss-linux-x64-gnu": "1.33.0", "lightningcss-linux-x64-musl": "1.33.0", "lightningcss-win32-arm64-msvc": "1.33.0", "lightningcss-win32-x64-msvc": "1.33.0" } }, "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA=="],
+
+    "vite-node/vite/postcss": ["postcss@8.5.26", "", { "dependencies": { "nanoid": "^3.3.17", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ=="],
+
+    "vitest/vite/lightningcss": ["lightningcss@1.33.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.33.0", "lightningcss-darwin-arm64": "1.33.0", "lightningcss-darwin-x64": "1.33.0", "lightningcss-freebsd-x64": "1.33.0", "lightningcss-linux-arm-gnueabihf": "1.33.0", "lightningcss-linux-arm64-gnu": "1.33.0", "lightningcss-linux-arm64-musl": "1.33.0", "lightningcss-linux-x64-gnu": "1.33.0", "lightningcss-linux-x64-musl": "1.33.0", "lightningcss-win32-arm64-msvc": "1.33.0", "lightningcss-win32-x64-msvc": "1.33.0" } }, "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA=="],
+
+    "vitest/vite/postcss": ["postcss@8.5.26", "", { "dependencies": { "nanoid": "^3.3.17", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ=="],
 
     "widest-line/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
@@ -2439,11 +2494,17 @@
 
     "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
+    "wxt/vite/lightningcss": ["lightningcss@1.33.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.33.0", "lightningcss-darwin-arm64": "1.33.0", "lightningcss-darwin-x64": "1.33.0", "lightningcss-freebsd-x64": "1.33.0", "lightningcss-linux-arm-gnueabihf": "1.33.0", "lightningcss-linux-arm64-gnu": "1.33.0", "lightningcss-linux-arm64-musl": "1.33.0", "lightningcss-linux-x64-gnu": "1.33.0", "lightningcss-linux-x64-musl": "1.33.0", "lightningcss-win32-arm64-msvc": "1.33.0", "lightningcss-win32-x64-msvc": "1.33.0" } }, "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA=="],
+
+    "wxt/vite/postcss": ["postcss@8.5.26", "", { "dependencies": { "nanoid": "^3.3.17", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ=="],
+
     "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "yargs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "boxen/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "htmlparser2/domutils/dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
@@ -2453,9 +2514,77 @@
 
     "rimraf/glob/jackspeak/@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
+    "rimraf/glob/minimatch/brace-expansion": ["brace-expansion@2.1.4", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg=="],
+
     "rimraf/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
+    "vite-node/vite/lightningcss/lightningcss-android-arm64": ["lightningcss-android-arm64@1.33.0", "", { "os": "android", "cpu": "arm64" }, "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg=="],
+
+    "vite-node/vite/lightningcss/lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.33.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg=="],
+
+    "vite-node/vite/lightningcss/lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.33.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ=="],
+
+    "vite-node/vite/lightningcss/lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.33.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg=="],
+
+    "vite-node/vite/lightningcss/lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.33.0", "", { "os": "linux", "cpu": "arm" }, "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ=="],
+
+    "vite-node/vite/lightningcss/lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg=="],
+
+    "vite-node/vite/lightningcss/lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ=="],
+
+    "vite-node/vite/lightningcss/lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg=="],
+
+    "vite-node/vite/lightningcss/lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw=="],
+
+    "vite-node/vite/lightningcss/lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.33.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA=="],
+
+    "vite-node/vite/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.33.0", "", { "os": "win32", "cpu": "x64" }, "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA=="],
+
+    "vitest/vite/lightningcss/lightningcss-android-arm64": ["lightningcss-android-arm64@1.33.0", "", { "os": "android", "cpu": "arm64" }, "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg=="],
+
+    "vitest/vite/lightningcss/lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.33.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg=="],
+
+    "vitest/vite/lightningcss/lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.33.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ=="],
+
+    "vitest/vite/lightningcss/lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.33.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg=="],
+
+    "vitest/vite/lightningcss/lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.33.0", "", { "os": "linux", "cpu": "arm" }, "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ=="],
+
+    "vitest/vite/lightningcss/lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg=="],
+
+    "vitest/vite/lightningcss/lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ=="],
+
+    "vitest/vite/lightningcss/lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg=="],
+
+    "vitest/vite/lightningcss/lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw=="],
+
+    "vitest/vite/lightningcss/lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.33.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA=="],
+
+    "vitest/vite/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.33.0", "", { "os": "win32", "cpu": "x64" }, "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA=="],
+
     "widest-line/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "wxt/vite/lightningcss/lightningcss-android-arm64": ["lightningcss-android-arm64@1.33.0", "", { "os": "android", "cpu": "arm64" }, "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg=="],
+
+    "wxt/vite/lightningcss/lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.33.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg=="],
+
+    "wxt/vite/lightningcss/lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.33.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ=="],
+
+    "wxt/vite/lightningcss/lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.33.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg=="],
+
+    "wxt/vite/lightningcss/lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.33.0", "", { "os": "linux", "cpu": "arm" }, "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ=="],
+
+    "wxt/vite/lightningcss/lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg=="],
+
+    "wxt/vite/lightningcss/lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ=="],
+
+    "wxt/vite/lightningcss/lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg=="],
+
+    "wxt/vite/lightningcss/lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw=="],
+
+    "wxt/vite/lightningcss/lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.33.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA=="],
+
+    "wxt/vite/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.33.0", "", { "os": "win32", "cpu": "x64" }, "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA=="],
 
     "publish-browser-extension/listr2/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 

--- a/package.json
+++ b/package.json
@@ -68,20 +68,11 @@
     "vitest": "4.1.10"
   },
   "overrides": {
-    "uuid": ">=11.1.1",
-    "tmp": "^0.2.6",
     "shell-quote": "^1.8.5",
+    "tmp": "^0.2.6",
     "axios": "^1.16.0",
-    "esbuild": "^0.28.1",
-    "js-yaml": "^4.3.0",
-    "valibot": "^1.4.2",
-    "nanoid": "^3.3.18",
-    "postcss": "^8.5.18",
-    "protobufjs": "^7.6.5",
-    "vite": "^7.3.3",
     "adm-zip": "^0.6.0",
-    "brace-expansion": "^5.0.8",
-    "fast-uri": "^3.1.4",
-    "@mysten/sui": "^2.22.1"
+    "esbuild": "^0.28.1",
+    "uuid": "^11.1.1"
   }
 }

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @evevault/shared
 
+## 0.0.17
+
+### Patch Changes
+
+- add transaction simulation to extension approval
+
 ## 0.0.16
 
 ### Patch Changes

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evevault/shared",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "imports": {

--- a/packages/shared/src/utils/__tests__/format.node.test.ts
+++ b/packages/shared/src/utils/__tests__/format.node.test.ts
@@ -133,6 +133,13 @@ describe('formatByDecimals', () => {
       expect(formatByDecimals('1', SUI_DECIMALS)).toBe('0.000000001')
       expect(formatByDecimals('100000000', SUI_DECIMALS)).toBe('0.1')
     })
+
+    it('formats negative amounts (e.g. a net gas rebate)', () => {
+      expect(formatByDecimals('-1500000000', SUI_DECIMALS)).toBe('-1.5')
+      expect(formatByDecimals('-1000000000', SUI_DECIMALS)).toBe('-1')
+      expect(formatByDecimals('-500000000', SUI_DECIMALS)).toBe('-0.5')
+      expect(formatByDecimals('-1', SUI_DECIMALS)).toBe('-0.000000001')
+    })
   })
 
   describe('trailing zero handling', () => {

--- a/packages/shared/src/utils/format.ts
+++ b/packages/shared/src/utils/format.ts
@@ -15,11 +15,16 @@ import { SUI_DECIMALS } from '@mysten/sui/utils'
 export function formatByDecimals(amount: string, decimals: number): string {
   const divisor = 10n ** BigInt(decimals)
   const value = BigInt(amount)
-  const integer = value / divisor
-  const fraction = value % divisor
+  // Operate on the magnitude so the sign is applied once at the end; splitting a
+  // negative value into integer/fraction otherwise yields garbage like "-1.-5".
+  const negative = value < 0n
+  const abs = negative ? -value : value
+  const sign = negative ? '-' : ''
+  const integer = abs / divisor
+  const fraction = abs % divisor
 
   if (fraction === 0n) {
-    return integer.toString()
+    return `${sign}${integer.toString()}`
   }
 
   const fractionStr = fraction
@@ -27,7 +32,7 @@ export function formatByDecimals(amount: string, decimals: number): string {
     .padStart(decimals, '0')
     .replace(/0+$/, '')
 
-  return `${integer.toString()}.${fractionStr}`
+  return `${sign}${integer.toString()}.${fractionStr}`
 }
 
 /**

--- a/packages/shared/src/wallet/__tests__/simulateTransaction.test.ts
+++ b/packages/shared/src/wallet/__tests__/simulateTransaction.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { invalidateCoinMetadataCache } from '#/wallet/utils/coinMetadata'
+import { simulateTransactionOutcome } from '#/wallet/utils/simulateTransaction'
+
+const SENDER =
+  '0x1111111111111111111111111111111111111111111111111111111111111111'
+const OTHER =
+  '0x2222222222222222222222222222222222222222222222222222222222222222'
+const EVE_COIN = '0xabc::eve::EVE'
+const OBJ_A = '0xaaa'
+const OBJ_B = '0xbbb'
+
+const GAS_USED = {
+  computationCost: '1000000',
+  storageCost: '2000000',
+  storageRebate: '500000',
+  nonRefundableStorageFee: '0',
+}
+// net gas = 1_000_000 + 2_000_000 − 500_000 = 2_500_000 mist = 0.0025 SUI
+
+function makeSuiClient(result: unknown) {
+  return {
+    simulateTransaction: vi.fn().mockResolvedValue(result),
+  } as never
+}
+
+// Non-SUI coins resolve decimals/symbol via GraphQL; SUI is known and never queries.
+function makeGraphqlClient(decimals: number, symbol: string) {
+  return {
+    query: vi.fn().mockResolvedValue({
+      data: { coinMetadata: { decimals, symbol, name: symbol } },
+    }),
+  } as never
+}
+
+const bytes = new Uint8Array([1, 2, 3])
+
+afterEach(() => {
+  invalidateCoinMetadataCache()
+  vi.restoreAllMocks()
+})
+
+describe('simulateTransactionOutcome', () => {
+  it('reports digest, gas, balance changes and changed objects', async () => {
+    const suiClient = makeSuiClient({
+      $kind: 'Transaction',
+      Transaction: {
+        digest: 'DiGeSt123',
+        objectTypes: { [OBJ_A]: '0x2::coin::Coin<0x2::sui::SUI>' },
+        effects: {
+          status: { success: true, error: null },
+          gasUsed: GAS_USED,
+          transactionDigest: 'DiGeSt123',
+          changedObjects: [
+            {
+              objectId: OBJ_A,
+              idOperation: 'None',
+              outputState: 'ObjectWrite',
+              inputOwner: { $kind: 'AddressOwner', AddressOwner: SENDER },
+              outputOwner: { $kind: 'AddressOwner', AddressOwner: OTHER },
+            },
+            {
+              objectId: OBJ_B,
+              idOperation: 'Created',
+              outputState: 'ObjectWrite',
+              outputOwner: {
+                $kind: 'Shared',
+                Shared: { initialSharedVersion: '1' },
+              },
+            },
+          ],
+        },
+        events: [
+          {
+            eventType: '0xpkg::market::Sale',
+            json: { price: '12500000000', buyer: OTHER },
+          },
+        ],
+        balanceChanges: [
+          { address: SENDER, coinType: EVE_COIN, amount: '12500000000' },
+          { address: SENDER, coinType: '0x2::sui::SUI', amount: '-2500000' },
+          // Another account's change must be filtered out.
+          { address: OTHER, coinType: EVE_COIN, amount: '-12500000000' },
+        ],
+      },
+    })
+
+    const outcome = await simulateTransactionOutcome({
+      transactionBytes: bytes,
+      sender: SENDER,
+      suiClient,
+      graphqlClient: makeGraphqlClient(9, 'EVE'),
+    })
+
+    expect(outcome.status).toBe('success')
+    expect(outcome.digest).toBe('DiGeSt123')
+    expect(outcome.gas).toEqual({
+      computation: '0.001',
+      storage: '0.002',
+      rebate: '0.0005',
+      net: '0.0025',
+    })
+    expect(outcome.balanceChanges).toEqual([
+      {
+        coinType: EVE_COIN,
+        symbol: 'EVE',
+        name: 'EVE',
+        amount: '12.5',
+        isDebit: false,
+      },
+      {
+        coinType: '0x2::sui::SUI',
+        symbol: 'SUI',
+        name: 'Sui',
+        amount: '0.0025',
+        isDebit: true,
+      },
+    ])
+    expect(outcome.changedObjects).toEqual([
+      {
+        objectId: OBJ_A,
+        kind: 'mutated',
+        objectType: '0x2::coin::Coin<0x2::sui::SUI>',
+        ownerBefore: SENDER,
+        ownerAfter: OTHER,
+      },
+      {
+        objectId: OBJ_B,
+        kind: 'created',
+        objectType: undefined,
+        ownerAfter: 'shared',
+      },
+    ])
+    expect(outcome.events).toEqual([
+      {
+        type: '0xpkg::market::Sale',
+        label: 'market::Sale',
+        json: { price: '12500000000', buyer: OTHER },
+      },
+    ])
+  })
+
+  it('surfaces the abort reason when the transaction would fail', async () => {
+    const suiClient = makeSuiClient({
+      $kind: 'FailedTransaction',
+      FailedTransaction: {
+        effects: {
+          status: {
+            success: false,
+            error: { message: 'MoveAbort in 0xdead::mod::fn: 7' },
+          },
+          gasUsed: GAS_USED,
+          transactionDigest: 'FailDigest',
+          changedObjects: [],
+        },
+        balanceChanges: [],
+      },
+    })
+
+    const outcome = await simulateTransactionOutcome({
+      transactionBytes: bytes,
+      sender: SENDER,
+      suiClient,
+      graphqlClient: makeGraphqlClient(9, 'EVE'),
+    })
+
+    expect(outcome.status).toBe('failure')
+    expect(outcome.error).toBe('MoveAbort in 0xdead::mod::fn: 7')
+    expect(outcome.digest).toBe('FailDigest')
+    expect(outcome.gas.net).toBe('0.0025')
+    expect(outcome.balanceChanges).toEqual([])
+  })
+
+  it('returns an empty change set when nothing touches the sender', async () => {
+    const suiClient = makeSuiClient({
+      $kind: 'Transaction',
+      Transaction: {
+        effects: {
+          status: { success: true, error: null },
+          gasUsed: GAS_USED,
+          changedObjects: [],
+        },
+        balanceChanges: [{ address: OTHER, coinType: EVE_COIN, amount: '5' }],
+      },
+    })
+
+    const outcome = await simulateTransactionOutcome({
+      transactionBytes: bytes,
+      sender: SENDER,
+      suiClient,
+      graphqlClient: makeGraphqlClient(9, 'EVE'),
+    })
+
+    expect(outcome.status).toBe('success')
+    expect(outcome.balanceChanges).toEqual([])
+  })
+})

--- a/packages/shared/src/wallet/__tests__/simulateTransaction.test.ts
+++ b/packages/shared/src/wallet/__tests__/simulateTransaction.test.ts
@@ -171,6 +171,57 @@ describe('simulateTransactionOutcome', () => {
     expect(outcome.balanceChanges).toEqual([])
   })
 
+  it('labels a published package as `published`, not `created`', async () => {
+    const PKG = '0xpkg'
+    const suiClient = makeSuiClient({
+      $kind: 'Transaction',
+      Transaction: {
+        effects: {
+          status: { success: true, error: null },
+          gasUsed: GAS_USED,
+          // A package publish reports Created + PackageWrite.
+          changedObjects: [
+            {
+              objectId: PKG,
+              idOperation: 'Created',
+              outputState: 'PackageWrite',
+            },
+          ],
+        },
+        balanceChanges: [],
+      },
+    })
+
+    const outcome = await simulateTransactionOutcome({
+      transactionBytes: bytes,
+      sender: SENDER,
+      suiClient,
+      graphqlClient: makeGraphqlClient(9, 'EVE'),
+    })
+
+    expect(outcome.changedObjects).toEqual([
+      {
+        objectId: PKG,
+        kind: 'published',
+        objectType: undefined,
+        ownerAfter: undefined,
+      },
+    ])
+  })
+
+  it('throws on an unrecognized response so the caller treats it as unavailable', async () => {
+    const suiClient = makeSuiClient({ $kind: 'SomethingElse' })
+
+    await expect(
+      simulateTransactionOutcome({
+        transactionBytes: bytes,
+        sender: SENDER,
+        suiClient,
+        graphqlClient: makeGraphqlClient(9, 'EVE'),
+      }),
+    ).rejects.toThrow(/Unrecognized simulation response/)
+  })
+
   it('returns an empty change set when nothing touches the sender', async () => {
     const suiClient = makeSuiClient({
       $kind: 'Transaction',

--- a/packages/shared/src/wallet/__tests__/simulateTransaction.test.ts
+++ b/packages/shared/src/wallet/__tests__/simulateTransaction.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { invalidateCoinMetadataCache } from '#/wallet/utils/coinMetadata'
-import { simulateTransactionOutcome } from '#/wallet/utils/simulateTransaction'
+import {
+  classifyBuildFailure,
+  simulateTransactionOutcome,
+} from '#/wallet/utils/simulateTransaction'
 
 const SENDER =
   '0x1111111111111111111111111111111111111111111111111111111111111111'
@@ -244,5 +247,164 @@ describe('simulateTransactionOutcome', () => {
 
     expect(outcome.status).toBe('success')
     expect(outcome.balanceChanges).toEqual([])
+  })
+})
+
+describe('classifyBuildFailure', () => {
+  it('reclassifies a gas-budget-probe SimulationError as a predicted failure', () => {
+    const err = Object.assign(
+      new Error(
+        'Transaction resolution failed: InsufficientCoinBalance in command 0',
+      ),
+      {
+        cause: {
+          $kind: 'FailedTransaction',
+          FailedTransaction: {
+            effects: {
+              status: {
+                success: false,
+                error: { message: 'InsufficientCoinBalance in command 0' },
+              },
+              gasUsed: GAS_USED,
+              transactionDigest: 'ProbeDigest',
+              changedObjects: [],
+            },
+          },
+        },
+      },
+    )
+
+    const outcome = classifyBuildFailure(err)
+
+    expect(outcome).toEqual({
+      status: 'failure',
+      error: 'InsufficientCoinBalance in command 0',
+      digest: 'ProbeDigest',
+      gas: {
+        computation: '0.001',
+        storage: '0.002',
+        rebate: '0.0005',
+        net: '0.0025',
+      },
+      balanceChanges: [],
+      changedObjects: [],
+      events: [],
+    })
+  })
+
+  it('reclassifies a SimulationError via executionError when cause was dropped', () => {
+    // The extension's transpilation of `super(message, { cause })` drops the
+    // cause value, but `.executionError` survives (message + kind).
+    const err = Object.assign(
+      new Error(
+        'Transaction resolution failed: InsufficientCoinBalance in command 0',
+      ),
+      { executionError: { message: 'InsufficientCoinBalance in command 0' } },
+    )
+
+    const outcome = classifyBuildFailure(err)
+
+    expect(outcome).toEqual({
+      status: 'failure',
+      error: 'InsufficientCoinBalance in command 0',
+      digest: '',
+      gas: { computation: '0', storage: '0', rebate: '0', net: '0' },
+      balanceChanges: [],
+      changedObjects: [],
+      events: [],
+    })
+  })
+
+  it('reclassifies a gas-selection insufficient-balance error as a predicted failure', () => {
+    // grpc resolver wraps the RPC failure as a SimulationError with an RpcError
+    // cause and no executionError (@mysten/sui grpc/core.ts:925).
+    const err = Object.assign(
+      new Error(
+        'Unable to perform gas selection due to insufficient SUI balance (in address balance or coins) for account 0xabc to satisfy required budget 2988000.',
+      ),
+      {
+        cause: Object.assign(new Error('rpc'), {
+          name: 'RpcError',
+          code: 'UNKNOWN',
+        }),
+      },
+    )
+
+    const outcome = classifyBuildFailure(err)
+
+    expect(outcome?.status).toBe('failure')
+    expect(outcome?.error).toContain('insufficient SUI balance')
+  })
+
+  it('reclassifies "no valid gas coins" as a predicted failure', () => {
+    const err = new Error('No valid gas coins found for the transaction.')
+
+    expect(classifyBuildFailure(err)?.status).toBe('failure')
+  })
+
+  it('reclassifies invalid transaction inputs (-32002) as a predicted failure', () => {
+    const err = new Error(
+      'Failed to submit transaction: Transaction validator signing failed due to issues with transaction inputs, code: -32002',
+    )
+
+    expect(classifyBuildFailure(err)?.status).toBe('failure')
+  })
+
+  it('reclassifies a VMVerification error as a predicted failure', () => {
+    const err = new Error(
+      'Error executing transaction: VMVerificationOrDeserializationError in command 0',
+    )
+
+    expect(classifyBuildFailure(err)?.status).toBe('failure')
+  })
+
+  it('reclassifies a deterministic gRPC status code as a predicted failure', () => {
+    const err = Object.assign(new Error('rejected'), {
+      cause: Object.assign(new Error('bad'), {
+        name: 'RpcError',
+        code: 'INVALID_ARGUMENT',
+      }),
+    })
+
+    expect(classifyBuildFailure(err)?.status).toBe('failure')
+  })
+
+  it('returns null for a transport error with no deterministic-failure signal', () => {
+    const err = Object.assign(new Error('Service unavailable'), {
+      cause: Object.assign(new Error('unavailable'), {
+        name: 'RpcError',
+        code: 'UNAVAILABLE',
+      }),
+    })
+
+    expect(classifyBuildFailure(err)).toBeNull()
+  })
+
+  it('returns null for object contention (reserved / equivocated)', () => {
+    const reserved = new Error(
+      'Failed to sign transaction by a quorum of validators because one or more of its objects is reserved for another transaction',
+    )
+    const equivocated = new Error(
+      'one or more of its objects is equivocated until the next epoch',
+    )
+
+    expect(classifyBuildFailure(reserved)).toBeNull()
+    expect(classifyBuildFailure(equivocated)).toBeNull()
+  })
+
+  it('returns null for an error whose cause is not a failed simulation', () => {
+    const err = Object.assign(new Error('boom'), {
+      cause: { $kind: 'Transaction' },
+    })
+
+    expect(classifyBuildFailure(err)).toBeNull()
+  })
+
+  it('returns null for an unrelated network error', () => {
+    expect(classifyBuildFailure(new Error('network timeout'))).toBeNull()
+  })
+
+  it('returns null for a non-Error throw', () => {
+    expect(classifyBuildFailure('some string')).toBeNull()
   })
 })

--- a/packages/shared/src/wallet/index.ts
+++ b/packages/shared/src/wallet/index.ts
@@ -27,6 +27,7 @@ export type {
 export type { BalanceAndMetadataResponse } from './types/graphql'
 export { invalidateCoinMetadataCache } from './utils/coinMetadata'
 export {
+  classifyBuildFailure,
   type ObjectChangeKind,
   type SimulatedBalanceChange,
   type SimulatedEvent,

--- a/packages/shared/src/wallet/index.ts
+++ b/packages/shared/src/wallet/index.ts
@@ -27,6 +27,15 @@ export type {
 export type { BalanceAndMetadataResponse } from './types/graphql'
 export { invalidateCoinMetadataCache } from './utils/coinMetadata'
 export {
+  type ObjectChangeKind,
+  type SimulatedBalanceChange,
+  type SimulatedEvent,
+  type SimulatedGas,
+  type SimulatedObjectChange,
+  simulateTransactionOutcome,
+  type TransactionSimulation,
+} from './utils/simulateTransaction'
+export {
   isZkLoginEpochExpiredError,
   withZkLoginEpochRetry,
 } from './zkEpochRetry'

--- a/packages/shared/src/wallet/utils/simulateTransaction.ts
+++ b/packages/shared/src/wallet/utils/simulateTransaction.ts
@@ -1,0 +1,251 @@
+import type { SuiClientTypes } from '@mysten/sui/client'
+import type { SuiGraphQLClient } from '@mysten/sui/graphql'
+import type { SuiGrpcClient } from '@mysten/sui/grpc'
+import { SUI_COIN_TYPE } from '#/utils'
+import { formatByDecimals, formatMistToSui } from '#/utils/format'
+import { fetchCoinMetadata } from './coinMetadata'
+import { extractSymbolFromCoinType } from './formatTransaction'
+
+// Ask the fullnode for the full effect surface: net balance deltas, parsed
+// effects (status, gas, changed objects, digest), the type of every changed
+// object, and emitted events, so the approval popup can show what the
+// transaction actually does.
+const SIMULATE_INCLUDE = {
+  effects: true,
+  balanceChanges: true,
+  objectTypes: true,
+  events: true,
+} as const
+
+type SimulateResult = SuiClientTypes.SimulateTransactionResult<
+  typeof SIMULATE_INCLUDE
+>
+
+export type SimulatedBalanceChange = {
+  coinType: string
+  symbol: string
+  name?: string
+  /** Formatted absolute amount, e.g. "12.5". */
+  amount: string
+  /** True when the account's balance of this coin decreases. */
+  isDebit: boolean
+}
+
+export type ObjectChangeKind =
+  | 'created'
+  | 'mutated'
+  | 'deleted'
+  | 'published'
+  | 'unknown'
+
+export type SimulatedObjectChange = {
+  objectId: string
+  kind: ObjectChangeKind
+  objectType?: string
+  /**
+   * Owner before/after, as display tokens: an address, `shared`, `immutable`,
+   * or `object:0x…`. Only set when the transition is meaningful (a created
+   * object's new owner, or a mutated object whose owner changed).
+   */
+  ownerBefore?: string
+  ownerAfter?: string
+}
+
+export type SimulatedEvent = {
+  /** Full Move type, e.g. `0xpkg::market::Sale`. */
+  type: string
+  /** `module::StructName`, for a compact label. */
+  label: string
+  /** Decoded Move struct data, when the node could render it. */
+  json?: unknown
+}
+
+export type SimulatedGas = {
+  /** All formatted in SUI. */
+  computation: string
+  storage: string
+  rebate: string
+  /** Net fee = computation + storage − rebate. */
+  net: string
+}
+
+export type TransactionSimulation = {
+  status: 'success' | 'failure'
+  /** Set when the transaction would fail on-chain. */
+  error?: string
+  /** Projected transaction digest. */
+  digest: string
+  gas: SimulatedGas
+  /** Net balance changes for the sender; the SUI line already reflects gas. */
+  balanceChanges: SimulatedBalanceChange[]
+  changedObjects: SimulatedObjectChange[]
+  events: SimulatedEvent[]
+}
+
+// Both `Transaction` and `FailedTransaction` responses carry effects (a failed
+// simulation still reports the gas it consumed), so read whichever is present.
+function getInner(result: SimulateResult) {
+  return result.$kind === 'Transaction'
+    ? result.Transaction
+    : result.FailedTransaction
+}
+
+function buildGas(
+  gas: SuiClientTypes.GasCostSummary | undefined,
+): SimulatedGas {
+  const computation = BigInt(gas?.computationCost ?? '0')
+  const storage = BigInt(gas?.storageCost ?? '0')
+  const rebate = BigInt(gas?.storageRebate ?? '0')
+  return {
+    computation: formatMistToSui(computation),
+    storage: formatMistToSui(storage),
+    rebate: formatMistToSui(rebate),
+    net: formatMistToSui(computation + storage - rebate),
+  }
+}
+
+function objectChangeKind(
+  change: SuiClientTypes.ChangedObject,
+): ObjectChangeKind {
+  if (change.idOperation === 'Created') return 'created'
+  if (change.idOperation === 'Deleted') return 'deleted'
+  if (change.outputState === 'PackageWrite') return 'published'
+  if (change.outputState === 'ObjectWrite') return 'mutated'
+  return 'unknown'
+}
+
+// Collapses an ObjectOwner into a single display token: an address, or one of
+// the shorthand kinds. Returns undefined for unknown/absent owners.
+function describeOwner(
+  owner: SuiClientTypes.ObjectOwner | null | undefined,
+): string | undefined {
+  if (!owner) return undefined
+  switch (owner.$kind) {
+    case 'AddressOwner':
+      return owner.AddressOwner
+    case 'ObjectOwner':
+      return `object:${owner.ObjectOwner}`
+    case 'ConsensusAddressOwner':
+      return owner.ConsensusAddressOwner.owner
+    case 'Shared':
+      return 'shared'
+    case 'Immutable':
+      return 'immutable'
+    default:
+      return undefined
+  }
+}
+
+function buildChangedObjects(
+  effects: SuiClientTypes.TransactionEffects | undefined,
+  objectTypes: Record<string, string> | undefined,
+): SimulatedObjectChange[] {
+  return (effects?.changedObjects ?? []).map((change) => {
+    const before = describeOwner(change.inputOwner)
+    const after = describeOwner(change.outputOwner)
+    // Only surface ownership when it tells a story: a brand-new owner, or a
+    // change of hands. A mutation that leaves the owner untouched adds noise.
+    const ownerChanged = change.idOperation === 'Created' || before !== after
+    return {
+      objectId: change.objectId,
+      kind: objectChangeKind(change),
+      objectType: objectTypes?.[change.objectId],
+      ...(ownerChanged && before ? { ownerBefore: before } : {}),
+      ...(ownerChanged && after ? { ownerAfter: after } : {}),
+    }
+  })
+}
+
+function buildEvents(
+  events: SuiClientTypes.Event[] | undefined,
+): SimulatedEvent[] {
+  return (events ?? []).map((event) => {
+    // eventType is `pkg::module::Name`; keep the readable `module::Name` tail.
+    const label = event.eventType.split('::').slice(-2).join('::')
+    return {
+      type: event.eventType,
+      label,
+      ...(event.json != null ? { json: event.json } : {}),
+    }
+  })
+}
+
+async function enrichBalanceChanges(
+  changes: SuiClientTypes.BalanceChange[],
+  graphqlClient: SuiGraphQLClient,
+): Promise<SimulatedBalanceChange[]> {
+  const items: SimulatedBalanceChange[] = []
+  for (const change of changes) {
+    const amount = BigInt(change.amount)
+    if (amount === 0n) continue
+
+    const coinType = change.coinType || SUI_COIN_TYPE
+    const metadata = await fetchCoinMetadata(graphqlClient, coinType)
+    const decimals = metadata?.decimals ?? 9
+    const abs = amount < 0n ? -amount : amount
+
+    items.push({
+      coinType,
+      symbol: metadata?.symbol ?? extractSymbolFromCoinType(coinType),
+      name: metadata?.name ?? undefined,
+      amount: formatByDecimals(abs.toString(), decimals),
+      isDebit: amount < 0n,
+    })
+  }
+  return items
+}
+
+/**
+ * Simulates already-built transaction bytes and shapes the fullnode response
+ * into the projected effect on the sender's account. Throws on transport
+ * failure so callers can distinguish "simulation unavailable" from "the
+ * transaction would fail on-chain".
+ */
+export async function simulateTransactionOutcome({
+  transactionBytes,
+  sender,
+  suiClient,
+  graphqlClient,
+}: {
+  transactionBytes: Uint8Array
+  sender: string
+  suiClient: SuiGrpcClient
+  graphqlClient: SuiGraphQLClient
+}): Promise<TransactionSimulation> {
+  const result = await suiClient.simulateTransaction({
+    transaction: transactionBytes,
+    include: SIMULATE_INCLUDE,
+  })
+
+  const inner = getInner(result)
+  const effects = inner?.effects
+  const gas = buildGas(effects?.gasUsed)
+  const digest = effects?.transactionDigest ?? inner?.digest ?? ''
+  const changedObjects = buildChangedObjects(effects, inner?.objectTypes)
+  const events = buildEvents(inner?.events)
+
+  if (effects?.status.success === false) {
+    return {
+      status: 'failure',
+      error: effects.status.error?.message ?? 'Transaction would fail',
+      digest,
+      gas,
+      balanceChanges: [],
+      changedObjects,
+      events,
+    }
+  }
+
+  const senderChanges = (inner?.balanceChanges ?? []).filter(
+    (bc) => bc.address.toLowerCase() === sender.toLowerCase(),
+  )
+
+  return {
+    status: 'success',
+    digest,
+    gas,
+    balanceChanges: await enrichBalanceChanges(senderChanges, graphqlClient),
+    changedObjects,
+    events,
+  }
+}

--- a/packages/shared/src/wallet/utils/simulateTransaction.ts
+++ b/packages/shared/src/wallet/utils/simulateTransaction.ts
@@ -199,6 +199,144 @@ async function enrichBalanceChanges(
   return items
 }
 
+function buildFailureSimulation({
+  error,
+  digest,
+  effects,
+  objectTypes,
+  events,
+}: {
+  error: string
+  digest?: string
+  effects?: SuiClientTypes.TransactionEffects
+  objectTypes?: Record<string, string>
+  events?: SuiClientTypes.Event[]
+}): TransactionSimulation {
+  return {
+    status: 'failure',
+    error,
+    digest: digest ?? '',
+    gas: buildGas(effects?.gasUsed),
+    balanceChanges: [],
+    changedObjects: buildChangedObjects(effects, objectTypes),
+    events: buildEvents(events),
+  }
+}
+
+// Matches the failed simulate result `SimulationError` from `Transaction#build()`
+// attaches as `.cause` (@mysten/sui `client/core-resolver.ts` `setGasBudget`).
+function isFailedSimulationCause(cause: unknown): cause is {
+  $kind: 'FailedTransaction'
+  FailedTransaction: {
+    effects?: SuiClientTypes.TransactionEffects
+    digest?: string
+    objectTypes?: Record<string, string>
+    events?: SuiClientTypes.Event[]
+  }
+} {
+  return (
+    !!cause &&
+    typeof cause === 'object' &&
+    (cause as { $kind?: unknown }).$kind === 'FailedTransaction' &&
+    'FailedTransaction' in cause
+  )
+}
+
+// Reads the parsed `ExecutionError` a `SimulationError` carries on
+// `.executionError`; survives bundling that drops `.cause`.
+function extractExecutionError(err: Error): { message?: string } | undefined {
+  const executionError = (err as { executionError?: unknown }).executionError
+  return executionError && typeof executionError === 'object'
+    ? (executionError as { message?: string })
+    : undefined
+}
+
+// Canonical gRPC status names, matched against `RpcError.code` on the error's
+// `.cause` — a string like `'UNAVAILABLE'` set from grpcweb's `GrpcStatusCode`.
+// Hardcoded rather than imported: the names are gRPC-spec stable, and comparing
+// strings keeps this decoupled from the transport library that produced them.
+const TRANSIENT_RPC_CODES = new Set([
+  'CANCELLED',
+  'DEADLINE_EXCEEDED',
+  'UNAVAILABLE',
+  'ABORTED',
+  'RESOURCE_EXHAUSTED',
+])
+const DETERMINISTIC_RPC_CODES = new Set([
+  'INVALID_ARGUMENT',
+  'FAILED_PRECONDITION',
+  'OUT_OF_RANGE',
+  'NOT_FOUND',
+  'UNIMPLEMENTED',
+  'PERMISSION_DENIED',
+  'UNAUTHENTICATED',
+])
+
+// Retryable transport/contention failures — outcome unknown.
+const TRANSIENT_MESSAGE =
+  /tim ?e?out|timed out|unavailable|temporarily|overloaded|connection|failed to connect|fetch failed|requires a connection|reserved for another transaction|equivocated|\b(403|429|502|503|504)\b|-32050|-32604/i
+// Failures the node reports before execution that the transaction cannot recover
+// from as-is (gas/balance shortfalls, input validation, verification).
+const DETERMINISTIC_MESSAGE =
+  /insufficient|no valid gas coins|gas selection|could not automatically determine a budget|unusedvalue|vmverification|deserialization|move ?abort|transaction inputs|validator signing failed|invalid sui address|unresolved address|-32002/i
+
+function rpcCode(cause: unknown): string | undefined {
+  const code =
+    cause && typeof cause === 'object'
+      ? (cause as { code?: unknown }).code
+      : undefined
+  return typeof code === 'string' ? code : undefined
+}
+
+export function classifyBuildFailure(
+  err: unknown,
+): TransactionSimulation | null {
+  if (!(err instanceof Error)) return null
+
+  const executionError = extractExecutionError(err)
+
+  // `.cause` carries full effects (gas, digest, changed objects).
+  const cause = (err as Error & { cause?: unknown }).cause
+  if (isFailedSimulationCause(cause)) {
+    const inner = cause.FailedTransaction
+    return buildFailureSimulation({
+      error:
+        inner.effects?.status.error?.message ??
+        executionError?.message ??
+        err.message,
+      digest: inner.effects?.transactionDigest ?? inner.digest,
+      effects: inner.effects,
+      objectTypes: inner.objectTypes,
+      events: inner.events,
+    })
+  }
+
+  // `.cause` dropped; report the abort without effect detail.
+  if (executionError) {
+    return buildFailureSimulation({
+      error: executionError.message ?? err.message,
+    })
+  }
+
+  // Transient first, so an incidental substring can't label a retryable error
+  // as a certain failure. Unrecognized errors fall through to unavailable.
+  const code = rpcCode(cause)
+  if (
+    (code && TRANSIENT_RPC_CODES.has(code)) ||
+    TRANSIENT_MESSAGE.test(err.message)
+  ) {
+    return null
+  }
+  if (
+    (code && DETERMINISTIC_RPC_CODES.has(code)) ||
+    DETERMINISTIC_MESSAGE.test(err.message)
+  ) {
+    return buildFailureSimulation({ error: err.message })
+  }
+
+  return null
+}
+
 /**
  * Simulates already-built transaction bytes and shapes the fullnode response
  * into the projected effect on the sender's account. Throws on transport
@@ -232,15 +370,13 @@ export async function simulateTransactionOutcome({
   const events = buildEvents(inner.events)
 
   if (effects?.status.success === false) {
-    return {
-      status: 'failure',
+    return buildFailureSimulation({
       error: effects.status.error?.message ?? 'Transaction would fail',
       digest,
-      gas,
-      balanceChanges: [],
-      changedObjects,
-      events,
-    }
+      effects,
+      objectTypes: inner.objectTypes,
+      events: inner.events,
+    })
   }
 
   const senderChanges = (inner.balanceChanges ?? []).filter(

--- a/packages/shared/src/wallet/utils/simulateTransaction.ts
+++ b/packages/shared/src/wallet/utils/simulateTransaction.ts
@@ -84,10 +84,12 @@ export type TransactionSimulation = {
 
 // Both `Transaction` and `FailedTransaction` responses carry effects (a failed
 // simulation still reports the gas it consumed), so read whichever is present.
+// Any other shape is unrecognized: return undefined so the caller treats the
+// simulation as unavailable rather than rendering an empty phantom success.
 function getInner(result: SimulateResult) {
-  return result.$kind === 'Transaction'
-    ? result.Transaction
-    : result.FailedTransaction
+  if (result.$kind === 'Transaction') return result.Transaction
+  if (result.$kind === 'FailedTransaction') return result.FailedTransaction
+  return undefined
 }
 
 function buildGas(
@@ -107,9 +109,11 @@ function buildGas(
 function objectChangeKind(
   change: SuiClientTypes.ChangedObject,
 ): ObjectChangeKind {
-  if (change.idOperation === 'Created') return 'created'
   if (change.idOperation === 'Deleted') return 'deleted'
+  // A published package is `Created` + `PackageWrite`; check the output state
+  // first so it is labeled `published` rather than a plain `created` object.
   if (change.outputState === 'PackageWrite') return 'published'
+  if (change.idOperation === 'Created') return 'created'
   if (change.outputState === 'ObjectWrite') return 'mutated'
   return 'unknown'
 }
@@ -218,11 +222,14 @@ export async function simulateTransactionOutcome({
   })
 
   const inner = getInner(result)
-  const effects = inner?.effects
+  if (!inner) {
+    throw new Error(`Unrecognized simulation response: ${result.$kind}`)
+  }
+  const effects = inner.effects
   const gas = buildGas(effects?.gasUsed)
-  const digest = effects?.transactionDigest ?? inner?.digest ?? ''
-  const changedObjects = buildChangedObjects(effects, inner?.objectTypes)
-  const events = buildEvents(inner?.events)
+  const digest = effects?.transactionDigest ?? inner.digest ?? ''
+  const changedObjects = buildChangedObjects(effects, inner.objectTypes)
+  const events = buildEvents(inner.events)
 
   if (effects?.status.success === false) {
     return {
@@ -236,7 +243,7 @@ export async function simulateTransactionOutcome({
     }
   }
 
-  const senderChanges = (inner?.balanceChanges ?? []).filter(
+  const senderChanges = (inner.balanceChanges ?? []).filter(
     (bc) => bc.address.toLowerCase() === sender.toLowerCase(),
   )
 


### PR DESCRIPTION
Addresses [EF-18338](https://fenriscreations.atlassian.net/browse/EF-18338)

When a dApp requests `signTransaction` or `signAndExecuteTransaction` (and for sponsored transactions), the approval popup previously showed only the decoded transaction payload — users had to reason about the raw PTB to know what would happen. This PR simulates the transaction against the fullnode **before approval** and surfaces the projected outcome, so users can see the concrete effect on their account instead of blind-approving.

### What's shown

The popup now leads with a **Projected outcome** view:

- **Status** — expected to succeed / expected to fail (with the on-chain abort reason)
- **Digest** — the projected transaction digest
- **Gas fee** — net (computation + storage − rebate), in SUI
- **Balance changes** — net per-coin deltas for the account, resolved to human-readable amounts/symbols via coin metadata
- **Changed objects** — each changed object's id, type, operation (created / mutated / deleted / published), and ownership transition (e.g. `you → 0x9f…aa`, `→ shared`)
- **Events** — emitted events with their decoded Move struct JSON (the contract's own description of what it did)

If the simulation predicts an **on-chain failure**, the user must tick the acknowledgement checkbox before approving (reuses the existing danger-acknowledgement gate). If simulation can't run (transport error), the popup shows a soft "could not simulate — approve with caution" notice with the reason, and does **not** hard-block.

### Screenshots

<img width="452" height="627" alt="Screenshot 2026-08-19 at 15 58 33" src="https://github.com/user-attachments/assets/7e04e102-83b7-41ba-998b-715b3ded6370" />
<img width="460" height="646" alt="Screenshot 2026-08-19 at 15 58 42" src="https://github.com/user-attachments/assets/414a6ca2-3e4d-4662-bdb7-cbd2378761e9" />

### How it works

- Reuses the gRPC client's `simulateTransaction` (already used for gas estimation) with `include: { effects, balanceChanges, objectTypes, events }`.
- The sender is resolved the same way the signing path does (`getSenderAddress`), not from the dApp payload — the wallet-standard `account.address` doesn't survive the storage round-trip into the popup.
- **dApp transactions** are built (`buildTransactionBytes`) then simulated, so the simulated bytes match what gets signed.
- **Sponsored transactions** are simulated from the already-built backend bytes as-is (rebuilding would drop the sponsor's gas payment).
- Simulation re-runs when the in-popup network selector changes, with a run-id guard to discard stale results.

### Scope

- Covers `sign_transaction`, `sign_and_execute_transaction`, and sponsored transactions.
- Personal-message signing is unaffected (nothing to simulate).