### PR TITLE
feat: enforce aliasing

### DIFF
--- a/.envsample
+++ b/.envsample
@@ -1,1 +1,5 @@
 EXTENSION_ID=
+
+# Address-alias enforcement kill-switch. Defaults to enabled; set to "false"
+# to disable the alias-setup gate and the signing backstop in both apps.
+VITE_ENFORCE_ADDRESS_ALIAS=true

--- a/.envsample
+++ b/.envsample
@@ -1,1 +1,4 @@
 EXTENSION_ID=
+
+# App-side rollout gate for address-alias enforcement.
+VITE_ADDRESS_ALIAS_ENFORCEMENT=true

--- a/.envsample
+++ b/.envsample
@@ -1,5 +1,1 @@
 EXTENSION_ID=
-
-# Address-alias enforcement kill-switch. Defaults to enabled; set to "false"
-# to disable the alias-setup gate and the signing backstop in both apps.
-VITE_ENFORCE_ADDRESS_ALIAS=true

--- a/apps/extension/CHANGELOG.md
+++ b/apps/extension/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @evevault/extension
 
+## 0.0.18
+
+### Patch Changes
+
+- add enforcement address aliasing
+- Updated dependencies
+  - @evevault/shared@0.0.18
+
 ## 0.0.17
 
 ### Patch Changes

--- a/apps/extension/CHANGELOG.md
+++ b/apps/extension/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- add enforcement address aliasing
+- Require zkLogin accounts to register a recovery alias before signing
 - Updated dependencies
   - @evevault/shared@0.0.18
 

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evevault/extension",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "type": "module",
   "scripts": {
     "dev": "wxt",

--- a/apps/extension/src/features/wallet/components/PopupApp.tsx
+++ b/apps/extension/src/features/wallet/components/PopupApp.tsx
@@ -76,7 +76,7 @@ function InitErrorView({ initError }: { initError: string }) {
   return (
     <SplashView title="Error">
       <Text color="error">Error: {initError}</Text>
-      <div className="w-full max-w-[300px]">
+      <div className="w-full max-w-75">
         <Button size="fill" onClick={() => window.location.reload()}>
           Reload
         </Button>

--- a/apps/extension/src/features/wallet/components/SignSponsoredTransaction.tsx
+++ b/apps/extension/src/features/wallet/components/SignSponsoredTransaction.tsx
@@ -3,6 +3,7 @@ import {
   requiresAcknowledgement,
   reviewTransaction,
 } from '@evefrontier/wallet-core/transaction'
+import { useRequireAlias } from '@evevault/shared'
 import { Text } from '@evevault/shared/components'
 import Json from '@evevault/shared/components/Json'
 import type { PendingSponsoredTransaction } from '@evevault/shared/types'
@@ -89,6 +90,7 @@ function SignSponsoredTransaction() {
     getSenderAddress,
     senderAddress,
   } = useWalletSigningContext()
+  const { ensureAlias, aliasSetupModal } = useRequireAlias()
   const {
     pending,
     loading,
@@ -116,6 +118,8 @@ function SignSponsoredTransaction() {
       setError(validationError)
       return
     }
+
+    if (!(await ensureAlias())) return
 
     try {
       setLoading(true)
@@ -203,51 +207,59 @@ function SignSponsoredTransaction() {
   ]
 
   return (
-    <SignRequestView
-      auth={auth}
-      title="Approve sponsored transaction"
-      hasPending={!!pending}
-      loading={loading}
-      error={error}
-      loadingMessage="Loading..."
-      chain={pending?.chain}
-      dapp={pending?.dapp}
-      requestKind="Sponsored transaction"
-      requireAcknowledgement={needsRiskAck || predictedFailure}
-      acknowledgementLabel={
-        predictedFailure && !needsRiskAck
-          ? PREDICTED_FAILURE_ACKNOWLEDGEMENT
-          : undefined
-      }
-      onApprove={handleApprove}
-      onReject={handleReject}
-    >
-      <div className="flex w-full flex-col items-center gap-2">
-        <div className="w-[320px] max-w-[88vw] border border-(--matter-05) p-3">
-          <Text size="small" color="grey-neutral">
-            Sponsored request
-          </Text>
-          <div className="mt-2 flex flex-col gap-2">
-            <SponsoredDetail label="Action" value={pending?.sponsoredAction} />
-            <SponsoredDetail
-              label="Assembly"
-              value={
-                pending?.assembly != null ? String(pending.assembly) : undefined
-              }
-            />
-            <SponsoredDetail label="Type" value={pending?.assemblyType} />
-            <SponsoredDetail label="URL" value={pending?.metadata?.url} />
-            <SponsoredDetail label="Name" value={pending?.metadata?.name} />
-            <SponsoredDetail
-              label="Description"
-              value={pending?.metadata?.description}
-            />
+    <>
+      <SignRequestView
+        auth={auth}
+        title="Approve sponsored transaction"
+        hasPending={!!pending}
+        loading={loading}
+        error={error}
+        loadingMessage="Loading..."
+        chain={pending?.chain}
+        dapp={pending?.dapp}
+        requestKind="Sponsored transaction"
+        requireAcknowledgement={needsRiskAck || predictedFailure}
+        acknowledgementLabel={
+          predictedFailure && !needsRiskAck
+            ? PREDICTED_FAILURE_ACKNOWLEDGEMENT
+            : undefined
+        }
+        onApprove={handleApprove}
+        onReject={handleReject}
+      >
+        <div className="flex w-full flex-col items-center gap-2">
+          <div className="w-[320px] max-w-[88vw] border border-(--matter-05) p-3">
+            <Text size="small" color="grey-neutral">
+              Sponsored request
+            </Text>
+            <div className="mt-2 flex flex-col gap-2">
+              <SponsoredDetail
+                label="Action"
+                value={pending?.sponsoredAction}
+              />
+              <SponsoredDetail
+                label="Assembly"
+                value={
+                  pending?.assembly != null
+                    ? String(pending.assembly)
+                    : undefined
+                }
+              />
+              <SponsoredDetail label="Type" value={pending?.assemblyType} />
+              <SponsoredDetail label="URL" value={pending?.metadata?.url} />
+              <SponsoredDetail label="Name" value={pending?.metadata?.name} />
+              <SponsoredDetail
+                label="Description"
+                value={pending?.metadata?.description}
+              />
+            </div>
           </div>
-        </div>
 
-        {pending && <ApprovalTabs tabs={tabs} />}
-      </div>
-    </SignRequestView>
+          {pending && <ApprovalTabs tabs={tabs} />}
+        </div>
+      </SignRequestView>
+      {aliasSetupModal}
+    </>
   )
 }
 

--- a/apps/extension/src/features/wallet/components/SignTransactionFlow.tsx
+++ b/apps/extension/src/features/wallet/components/SignTransactionFlow.tsx
@@ -3,6 +3,7 @@ import {
   requiresAcknowledgement,
   reviewTransaction,
 } from '@evefrontier/wallet-core/transaction'
+import { useRequireAlias } from '@evevault/shared'
 import Json from '@evevault/shared/components/Json'
 import { useWalletSigningContext } from '@evevault/shared/wallet'
 import {
@@ -48,8 +49,13 @@ export function SignTransactionFlow({
     fallbackSender: pendingTransaction?.account?.address,
   })
 
-  const handleApprove = () =>
-    withSigning((result) => onSign(result, storeResult))
+  const { ensureAlias, aliasSetupModal } = useRequireAlias()
+
+  const handleApprove = async () => {
+    if (!(await ensureAlias())) return
+    await withSigning((result) => onSign(result, storeResult))
+  }
+
   const riskFindings = pendingTransaction
     ? reviewTransaction(pendingTransaction.reviewValue)
     : []
@@ -98,31 +104,34 @@ export function SignTransactionFlow({
     : []
 
   return (
-    <SignRequestView
-      auth={auth}
-      title={title}
-      hasPending={!!pendingTransaction}
-      loading={loading}
-      error={error}
-      loadingMessage="Loading transaction..."
-      chain={pendingTransaction?.chain}
-      dapp={pendingTransaction?.dapp}
-      accountAddress={senderAddress ?? pendingTransaction?.account?.address}
-      requestKind={title}
-      requireAcknowledgement={needsRiskAck || predictedFailure}
-      acknowledgementLabel={
-        predictedFailure && !needsRiskAck
-          ? PREDICTED_FAILURE_ACKNOWLEDGEMENT
-          : undefined
-      }
-      onApprove={handleApprove}
-      onReject={handleReject}
-    >
-      {pendingTransaction && (
-        <div className="flex w-full flex-col items-center gap-2">
-          <ApprovalTabs tabs={tabs} />
-        </div>
-      )}
-    </SignRequestView>
+    <>
+      <SignRequestView
+        auth={auth}
+        title={title}
+        hasPending={!!pendingTransaction}
+        loading={loading}
+        error={error}
+        loadingMessage="Loading transaction..."
+        chain={pendingTransaction?.chain}
+        dapp={pendingTransaction?.dapp}
+        accountAddress={senderAddress ?? pendingTransaction?.account?.address}
+        requestKind={title}
+        requireAcknowledgement={needsRiskAck || predictedFailure}
+        acknowledgementLabel={
+          predictedFailure && !needsRiskAck
+            ? PREDICTED_FAILURE_ACKNOWLEDGEMENT
+            : undefined
+        }
+        onApprove={handleApprove}
+        onReject={handleReject}
+      >
+        {pendingTransaction && (
+          <div className="flex w-full flex-col items-center gap-2">
+            <ApprovalTabs tabs={tabs} />
+          </div>
+        )}
+      </SignRequestView>
+      {aliasSetupModal}
+    </>
   )
 }

--- a/apps/extension/src/features/wallet/components/__tests__/SignExecuteTransaction.test.tsx
+++ b/apps/extension/src/features/wallet/components/__tests__/SignExecuteTransaction.test.tsx
@@ -21,6 +21,15 @@ vi.mock('@evevault/shared/wallet', () => ({
   ADDRESS_ALIAS_MODULE: mockAddressAliasModule,
 }))
 
+// mock useRequireAlias to keep the alias gate open and avoid loading shared's
+// real queryClient (which the react-query mock below doesn't provide).
+vi.mock('@evevault/shared', () => ({
+  useRequireAlias: () => ({
+    ensureAlias: () => Promise.resolve(true),
+    aliasSetupModal: null,
+  }),
+}))
+
 vi.mock('@/features/wallet/components/TransactionSimulationPanel', () => ({
   TransactionSimulationPanel: () => null,
 }))

--- a/apps/extension/src/features/wallet/components/__tests__/SignSponsoredTransaction.test.tsx
+++ b/apps/extension/src/features/wallet/components/__tests__/SignSponsoredTransaction.test.tsx
@@ -29,6 +29,7 @@ vi.mock('@/features/wallet/components/TransactionSimulationPanel', () => ({
 vi.mock('@evevault/shared/wallet', () => ({
   useWalletSigningContext: mockUseWalletSigningContext,
   ADDRESS_ALIAS_MODULE: mockAddressAliasModule,
+  isAliasEnforcementFeatureEnabled: () => false,
 }))
 
 vi.mock('@evevault/shared/utils', async (importOriginal) => {

--- a/apps/extension/src/features/wallet/components/__tests__/SignTransaction.test.tsx
+++ b/apps/extension/src/features/wallet/components/__tests__/SignTransaction.test.tsx
@@ -12,6 +12,7 @@ vi.mock('@/features/wallet/hooks', () => ({
 
 vi.mock('@evevault/shared/wallet', () => ({
   useWalletSigningContext: () => ({ suiClient: {}, chain: 'sui:testnet' }),
+  isAliasEnforcementFeatureEnabled: () => false,
 }))
 
 vi.mock('@/features/wallet/components/TransactionSimulationPanel', () => ({

--- a/apps/extension/src/features/wallet/components/__tests__/SignTransactionFlow.test.tsx
+++ b/apps/extension/src/features/wallet/components/__tests__/SignTransactionFlow.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { mockUseTransactionSigning, mockUseTransactionSimulation } = vi.hoisted(
@@ -15,6 +15,13 @@ vi.mock('@/features/wallet/hooks', () => ({
 
 vi.mock('@evevault/shared/wallet', () => ({
   useWalletSigningContext: () => ({ suiClient: {}, chain: 'sui:testnet' }),
+}))
+
+vi.mock('@evevault/shared', () => ({
+  useRequireAlias: () => ({
+    ensureAlias: () => Promise.resolve(true),
+    aliasSetupModal: null,
+  }),
 }))
 
 vi.mock('@/features/wallet/components/TransactionSimulationPanel', () => ({
@@ -252,7 +259,7 @@ describe('SignTransactionFlow', () => {
     expect(handleReject).toHaveBeenCalledTimes(1)
   })
 
-  it('calls withSigning (via handleApprove) when Approve is clicked', () => {
+  it('calls withSigning (via handleApprove) when Approve is clicked', async () => {
     const withSigning = vi.fn()
     stubSigning({
       pendingTransaction: {
@@ -268,7 +275,9 @@ describe('SignTransactionFlow', () => {
     const onSign = vi.fn()
     render(<SignTransactionFlow title="Sign Transaction" onSign={onSign} />)
     fireEvent.click(screen.getByTestId('approve-btn'))
-    expect(withSigning).toHaveBeenCalledWith(expect.any(Function))
+    await waitFor(() =>
+      expect(withSigning).toHaveBeenCalledWith(expect.any(Function)),
+    )
   })
 })
 

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @evevault/web
 
+## 0.0.18
+
+### Patch Changes
+
+- add enforcement address aliasing
+- Updated dependencies
+  - @evevault/shared@0.0.18
+
 ## 0.0.17
 
 ### Patch Changes

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- add enforcement address aliasing
+- Require zkLogin accounts to register a recovery alias before signing
 - Updated dependencies
   - @evevault/shared@0.0.18
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evevault/web",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- add enforcement address aliasing
+- Require zkLogin accounts to register a recovery alias before signing
 
 ## 0.0.17
 

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @evevault/shared
 
+## 0.0.18
+
+### Patch Changes
+
+- add enforcement address aliasing
+
 ## 0.0.17
 
 ### Patch Changes

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evevault/shared",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "imports": {

--- a/packages/shared/src/components/Button/Button.css
+++ b/packages/shared/src/components/Button/Button.css
@@ -209,3 +209,22 @@
   outline: 2px solid #ff4700;
   outline-offset: 2px;
 }
+
+/* Loading spinner (rendered when isLoading is set) */
+.button__spinner {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  margin-right: 0.5em;
+  vertical-align: -0.125em;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: button-spin 0.6s linear infinite;
+}
+
+@keyframes button-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/packages/shared/src/components/Button/Button.tsx
+++ b/packages/shared/src/components/Button/Button.tsx
@@ -10,11 +10,13 @@ export const Button: FC<ButtonProps> = ({
   children,
   className = '',
   disabled,
+  isLoading = false,
   ...props
 }) => {
   const sizeClass = `button--${size}`
   const variantClass = `button--${variant}`
-  const disabledClass = disabled ? 'button--disabled' : ''
+  const isDisabled = disabled || isLoading
+  const disabledClass = isDisabled ? 'button--disabled' : ''
   const showDecorations = variant === 'primary' || variant === 'secondary'
 
   const contentRef = useRef<HTMLSpanElement>(null)
@@ -53,11 +55,13 @@ export const Button: FC<ButtonProps> = ({
   return (
     <button
       className={`button ${sizeClass} ${variantClass} ${disabledClass} ${className}`.trim()}
-      disabled={disabled}
+      disabled={isDisabled}
+      aria-busy={isLoading || undefined}
       {...props}
     >
       {/* Main content */}
       <span ref={contentRef} className="button__content">
+        {isLoading && <span className="button__spinner" aria-hidden="true" />}
         {children}
       </span>
 

--- a/packages/shared/src/screens/AliasRecoverySetupScreen/AliasRecoverySetupScreen.parts.tsx
+++ b/packages/shared/src/screens/AliasRecoverySetupScreen/AliasRecoverySetupScreen.parts.tsx
@@ -124,8 +124,8 @@ export const TermsStep: React.FC<{
       <Text variant="light" size="large" color="neutral-90">
         Before you can sign transactions, register a personal access key as an
         address alias. This key co-owns your account and lets you keep access if
-        you lose this device. The next screens walk you through generating it,
-        saving your recovery methods, and confirming you understand the terms.
+        you lose this device. The next step generates it, shows your recovery
+        methods, and registers it once you accept the terms.
       </Text>
     </div>
 
@@ -143,19 +143,30 @@ export const TermsStep: React.FC<{
 )
 
 /**
- * Step 2: reveal the generated key and take a single acceptance. Continue is
- * gated only on the acceptance checkbox being ticked.
+ * Step 2 (terminal): reveal the generated key, then a single acceptance both
+ * asserts the user read and agreed to the terms and registers the alias
+ * on-chain. The register button is gated on the acceptance checkbox.
  */
 export const RevealStep: React.FC<{
   aliasKey: GeneratedAliasKey
   accepted: boolean
   onAcceptChange: (accepted: boolean) => void
-  onContinue: () => void
+  isSubmitting: boolean
+  /** Register the alias on-chain. Guarded by the acceptance checkbox. */
+  onRegister: () => void
   /** Discard the generated key and return to the intro step. */
   onBack: () => void
   /** Exit without setting up a key. Omitted when there is no exit path. */
   onCancel?: () => void
-}> = ({ aliasKey, accepted, onAcceptChange, onContinue, onBack, onCancel }) => {
+}> = ({
+  aliasKey,
+  accepted,
+  onAcceptChange,
+  isSubmitting,
+  onRegister,
+  onBack,
+  onCancel,
+}) => {
   const { copy } = useCopyToClipboard('Copied to clipboard')
 
   return (
@@ -184,20 +195,29 @@ export const RevealStep: React.FC<{
       <Checkbox
         name="accept-recovery"
         isChecked={accepted}
-        text="I've saved my recovery phrase or private key — or I accept that I may permanently lose access to this key. It won't be shown again."
+        isDisabled={isSubmitting}
+        text="This key co-owns my account and won't be shown again. I've saved my recovery phrase or private key, or accept I may lose access forever."
         onChange={onAcceptChange}
       />
 
-      <Button disabled={!accepted} onClick={onContinue}>
-        Continue
+      <Button
+        disabled={!accepted || isSubmitting}
+        isLoading={isSubmitting}
+        onClick={onRegister}
+      >
+        Set up personal access key
       </Button>
 
       <div className="flex gap-1">
-        <Button variant="secondary" onClick={onBack}>
+        <Button variant="secondary" disabled={isSubmitting} onClick={onBack}>
           Back
         </Button>
         {onCancel && (
-          <Button variant="secondary" onClick={onCancel}>
+          <Button
+            variant="secondary"
+            disabled={isSubmitting}
+            onClick={onCancel}
+          >
             Cancel
           </Button>
         )}
@@ -205,50 +225,6 @@ export const RevealStep: React.FC<{
     </div>
   )
 }
-
-/**
- * Step 3: the terminal action. Setting up here asserts the user read and agreed
- * to every prior step, then registers the alias on-chain — unblocking signing.
- */
-export const ConfirmStep: React.FC<{
-  isSubmitting: boolean
-  onRegister: () => void
-  onBack: () => void
-  onCancel?: () => void
-}> = ({ isSubmitting, onRegister, onBack, onCancel }) => (
-  <div className="flex flex-col gap-10">
-    <div className="flex flex-col gap-4">
-      <Heading level={2} variant="bold" color="neutral">
-        Confirm and set up
-      </Heading>
-      <Text variant="light" size="large" color="neutral-90">
-        By setting up your personal access key you confirm you have read and
-        agree to everything in the previous steps: this key co-owns your
-        account, it is shown only once and never stored by this app, and you are
-        responsible for saving your recovery phrase or private key.
-      </Text>
-    </div>
-
-    <Button
-      disabled={isSubmitting}
-      isLoading={isSubmitting}
-      onClick={onRegister}
-    >
-      Set up personal access key
-    </Button>
-
-    <div className="flex gap-1">
-      <Button variant="secondary" disabled={isSubmitting} onClick={onBack}>
-        Back
-      </Button>
-      {onCancel && (
-        <Button variant="secondary" disabled={isSubmitting} onClick={onCancel}>
-          Cancel
-        </Button>
-      )}
-    </div>
-  </div>
-)
 
 /** Success state shown once the alias is registered on-chain. */
 export const RecoverySuccess: React.FC<{ onContinue: () => void }> = ({

--- a/packages/shared/src/screens/AliasRecoverySetupScreen/AliasRecoverySetupScreen.parts.tsx
+++ b/packages/shared/src/screens/AliasRecoverySetupScreen/AliasRecoverySetupScreen.parts.tsx
@@ -1,10 +1,33 @@
 import type { GeneratedAliasKey } from '@evefrontier/wallet-core/address-alias'
 import type React from 'react'
+import { useState } from 'react'
 import Button from '#/components/Button'
 import Heading from '#/components/Heading'
 import { Checkbox } from '#/components/Inputs'
 import Text from '#/components/Text'
 import { useCopyToClipboard } from '#/hooks'
+
+/** Progress breadcrumb */
+export const StepDots: React.FC<{
+  steps: readonly string[]
+  current: number
+}> = ({ steps, current }) => (
+  <div
+    className="flex gap-2"
+    role="progressbar"
+    aria-valuenow={current}
+    aria-valuemin={1}
+    aria-valuemax={steps.length}
+    aria-label={`Step ${current} of ${steps.length}`}
+  >
+    {steps.map((step, i) => (
+      <span
+        key={step}
+        className={`h-2 w-2 rounded-full ${i < current ? 'bg-neutral' : 'bg-neutral/20'}`}
+      />
+    ))}
+  </div>
+)
 
 /** Critical warning about the co-owner semantics of a personal access alias. */
 export const RecoveryWarningBanner: React.FC = () => (
@@ -18,65 +41,121 @@ export const RecoveryWarningBanner: React.FC = () => (
   </div>
 )
 
-/** A labelled, copyable secret value, with an optional note describing its format. */
+/**
+ * A labelled secret value with an optional format note. When `revealable`, the
+ * value is blurred until the user clicks "Reveal"; copy is offered only once
+ * revealed.
+ */
 const SecretField: React.FC<{
   label: string
   value: string
   onCopy: () => void
   formatHint?: string
-}> = ({ label, value, onCopy, formatHint }) => (
-  <div className="flex flex-col gap-2 w-full">
-    <div className="flex justify-between items-center">
-      <Text variant="bold" size="small" color="neutral-90">
-        {label}
-      </Text>
-      <Button variant="secondary" size="small" onClick={onCopy}>
-        Copy
-      </Button>
+  revealable?: boolean
+}> = ({ label, value, onCopy, formatHint, revealable }) => {
+  const [revealed, setRevealed] = useState(false)
+  const hidden = revealable && !revealed
+
+  return (
+    <div className="flex flex-col gap-2 w-full">
+      <div className="flex justify-between items-center">
+        <Text variant="bold" size="small" color="neutral-90">
+          {label}
+        </Text>
+        {hidden ? (
+          <Button
+            variant="secondary"
+            size="small"
+            onClick={() => setRevealed(true)}
+          >
+            Reveal
+          </Button>
+        ) : (
+          <div className="flex gap-1">
+            {revealable && (
+              <Button
+                variant="secondary"
+                size="small"
+                onClick={() => setRevealed(false)}
+              >
+                Hide
+              </Button>
+            )}
+            <Button variant="secondary" size="small" onClick={onCopy}>
+              Copy
+            </Button>
+          </div>
+        )}
+      </div>
+      {formatHint && (
+        <Text
+          variant="light"
+          size="xsmall"
+          color="neutral-60"
+          style={{ fontSize: '12px', lineHeight: '16px' }}
+        >
+          {formatHint}
+        </Text>
+      )}
+      <div className="w-full rounded border border-(--quantum-30) bg-(--quantum-10) p-2">
+        <Text
+          variant="light"
+          size="xsmall"
+          color="neutral-90"
+          className={`break-all font-mono ${hidden ? 'blur-sm select-none' : ''}`}
+        >
+          {value}
+        </Text>
+      </div>
     </div>
-    {formatHint && (
-      <Text
-        variant="light"
-        size="xsmall"
-        color="neutral-60"
-        style={{ fontSize: '12px', lineHeight: '16px' }}
-      >
-        {formatHint}
+  )
+}
+
+/** Step 1: introduce the personal access key and its co-owner risk before generating one. */
+export const TermsStep: React.FC<{
+  onContinue: () => void
+  onCancel?: () => void
+}> = ({ onContinue, onCancel }) => (
+  <div className="flex flex-col gap-10">
+    <div className="flex flex-col gap-4">
+      <Heading level={2} variant="bold" color="neutral">
+        Set up your personal access key
+      </Heading>
+      <Text variant="light" size="large" color="neutral-90">
+        Before you can sign transactions, register a personal access key as an
+        address alias. This key co-owns your account and lets you keep access if
+        you lose this device. The next screens walk you through generating it,
+        saving your recovery methods, and confirming you understand the terms.
       </Text>
-    )}
-    <div className="w-full rounded border border-(--quantum-30) bg-(--quantum-10) p-2">
-      <Text
-        variant="light"
-        size="xsmall"
-        color="neutral-90"
-        className="break-all font-mono"
-      >
-        {value}
-      </Text>
+    </div>
+
+    <RecoveryWarningBanner />
+
+    <div className="flex flex-col gap-4">
+      <Button onClick={onContinue}>I understand — continue</Button>
+      {onCancel && (
+        <Button variant="secondary" onClick={onCancel}>
+          Cancel
+        </Button>
+      )}
     </div>
   </div>
 )
 
-/** Reveals the generated personal access key once and gates registration on acknowledgement. */
-export const RecoveryKeyReveal: React.FC<{
+/**
+ * Step 2: reveal the generated key and take a single acceptance. Continue is
+ * gated only on the acceptance checkbox being ticked.
+ */
+export const RevealStep: React.FC<{
   aliasKey: GeneratedAliasKey
-  acknowledged: boolean
-  onAcknowledgeChange: (checked: boolean) => void
-  isSubmitting: boolean
-  onRegister: () => void
+  accepted: boolean
+  onAcceptChange: (accepted: boolean) => void
+  onContinue: () => void
   /** Discard the generated key and return to the intro step. */
   onBack: () => void
   /** Exit without setting up a key. Omitted when there is no exit path. */
   onCancel?: () => void
-}> = ({
-  aliasKey,
-  acknowledged,
-  onAcknowledgeChange,
-  isSubmitting,
-  onRegister,
-  onBack,
-  onCancel,
-}) => {
+}> = ({ aliasKey, accepted, onAcceptChange, onContinue, onBack, onCancel }) => {
   const { copy } = useCopyToClipboard('Copied to clipboard')
 
   return (
@@ -84,12 +163,14 @@ export const RecoveryKeyReveal: React.FC<{
       <SecretField
         label="Recovery phrase"
         value={aliasKey.mnemonic}
+        revealable
         onCopy={() => copy(aliasKey.mnemonic)}
         formatHint="A standard 24-word BIP-39 mnemonic. Any wallet that supports BIP-39 can restore the same key from these words."
       />
       <SecretField
         label="Private key"
         value={aliasKey.privateKey}
+        revealable
         onCopy={() => copy(aliasKey.privateKey)}
         formatHint="A Sui Ed25519 private key, Bech32-encoded with the 'suiprivkey1' prefix. Derived from the recovery phrase above — either one alone can restore this key."
       />
@@ -101,31 +182,22 @@ export const RecoveryKeyReveal: React.FC<{
       />
 
       <Checkbox
-        name="acknowledge-recovery-key"
-        isChecked={acknowledged}
-        text="I've saved my recovery phrase and private key somewhere safe"
-        isDisabled={isSubmitting}
-        onChange={onAcknowledgeChange}
+        name="accept-recovery"
+        isChecked={accepted}
+        text="I've saved my recovery phrase or private key — or I accept that I may permanently lose access to this key. It won't be shown again."
+        onChange={onAcceptChange}
       />
 
-      <Button
-        disabled={!acknowledged || isSubmitting}
-        isLoading={isSubmitting}
-        onClick={onRegister}
-      >
-        Register personal access key
+      <Button disabled={!accepted} onClick={onContinue}>
+        Continue
       </Button>
 
       <div className="flex gap-1">
-        <Button variant="secondary" disabled={isSubmitting} onClick={onBack}>
+        <Button variant="secondary" onClick={onBack}>
           Back
         </Button>
         {onCancel && (
-          <Button
-            variant="secondary"
-            disabled={isSubmitting}
-            onClick={onCancel}
-          >
+          <Button variant="secondary" onClick={onCancel}>
             Cancel
           </Button>
         )}
@@ -133,6 +205,50 @@ export const RecoveryKeyReveal: React.FC<{
     </div>
   )
 }
+
+/**
+ * Step 3: the terminal action. Setting up here asserts the user read and agreed
+ * to every prior step, then registers the alias on-chain — unblocking signing.
+ */
+export const ConfirmStep: React.FC<{
+  isSubmitting: boolean
+  onRegister: () => void
+  onBack: () => void
+  onCancel?: () => void
+}> = ({ isSubmitting, onRegister, onBack, onCancel }) => (
+  <div className="flex flex-col gap-10">
+    <div className="flex flex-col gap-4">
+      <Heading level={2} variant="bold" color="neutral">
+        Confirm and set up
+      </Heading>
+      <Text variant="light" size="large" color="neutral-90">
+        By setting up your personal access key you confirm you have read and
+        agree to everything in the previous steps: this key co-owns your
+        account, it is shown only once and never stored by this app, and you are
+        responsible for saving your recovery phrase or private key.
+      </Text>
+    </div>
+
+    <Button
+      disabled={isSubmitting}
+      isLoading={isSubmitting}
+      onClick={onRegister}
+    >
+      Set up personal access key
+    </Button>
+
+    <div className="flex gap-1">
+      <Button variant="secondary" disabled={isSubmitting} onClick={onBack}>
+        Back
+      </Button>
+      {onCancel && (
+        <Button variant="secondary" disabled={isSubmitting} onClick={onCancel}>
+          Cancel
+        </Button>
+      )}
+    </div>
+  </div>
+)
 
 /** Success state shown once the alias is registered on-chain. */
 export const RecoverySuccess: React.FC<{ onContinue: () => void }> = ({

--- a/packages/shared/src/screens/AliasRecoverySetupScreen/AliasRecoverySetupScreen.parts.tsx
+++ b/packages/shared/src/screens/AliasRecoverySetupScreen/AliasRecoverySetupScreen.parts.tsx
@@ -1,0 +1,153 @@
+import type { GeneratedAliasKey } from '@evefrontier/wallet-core/address-alias'
+import type React from 'react'
+import Button from '#/components/Button'
+import Heading from '#/components/Heading'
+import { Checkbox } from '#/components/Inputs'
+import Text from '#/components/Text'
+import { useCopyToClipboard } from '#/hooks'
+
+/** Critical warning about the co-owner semantics of a personal access alias. */
+export const RecoveryWarningBanner: React.FC = () => (
+  <div className="w-full rounded border border-critical bg-critical/50 p-2">
+    <Text variant="light" size="xsmall">
+      Anyone with this recovery phrase or personal access key has complete,
+      unilateral control over your account and can take all of its coins,
+      balances, and other resources. Save it somewhere safe and private. It will
+      be shown only once and is never stored by this app.
+    </Text>
+  </div>
+)
+
+/** A labelled, copyable secret value, with an optional note describing its format. */
+const SecretField: React.FC<{
+  label: string
+  value: string
+  onCopy: () => void
+  formatHint?: string
+}> = ({ label, value, onCopy, formatHint }) => (
+  <div className="flex flex-col gap-2 w-full">
+    <div className="flex justify-between items-center">
+      <Text variant="bold" size="small" color="neutral-90">
+        {label}
+      </Text>
+      <Button variant="secondary" size="small" onClick={onCopy}>
+        Copy
+      </Button>
+    </div>
+    {formatHint && (
+      <Text
+        variant="light"
+        size="xsmall"
+        color="neutral-60"
+        style={{ fontSize: '12px', lineHeight: '16px' }}
+      >
+        {formatHint}
+      </Text>
+    )}
+    <div className="w-full rounded border border-(--quantum-30) bg-(--quantum-10) p-2">
+      <Text
+        variant="light"
+        size="xsmall"
+        color="neutral-90"
+        className="break-all font-mono"
+      >
+        {value}
+      </Text>
+    </div>
+  </div>
+)
+
+/** Reveals the generated personal access key once and gates registration on acknowledgement. */
+export const RecoveryKeyReveal: React.FC<{
+  aliasKey: GeneratedAliasKey
+  acknowledged: boolean
+  onAcknowledgeChange: (checked: boolean) => void
+  isSubmitting: boolean
+  onRegister: () => void
+  /** Discard the generated key and return to the intro step. */
+  onBack: () => void
+  /** Exit without setting up a key. Omitted when there is no exit path. */
+  onCancel?: () => void
+}> = ({
+  aliasKey,
+  acknowledged,
+  onAcknowledgeChange,
+  isSubmitting,
+  onRegister,
+  onBack,
+  onCancel,
+}) => {
+  const { copy } = useCopyToClipboard('Copied to clipboard')
+
+  return (
+    <div className="flex flex-col gap-6 w-full">
+      <SecretField
+        label="Recovery phrase"
+        value={aliasKey.mnemonic}
+        onCopy={() => copy(aliasKey.mnemonic)}
+        formatHint="A standard 24-word BIP-39 mnemonic. Any wallet that supports BIP-39 can restore the same key from these words."
+      />
+      <SecretField
+        label="Private key"
+        value={aliasKey.privateKey}
+        onCopy={() => copy(aliasKey.privateKey)}
+        formatHint="A Sui Ed25519 private key, Bech32-encoded with the 'suiprivkey1' prefix. Derived from the recovery phrase above — either one alone can restore this key."
+      />
+      <SecretField
+        label="Alias address"
+        value={aliasKey.address}
+        onCopy={() => copy(aliasKey.address)}
+        formatHint="The Sui address derived from this key. This is what gets registered on-chain as your alias."
+      />
+
+      <Checkbox
+        name="acknowledge-recovery-key"
+        isChecked={acknowledged}
+        text="I've saved my recovery phrase and private key somewhere safe"
+        isDisabled={isSubmitting}
+        onChange={onAcknowledgeChange}
+      />
+
+      <Button
+        disabled={!acknowledged || isSubmitting}
+        isLoading={isSubmitting}
+        onClick={onRegister}
+      >
+        Register personal access key
+      </Button>
+
+      <div className="flex gap-1">
+        <Button variant="secondary" disabled={isSubmitting} onClick={onBack}>
+          Back
+        </Button>
+        {onCancel && (
+          <Button
+            variant="secondary"
+            disabled={isSubmitting}
+            onClick={onCancel}
+          >
+            Cancel
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/** Success state shown once the alias is registered on-chain. */
+export const RecoverySuccess: React.FC<{ onContinue: () => void }> = ({
+  onContinue,
+}) => (
+  <div className="flex flex-col gap-10">
+    <div className="flex flex-col gap-4">
+      <Heading level={2} variant="bold" color="neutral">
+        Recovery alias registered
+      </Heading>
+      <Text variant="light" size="large" color="neutral-90">
+        Your personal access key is now a co-owner of your account. You can sign
+        transactions.
+      </Text>
+    </div>
+    <Button onClick={onContinue}>Continue</Button>
+  </div>
+)

--- a/packages/shared/src/screens/AliasRecoverySetupScreen/AliasRecoverySetupScreen.tsx
+++ b/packages/shared/src/screens/AliasRecoverySetupScreen/AliasRecoverySetupScreen.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react'
 import Text from '#/components/Text'
 import { useAliasProvisioning } from '#/wallet'
 import {
-  ConfirmStep,
   RecoverySuccess,
   RevealStep,
   StepDots,
@@ -19,15 +18,15 @@ export interface AliasRecoverySetupScreenProps {
   onCancel?: () => void
 }
 
-const STEP_ORDER = ['terms', 'reveal', 'confirm'] as const
+const STEP_ORDER = ['terms', 'reveal'] as const
 type Step = (typeof STEP_ORDER)[number]
 
 /**
  * Onboarding gate shown when a zkLogin account has no non-self address alias.
- * A multi-step terms-and-conditions clickthrough: the user reads the terms,
- * reveals a one-time client-only personal access key and accepts the recovery
- * terms, then confirms — the final step registers the key's address on-chain as
- * an alias.
+ * A two-step terms-and-conditions clickthrough: the user reads the terms, then
+ * reveals a one-time client-only personal access key and accepts the terms —
+ * that acceptance registers the key's address on-chain as an alias. A success
+ * screen confirms setup.
  */
 export const AliasRecoverySetupScreen: React.FC<
   AliasRecoverySetupScreenProps
@@ -43,6 +42,8 @@ export const AliasRecoverySetupScreen: React.FC<
 
   return (
     <div className="flex flex-col gap-10">
+      <StepDots steps={STEP_ORDER} current={STEP_ORDER.indexOf(step) + 1} />
+
       {step === 'terms' && (
         <TermsStep
           onContinue={() => {
@@ -58,7 +59,10 @@ export const AliasRecoverySetupScreen: React.FC<
           aliasKey={aliasKey}
           accepted={accepted}
           onAcceptChange={setAccepted}
-          onContinue={() => setStep('confirm')}
+          isSubmitting={isSubmitting}
+          // wallet-core's register(acknowledged) takes only a boolean; ticking
+          // the acceptance checkbox is the acknowledgement.
+          onRegister={() => register(true)}
           onBack={() => {
             clear()
             setAccepted(false)
@@ -67,19 +71,6 @@ export const AliasRecoverySetupScreen: React.FC<
           onCancel={onCancel}
         />
       )}
-
-      {step === 'confirm' && (
-        <ConfirmStep
-          isSubmitting={isSubmitting}
-          // wallet-core's register(acknowledged) takes only a boolean; reaching
-          // this step (having ticked the acceptance checkbox) is the acknowledgement.
-          onRegister={() => register(true)}
-          onBack={() => setStep('reveal')}
-          onCancel={onCancel}
-        />
-      )}
-
-      <StepDots steps={STEP_ORDER} current={STEP_ORDER.indexOf(step) + 1} />
 
       {error && (
         <div className="w-full rounded border border-red-10/30 bg-red-10/10 p-2">

--- a/packages/shared/src/screens/AliasRecoverySetupScreen/AliasRecoverySetupScreen.tsx
+++ b/packages/shared/src/screens/AliasRecoverySetupScreen/AliasRecoverySetupScreen.tsx
@@ -1,0 +1,91 @@
+import type React from 'react'
+import { useState } from 'react'
+import Button from '#/components/Button'
+import Heading from '#/components/Heading'
+import Text from '#/components/Text'
+import { useAliasProvisioning } from '#/wallet'
+import {
+  RecoveryKeyReveal,
+  RecoverySuccess,
+  RecoveryWarningBanner,
+} from './AliasRecoverySetupScreen.parts'
+
+export interface AliasRecoverySetupScreenProps {
+  /** Called after successful registration (e.g. to refresh the enforcement gate). */
+  onComplete?: () => void
+  /**
+   * Exit without setting up a key.
+   */
+  onCancel?: () => void
+}
+
+/**
+ * Onboarding gate shown when a zkLogin account has no non-self address alias.
+ * Generates a one-time client-only personal access key, reveals it once, requires an
+ * explicit acknowledgement, then registers its address on-chain as an alias —
+ * unblocking signing.
+ */
+export const AliasRecoverySetupScreen: React.FC<
+  AliasRecoverySetupScreenProps
+> = ({ onComplete, onCancel }) => {
+  const { aliasKey, generate, clear, register, isSubmitting, error, txDigest } =
+    useAliasProvisioning()
+  const [acknowledged, setAcknowledged] = useState(false)
+
+  if (txDigest) {
+    return <RecoverySuccess onContinue={() => onComplete?.()} />
+  }
+
+  return (
+    <div className="flex flex-col gap-10">
+      <div className="flex flex-col gap-4">
+        <Heading level={2} variant="bold" color="neutral">
+          Set up your personal access key
+        </Heading>
+        <Text variant="light" size="large" color="neutral-90">
+          Before you can sign transactions, register a personal access key as an
+          address alias. This key co-owns your account and lets you keep access
+          if you lose this device.
+        </Text>
+      </div>
+
+      <RecoveryWarningBanner />
+
+      {!aliasKey ? (
+        <div className="flex flex-col gap-4">
+          <Button isLoading={isSubmitting} onClick={generate}>
+            Generate personal access key
+          </Button>
+          {onCancel && (
+            <Button variant="secondary" onClick={onCancel}>
+              Cancel
+            </Button>
+          )}
+        </div>
+      ) : (
+        <RecoveryKeyReveal
+          aliasKey={aliasKey}
+          acknowledged={acknowledged}
+          onAcknowledgeChange={setAcknowledged}
+          isSubmitting={isSubmitting}
+          onRegister={() => register(true)}
+          onBack={() => {
+            setAcknowledged(false)
+            clear()
+          }}
+          onCancel={onCancel}
+        />
+      )}
+
+      {error && (
+        <div className="w-full rounded border border-red-10/30 bg-red-10/10 p-2">
+          <Text variant="light" size="xsmall" color="error">
+            {error}
+          </Text>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default AliasRecoverySetupScreen

--- a/packages/shared/src/screens/AliasRecoverySetupScreen/AliasRecoverySetupScreen.tsx
+++ b/packages/shared/src/screens/AliasRecoverySetupScreen/AliasRecoverySetupScreen.tsx
@@ -1,13 +1,13 @@
 import type React from 'react'
 import { useState } from 'react'
-import Button from '#/components/Button'
-import Heading from '#/components/Heading'
 import Text from '#/components/Text'
 import { useAliasProvisioning } from '#/wallet'
 import {
-  RecoveryKeyReveal,
+  ConfirmStep,
   RecoverySuccess,
-  RecoveryWarningBanner,
+  RevealStep,
+  StepDots,
+  TermsStep,
 } from './AliasRecoverySetupScreen.parts'
 
 export interface AliasRecoverySetupScreenProps {
@@ -19,18 +19,23 @@ export interface AliasRecoverySetupScreenProps {
   onCancel?: () => void
 }
 
+const STEP_ORDER = ['terms', 'reveal', 'confirm'] as const
+type Step = (typeof STEP_ORDER)[number]
+
 /**
  * Onboarding gate shown when a zkLogin account has no non-self address alias.
- * Generates a one-time client-only personal access key, reveals it once, requires an
- * explicit acknowledgement, then registers its address on-chain as an alias —
- * unblocking signing.
+ * A multi-step terms-and-conditions clickthrough: the user reads the terms,
+ * reveals a one-time client-only personal access key and accepts the recovery
+ * terms, then confirms — the final step registers the key's address on-chain as
+ * an alias.
  */
 export const AliasRecoverySetupScreen: React.FC<
   AliasRecoverySetupScreenProps
 > = ({ onComplete, onCancel }) => {
   const { aliasKey, generate, clear, register, isSubmitting, error, txDigest } =
     useAliasProvisioning()
-  const [acknowledged, setAcknowledged] = useState(false)
+  const [step, setStep] = useState<Step>('terms')
+  const [accepted, setAccepted] = useState(false)
 
   if (txDigest) {
     return <RecoverySuccess onContinue={() => onComplete?.()} />
@@ -38,44 +43,43 @@ export const AliasRecoverySetupScreen: React.FC<
 
   return (
     <div className="flex flex-col gap-10">
-      <div className="flex flex-col gap-4">
-        <Heading level={2} variant="bold" color="neutral">
-          Set up your personal access key
-        </Heading>
-        <Text variant="light" size="large" color="neutral-90">
-          Before you can sign transactions, register a personal access key as an
-          address alias. This key co-owns your account and lets you keep access
-          if you lose this device.
-        </Text>
-      </div>
-
-      <RecoveryWarningBanner />
-
-      {!aliasKey ? (
-        <div className="flex flex-col gap-4">
-          <Button isLoading={isSubmitting} onClick={generate}>
-            Generate personal access key
-          </Button>
-          {onCancel && (
-            <Button variant="secondary" onClick={onCancel}>
-              Cancel
-            </Button>
-          )}
-        </div>
-      ) : (
-        <RecoveryKeyReveal
-          aliasKey={aliasKey}
-          acknowledged={acknowledged}
-          onAcknowledgeChange={setAcknowledged}
-          isSubmitting={isSubmitting}
-          onRegister={() => register(true)}
-          onBack={() => {
-            setAcknowledged(false)
-            clear()
+      {step === 'terms' && (
+        <TermsStep
+          onContinue={() => {
+            if (!aliasKey) generate()
+            setStep('reveal')
           }}
           onCancel={onCancel}
         />
       )}
+
+      {step === 'reveal' && aliasKey && (
+        <RevealStep
+          aliasKey={aliasKey}
+          accepted={accepted}
+          onAcceptChange={setAccepted}
+          onContinue={() => setStep('confirm')}
+          onBack={() => {
+            clear()
+            setAccepted(false)
+            setStep('terms')
+          }}
+          onCancel={onCancel}
+        />
+      )}
+
+      {step === 'confirm' && (
+        <ConfirmStep
+          isSubmitting={isSubmitting}
+          // wallet-core's register(acknowledged) takes only a boolean; reaching
+          // this step (having ticked the acceptance checkbox) is the acknowledgement.
+          onRegister={() => register(true)}
+          onBack={() => setStep('reveal')}
+          onCancel={onCancel}
+        />
+      )}
+
+      <StepDots steps={STEP_ORDER} current={STEP_ORDER.indexOf(step) + 1} />
 
       {error && (
         <div className="w-full rounded border border-red-10/30 bg-red-10/10 p-2">

--- a/packages/shared/src/screens/AliasRecoverySetupScreen/__tests__/useRequireAlias.test.tsx
+++ b/packages/shared/src/screens/AliasRecoverySetupScreen/__tests__/useRequireAlias.test.tsx
@@ -83,14 +83,15 @@ describe('useRequireAlias', () => {
     expect(mockResolve).toHaveBeenCalledWith(OWNER, 'sui:testnet')
   })
 
-  it('throws when zklogin enforcement applies but no sender is available', async () => {
+  it('does not gate when no sender is available', async () => {
     mockSigningContext.mockReturnValue({
       mode: 'zklogin',
       senderAddress: null,
       chain: 'sui:testnet',
     })
     render(<Harness />)
-    await expect(api.ensureAlias()).rejects.toThrow('No sender address')
+    await expect(api.ensureAlias()).resolves.toBe(true)
+    expect(mockResolve).not.toHaveBeenCalled()
   })
 
   it('opens the modal and resolves true once registration completes', async () => {

--- a/packages/shared/src/screens/AliasRecoverySetupScreen/__tests__/useRequireAlias.test.tsx
+++ b/packages/shared/src/screens/AliasRecoverySetupScreen/__tests__/useRequireAlias.test.tsx
@@ -3,11 +3,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { UseRequireAliasResult } from '../useRequireAlias'
 
 const mockSigningContext = vi.fn()
+const mockFeatureEnabled = vi.fn()
 const mockOverridden = vi.fn()
 const mockResolve = vi.fn()
 
 vi.mock('#/wallet', () => ({
   useWalletSigningContext: () => mockSigningContext(),
+  isAliasEnforcementFeatureEnabled: () => mockFeatureEnabled(),
   isEnforcementOverridden: (...args: unknown[]) => mockOverridden(...args),
   resolveAliasEnforcementStatus: (...args: unknown[]) => mockResolve(...args),
 }))
@@ -53,11 +55,19 @@ beforeEach(() => {
     senderAddress: OWNER,
     chain: 'sui:testnet',
   })
+  mockFeatureEnabled.mockReset().mockReturnValue(true)
   mockOverridden.mockReset().mockReturnValue(false)
   mockResolve.mockReset()
 })
 
 describe('useRequireAlias', () => {
+  it('allows immediately when the feature is staged off', async () => {
+    mockFeatureEnabled.mockReturnValue(false)
+    render(<Harness />)
+    await expect(api.ensureAlias()).resolves.toBe(true)
+    expect(mockResolve).not.toHaveBeenCalled()
+  })
+
   it('allows immediately when an ops override is active', async () => {
     mockOverridden.mockReturnValue(true)
     render(<Harness />)

--- a/packages/shared/src/screens/AliasRecoverySetupScreen/__tests__/useRequireAlias.test.tsx
+++ b/packages/shared/src/screens/AliasRecoverySetupScreen/__tests__/useRequireAlias.test.tsx
@@ -3,12 +3,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { UseRequireAliasResult } from '../useRequireAlias'
 
 const mockSigningContext = vi.fn()
-const mockEnabled = vi.fn()
+const mockOverridden = vi.fn()
 const mockResolve = vi.fn()
 
 vi.mock('#/wallet', () => ({
   useWalletSigningContext: () => mockSigningContext(),
-  isAddressAliasEnforcementEnabled: () => mockEnabled(),
+  isEnforcementOverridden: (...args: unknown[]) => mockOverridden(...args),
   resolveAliasEnforcementStatus: (...args: unknown[]) => mockResolve(...args),
 }))
 
@@ -53,13 +53,13 @@ beforeEach(() => {
     senderAddress: OWNER,
     chain: 'sui:testnet',
   })
-  mockEnabled.mockReset().mockReturnValue(true)
+  mockOverridden.mockReset().mockReturnValue(false)
   mockResolve.mockReset()
 })
 
 describe('useRequireAlias', () => {
-  it('allows immediately when enforcement is disabled', async () => {
-    mockEnabled.mockReturnValue(false)
+  it('allows immediately when an ops override is active', async () => {
+    mockOverridden.mockReturnValue(true)
     render(<Harness />)
     await expect(api.ensureAlias()).resolves.toBe(true)
     expect(mockResolve).not.toHaveBeenCalled()

--- a/packages/shared/src/screens/AliasRecoverySetupScreen/__tests__/useRequireAlias.test.tsx
+++ b/packages/shared/src/screens/AliasRecoverySetupScreen/__tests__/useRequireAlias.test.tsx
@@ -1,0 +1,125 @@
+import { act, render, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { UseRequireAliasResult } from '../useRequireAlias'
+
+const mockSigningContext = vi.fn()
+const mockEnabled = vi.fn()
+const mockResolve = vi.fn()
+
+vi.mock('#/wallet', () => ({
+  useWalletSigningContext: () => mockSigningContext(),
+  isAddressAliasEnforcementEnabled: () => mockEnabled(),
+  resolveAliasEnforcementStatus: (...args: unknown[]) => mockResolve(...args),
+}))
+
+// Capture the props handed to the setup screen so tests can drive
+// onComplete / onCancel without exercising the real registration flow.
+let setupProps: { onComplete: () => void; onCancel: () => void } | null = null
+vi.mock('../AliasRecoverySetupScreen', () => ({
+  AliasRecoverySetupScreen: (props: {
+    onComplete: () => void
+    onCancel: () => void
+  }) => {
+    setupProps = props
+    return null
+  },
+}))
+
+// Render the modal's children only while open, mirroring the real Modal.
+vi.mock('#/components', () => ({
+  Modal: ({
+    isOpen,
+    children,
+  }: {
+    isOpen: boolean
+    children: React.ReactNode
+  }) => (isOpen ? children : null),
+}))
+
+import { useRequireAlias } from '../useRequireAlias'
+
+const OWNER = `0x${'a'.repeat(64)}`
+
+let api: UseRequireAliasResult
+function Harness() {
+  api = useRequireAlias()
+  return <>{api.aliasSetupModal}</>
+}
+
+beforeEach(() => {
+  setupProps = null
+  mockSigningContext.mockReset().mockReturnValue({
+    mode: 'zklogin',
+    senderAddress: OWNER,
+    chain: 'sui:testnet',
+  })
+  mockEnabled.mockReset().mockReturnValue(true)
+  mockResolve.mockReset()
+})
+
+describe('useRequireAlias', () => {
+  it('allows immediately when enforcement is disabled', async () => {
+    mockEnabled.mockReturnValue(false)
+    render(<Harness />)
+    await expect(api.ensureAlias()).resolves.toBe(true)
+    expect(mockResolve).not.toHaveBeenCalled()
+  })
+
+  it('allows immediately for non-zklogin (localnet) mode', async () => {
+    mockSigningContext.mockReturnValue({
+      mode: 'localnet',
+      senderAddress: OWNER,
+      chain: 'sui:localnet',
+    })
+    render(<Harness />)
+    await expect(api.ensureAlias()).resolves.toBe(true)
+    expect(mockResolve).not.toHaveBeenCalled()
+  })
+
+  it('allows immediately when an alias already exists', async () => {
+    mockResolve.mockResolvedValue({ satisfied: true })
+    render(<Harness />)
+    await expect(api.ensureAlias()).resolves.toBe(true)
+    expect(mockResolve).toHaveBeenCalledWith(OWNER, 'sui:testnet')
+  })
+
+  it('throws when zklogin enforcement applies but no sender is available', async () => {
+    mockSigningContext.mockReturnValue({
+      mode: 'zklogin',
+      senderAddress: null,
+      chain: 'sui:testnet',
+    })
+    render(<Harness />)
+    await expect(api.ensureAlias()).rejects.toThrow('No sender address')
+  })
+
+  it('opens the modal and resolves true once registration completes', async () => {
+    mockResolve.mockResolvedValue({ satisfied: false })
+    render(<Harness />)
+
+    let pending = Promise.resolve(false)
+    act(() => {
+      pending = api.ensureAlias()
+    })
+
+    await waitFor(() => expect(setupProps).not.toBeNull())
+    act(() => setupProps?.onComplete())
+
+    await expect(pending).resolves.toBe(true)
+  })
+
+  it('opens the modal and resolves false when the user cancels', async () => {
+    mockResolve.mockResolvedValue({ satisfied: false })
+    render(<Harness />)
+
+    let pending = Promise.resolve(false)
+    act(() => {
+      pending = api.ensureAlias()
+    })
+
+    await waitFor(() => expect(setupProps).not.toBeNull())
+    act(() => setupProps?.onCancel())
+
+    await expect(pending).resolves.toBe(false)
+  })
+})

--- a/packages/shared/src/screens/AliasRecoverySetupScreen/index.ts
+++ b/packages/shared/src/screens/AliasRecoverySetupScreen/index.ts
@@ -1,0 +1,6 @@
+export {
+  AliasRecoverySetupScreen,
+  type AliasRecoverySetupScreenProps,
+  default,
+} from './AliasRecoverySetupScreen'
+export { useRequireAlias } from './useRequireAlias'

--- a/packages/shared/src/screens/AliasRecoverySetupScreen/useRequireAlias.tsx
+++ b/packages/shared/src/screens/AliasRecoverySetupScreen/useRequireAlias.tsx
@@ -2,7 +2,7 @@ import type React from 'react'
 import { useRef, useState } from 'react'
 import { Modal } from '#/components'
 import {
-  isAddressAliasEnforcementEnabled,
+  isEnforcementOverridden,
   resolveAliasEnforcementStatus,
   useWalletSigningContext,
 } from '#/wallet'
@@ -10,10 +10,10 @@ import { AliasRecoverySetupScreen } from './AliasRecoverySetupScreen'
 
 export interface UseRequireAliasResult {
   /**
-   * Resolves `true` when the account may sign (enforcement off, non-zklogin, no
-   * sender, or a non-self alias already exists). Otherwise opens the recovery
-   * setup modal and resolves `true` once an alias is registered, or `false` if
-   * the user cancels. Await it before signing and bail when it returns `false`.
+   * Resolves `true` when the account may sign (non-zklogin, no sender, an ops
+   * override is active, or a non-self alias already exists). Otherwise opens the
+   * recovery setup modal and resolves `true` once an alias is registered, or
+   * `false` if the user cancels. Await it before signing and bail on `false`.
    */
   ensureAlias: () => Promise<boolean>
   /** Render this in the component tree so the setup modal can appear. */
@@ -21,9 +21,9 @@ export interface UseRequireAliasResult {
 }
 
 /**
- * Just-in-time address-alias gate. Instead of blocking the dashboard, callers
- * invoke `ensureAlias()` right before signing; the setup modal is shown only
- * when an on-chain lookup finds no non-self alias for the zklogin account.
+ * Just-in-time address-alias gate. Callers invoke `ensureAlias()` right
+ * before signing; the setup modal is shown when an on-chain lookup
+ * finds no non-self alias for the zklogin account.
  */
 export function useRequireAlias(): UseRequireAliasResult {
   const { mode, senderAddress, chain } = useWalletSigningContext()
@@ -40,13 +40,18 @@ export function useRequireAlias(): UseRequireAliasResult {
   }
 
   const ensureAlias = async (): Promise<boolean> => {
-    if (mode !== 'zklogin' || !isAddressAliasEnforcementEnabled()) {
-      // Localnet and flag-off accounts are never gated.
+    if (mode !== 'zklogin') {
+      // Non-zklogin (localnet) accounts are never gated.
       return true
     }
 
     if (!senderAddress) {
       // No account to gate; let the downstream no-sender handling take over.
+      return true
+    }
+
+    if (isEnforcementOverridden(senderAddress)) {
+      // Ops break-glass active (audit-logged); mirror the signing backstop.
       return true
     }
 

--- a/packages/shared/src/screens/AliasRecoverySetupScreen/useRequireAlias.tsx
+++ b/packages/shared/src/screens/AliasRecoverySetupScreen/useRequireAlias.tsx
@@ -46,7 +46,8 @@ export function useRequireAlias(): UseRequireAliasResult {
     }
 
     if (!senderAddress) {
-      throw new Error('No sender address available')
+      // No account to gate; let the downstream no-sender handling take over.
+      return true
     }
 
     const status = await resolveAliasEnforcementStatus(senderAddress, chain)
@@ -55,6 +56,9 @@ export function useRequireAlias(): UseRequireAliasResult {
     }
 
     return new Promise<boolean>((resolve) => {
+      // A pending caller from a prior (still-open) invocation would otherwise be
+      // orphaned when we overwrite the ref; settle it so it never hangs.
+      resolverRef.current?.(false)
       resolverRef.current = resolve
       setIsOpen(true)
     })

--- a/packages/shared/src/screens/AliasRecoverySetupScreen/useRequireAlias.tsx
+++ b/packages/shared/src/screens/AliasRecoverySetupScreen/useRequireAlias.tsx
@@ -2,6 +2,7 @@ import type React from 'react'
 import { useRef, useState } from 'react'
 import { Modal } from '#/components'
 import {
+  isAliasEnforcementFeatureEnabled,
   isEnforcementOverridden,
   resolveAliasEnforcementStatus,
   useWalletSigningContext,
@@ -40,6 +41,11 @@ export function useRequireAlias(): UseRequireAliasResult {
   }
 
   const ensureAlias = async (): Promise<boolean> => {
+    if (!isAliasEnforcementFeatureEnabled()) {
+      // Do not gate if feature staged off
+      return true
+    }
+
     if (mode !== 'zklogin') {
       // Non-zklogin (localnet) accounts are never gated.
       return true

--- a/packages/shared/src/screens/AliasRecoverySetupScreen/useRequireAlias.tsx
+++ b/packages/shared/src/screens/AliasRecoverySetupScreen/useRequireAlias.tsx
@@ -1,0 +1,73 @@
+import type React from 'react'
+import { useRef, useState } from 'react'
+import { Modal } from '#/components'
+import {
+  isAddressAliasEnforcementEnabled,
+  resolveAliasEnforcementStatus,
+  useWalletSigningContext,
+} from '#/wallet'
+import { AliasRecoverySetupScreen } from './AliasRecoverySetupScreen'
+
+export interface UseRequireAliasResult {
+  /**
+   * Resolves `true` when the account may sign (enforcement off, non-zklogin, no
+   * sender, or a non-self alias already exists). Otherwise opens the recovery
+   * setup modal and resolves `true` once an alias is registered, or `false` if
+   * the user cancels. Await it before signing and bail when it returns `false`.
+   */
+  ensureAlias: () => Promise<boolean>
+  /** Render this in the component tree so the setup modal can appear. */
+  aliasSetupModal: React.ReactNode
+}
+
+/**
+ * Just-in-time address-alias gate. Instead of blocking the dashboard, callers
+ * invoke `ensureAlias()` right before signing; the setup modal is shown only
+ * when an on-chain lookup finds no non-self alias for the zklogin account.
+ */
+export function useRequireAlias(): UseRequireAliasResult {
+  const { mode, senderAddress, chain } = useWalletSigningContext()
+  const [isOpen, setIsOpen] = useState(false)
+  // Holds the pending ensureAlias() promise resolver across the async gap while
+  // the modal is open, so onComplete/onCancel can settle the original call.
+  const resolverRef = useRef<((value: boolean) => void) | null>(null)
+
+  const settle = (value: boolean) => {
+    setIsOpen(false)
+    const resolve = resolverRef.current
+    resolverRef.current = null
+    resolve?.(value)
+  }
+
+  const ensureAlias = async (): Promise<boolean> => {
+    if (mode !== 'zklogin' || !isAddressAliasEnforcementEnabled()) {
+      // Localnet and flag-off accounts are never gated.
+      return true
+    }
+
+    if (!senderAddress) {
+      throw new Error('No sender address available')
+    }
+
+    const status = await resolveAliasEnforcementStatus(senderAddress, chain)
+    if (status.satisfied) {
+      return true
+    }
+
+    return new Promise<boolean>((resolve) => {
+      resolverRef.current = resolve
+      setIsOpen(true)
+    })
+  }
+
+  const aliasSetupModal: React.ReactNode = (
+    <Modal isOpen={isOpen} size="large" onClose={() => settle(false)}>
+      <AliasRecoverySetupScreen
+        onComplete={() => settle(true)}
+        onCancel={() => settle(false)}
+      />
+    </Modal>
+  )
+
+  return { ensureAlias, aliasSetupModal }
+}

--- a/packages/shared/src/screens/SendTokenScreen/SendTokenScreen.tsx
+++ b/packages/shared/src/screens/SendTokenScreen/SendTokenScreen.tsx
@@ -7,6 +7,7 @@ import { getFaucetUrlForChain } from '#/sui'
 import type { SendTokenScreenProps } from '#/types'
 import { getSuiscanUrl } from '#/utils'
 import { useSendToken } from '#/wallet'
+import { useRequireAlias } from '../AliasRecoverySetupScreen/useRequireAlias'
 import { TransferForm, TransferSuccessScreen } from './SendTokenScreen.parts'
 
 export const SendTokenScreen: React.FC<SendTokenScreenProps> = ({
@@ -14,6 +15,7 @@ export const SendTokenScreen: React.FC<SendTokenScreenProps> = ({
   onCancel,
 }) => {
   const { showToast } = useToast()
+  const { ensureAlias, aliasSetupModal } = useRequireAlias()
   const { chain: currentChain } = useContext()
   const {
     localnet: { url: localnetUrl },
@@ -63,6 +65,7 @@ export const SendTokenScreen: React.FC<SendTokenScreenProps> = ({
   }
 
   const handleSend = async () => {
+    if (!(await ensureAlias())) return
     // Store the values before sending so we can show them on success screen
     setSubmittedRecipient(recipientAddress)
     setSubmittedAmount(amount)
@@ -105,35 +108,38 @@ export const SendTokenScreen: React.FC<SendTokenScreenProps> = ({
   }
 
   return (
-    <TransferForm
-      values={{
-        recipientAddress,
-        amount,
-        currentBalance,
-        tokenSymbol,
-      }}
-      status={{
-        isValidRecipient,
-        isValidAmount,
-        validationErrors,
-        canSend,
-        isLoading,
-        error,
-      }}
-      notices={{
-        suiForGasWarning,
-        gasFeeWarning,
-        estimatedGasFee,
-        estimatedGasFeeLoading,
-        showFaucetTestSui,
-        faucetUrl,
-      }}
-      actions={{
-        onRecipientChange: handleRecipientChange,
-        onAmountChange: handleAmountChange,
-        onSend: handleSend,
-        onCancel,
-      }}
-    />
+    <>
+      <TransferForm
+        values={{
+          recipientAddress,
+          amount,
+          currentBalance,
+          tokenSymbol,
+        }}
+        status={{
+          isValidRecipient,
+          isValidAmount,
+          validationErrors,
+          canSend,
+          isLoading,
+          error,
+        }}
+        notices={{
+          suiForGasWarning,
+          gasFeeWarning,
+          estimatedGasFee,
+          estimatedGasFeeLoading,
+          showFaucetTestSui,
+          faucetUrl,
+        }}
+        actions={{
+          onRecipientChange: handleRecipientChange,
+          onAmountChange: handleAmountChange,
+          onSend: handleSend,
+          onCancel,
+        }}
+      />
+      {aliasSetupModal}
+    </>
   )
 }

--- a/packages/shared/src/screens/TransactionsScreen/TransactionsScreen.helpers.ts
+++ b/packages/shared/src/screens/TransactionsScreen/TransactionsScreen.helpers.ts
@@ -98,13 +98,24 @@ function getSummaryAmounts(transaction: Transaction) {
 }
 
 /**
+ * Truncates hex addresses, but leaves non-address counterparties (e.g. a
+ * `module::function` label for a coin-less move call) intact so they aren't
+ * mangled by the address ellipsis.
+ */
+function formatCounterparty(counterparty: string) {
+  return counterparty.startsWith('0x')
+    ? formatAddress(counterparty, 6, 6)
+    : counterparty
+}
+
+/**
  * Precomputes row display fields so the JSX parts do not duplicate address
  * truncation or sent/received direction logic.
  */
 export function getTransactionRowSummary(transaction: Transaction) {
   return {
     iconName: transaction.direction === 'sent' ? 'ArrowRight' : 'ArrowLeft',
-    shortCounterparty: formatAddress(transaction.counterparty, 6, 6),
+    shortCounterparty: formatCounterparty(transaction.counterparty),
     shortDigest: formatAddress(transaction.digest, 8, 8),
     summaryAmounts: getSummaryAmounts(transaction),
   } as const

--- a/packages/shared/src/screens/TransactionsScreen/__tests__/TransactionsScreen.helpers.test.ts
+++ b/packages/shared/src/screens/TransactionsScreen/__tests__/TransactionsScreen.helpers.test.ts
@@ -137,6 +137,14 @@ describe('transaction list helpers', () => {
     ).toBe('−1 SUI')
   })
 
+  it('leaves a non-address counterparty label untruncated', () => {
+    expect(
+      getTransactionRowSummary(
+        createTransaction({ counterparty: 'address_alias::add' }),
+      ).shortCounterparty,
+    ).toBe('address_alias::add')
+  })
+
   it('leaves sent summaries unsigned when there are no balance changes', () => {
     expect(
       getTransactionRowSummary(

--- a/packages/shared/src/screens/index.ts
+++ b/packages/shared/src/screens/index.ts
@@ -1,5 +1,6 @@
 export * from './AddressAliasesScreen'
 export * from './AddTokenScreen'
+export * from './AliasRecoverySetupScreen'
 export * from './Lockscreen'
 export * from './NotFoundScreen'
 export * from './SendTokenScreen'

--- a/packages/shared/src/theme/global.css
+++ b/packages/shared/src/theme/global.css
@@ -110,6 +110,7 @@
   --crude: #130904;
   --neutral: #ffffd6;
   --neutral-50: rgba(255, 255, 214, 0.5);
+  --neutral-60: rgba(255, 255, 214, 0.6);
   --neutral-90: rgba(255, 255, 214, 0.9);
   --grey-neutral: #8e8c77;
   --quantum: #c64f05;

--- a/packages/shared/src/wallet/__tests__/aliasEnforcement.test.ts
+++ b/packages/shared/src/wallet/__tests__/aliasEnforcement.test.ts
@@ -1,5 +1,5 @@
 import { SUI_DEVNET_CHAIN, SUI_LOCALNET_CHAIN } from '@mysten/wallet-standard'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockListOwnedObjects = vi.fn()
 
@@ -25,8 +25,8 @@ vi.mock('@mysten/sui/transactions', () => ({
 import { Transaction } from '@mysten/sui/transactions'
 import {
   assertAliasEnforced,
-  invalidateAliasEnforcement,
   isAliasEnforcementError,
+  resolveEnforcementOverride,
 } from '#/wallet/aliasEnforcement'
 
 const OWNER = `0x${'a'.repeat(64)}`
@@ -45,14 +45,8 @@ function stubDecodedModule(module: string) {
 }
 
 beforeEach(() => {
-  invalidateAliasEnforcement()
   mockListOwnedObjects.mockReset()
   vi.mocked(Transaction.from).mockReset()
-  vi.unstubAllEnvs()
-})
-
-afterEach(() => {
-  vi.unstubAllEnvs()
 })
 
 describe('assertAliasEnforced', () => {
@@ -95,7 +89,7 @@ describe('assertAliasEnforced', () => {
     expect(mockListOwnedObjects).not.toHaveBeenCalled()
   })
 
-  it('always enforces personal messages (no bypass)', async () => {
+  it('never gates personal messages (off-chain signatures)', async () => {
     mockListOwnedObjects.mockResolvedValue(objectsWith([OWNER]))
     await expect(
       assertAliasEnforced({
@@ -104,7 +98,8 @@ describe('assertAliasEnforced', () => {
         scope: 'PersonalMessage',
         msgBytes: new Uint8Array([1]),
       }),
-    ).rejects.toMatchObject({ code: 'alias_enforcement_required' })
+    ).resolves.toBeUndefined()
+    expect(mockListOwnedObjects).not.toHaveBeenCalled()
   })
 
   it('is a no-op on localnet', async () => {
@@ -119,20 +114,7 @@ describe('assertAliasEnforced', () => {
     expect(mockListOwnedObjects).not.toHaveBeenCalled()
   })
 
-  it('is a no-op when the flag is disabled', async () => {
-    vi.stubEnv('VITE_ENFORCE_ADDRESS_ALIAS', 'false')
-    await expect(
-      assertAliasEnforced({
-        chain: SUI_DEVNET_CHAIN,
-        owner: OWNER,
-        scope: 'TransactionData',
-        msgBytes: new Uint8Array([1]),
-      }),
-    ).resolves.toBeUndefined()
-    expect(mockListOwnedObjects).not.toHaveBeenCalled()
-  })
-
-  it('caches a satisfied result and re-reads after invalidation', async () => {
+  it('reads on-chain state fresh on every call (no caching)', async () => {
     mockListOwnedObjects.mockResolvedValue(objectsWith([ALIAS]))
     stubDecodedModule('coin')
     const params = {
@@ -143,10 +125,6 @@ describe('assertAliasEnforced', () => {
     }
 
     await assertAliasEnforced(params)
-    await assertAliasEnforced(params)
-    expect(mockListOwnedObjects).toHaveBeenCalledTimes(1)
-
-    invalidateAliasEnforcement(OWNER, SUI_DEVNET_CHAIN)
     await assertAliasEnforced(params)
     expect(mockListOwnedObjects).toHaveBeenCalledTimes(2)
   })
@@ -159,5 +137,43 @@ describe('isAliasEnforcementError', () => {
     ).toBe(true)
     expect(isAliasEnforcementError(new Error('nope'))).toBe(false)
     expect(isAliasEnforcementError(null)).toBe(false)
+  })
+})
+
+describe('resolveEnforcementOverride (break-glass, fail-closed)', () => {
+  const NOW = 1_000_000
+
+  it('accepts a well-formed, unexpired override', () => {
+    expect(
+      resolveEnforcementOverride(
+        { reason: 'incident-123', until: NOW + 1000, actor: 'ops@eve' },
+        NOW,
+      ),
+    ).toEqual({ reason: 'incident-123', until: NOW + 1000, actor: 'ops@eve' })
+  })
+
+  it('drops actor when it is not a string but keeps the override', () => {
+    expect(
+      resolveEnforcementOverride({ reason: 'x', until: NOW + 1 }, NOW),
+    ).toEqual({ reason: 'x', until: NOW + 1, actor: undefined })
+  })
+
+  it('rejects an expired override', () => {
+    expect(
+      resolveEnforcementOverride({ reason: 'x', until: NOW - 1 }, NOW),
+    ).toBeNull()
+  })
+
+  it('rejects malformed / missing claims', () => {
+    expect(resolveEnforcementOverride(null, NOW)).toBeNull()
+    expect(resolveEnforcementOverride('nope', NOW)).toBeNull()
+    expect(resolveEnforcementOverride({ until: NOW + 1 }, NOW)).toBeNull()
+    expect(
+      resolveEnforcementOverride({ reason: '', until: NOW + 1 }, NOW),
+    ).toBeNull()
+    expect(resolveEnforcementOverride({ reason: 'x' }, NOW)).toBeNull()
+    expect(
+      resolveEnforcementOverride({ reason: 'x', until: 'soon' }, NOW),
+    ).toBeNull()
   })
 })

--- a/packages/shared/src/wallet/__tests__/aliasEnforcement.test.ts
+++ b/packages/shared/src/wallet/__tests__/aliasEnforcement.test.ts
@@ -1,0 +1,163 @@
+import { SUI_DEVNET_CHAIN, SUI_LOCALNET_CHAIN } from '@mysten/wallet-standard'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockListOwnedObjects = vi.fn()
+
+vi.mock('#/sui', () => ({
+  createSuiClient: vi.fn(() => ({
+    core: { listOwnedObjects: mockListOwnedObjects },
+  })),
+}))
+
+vi.mock('#/utils', () => ({
+  createLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}))
+
+vi.mock('@mysten/sui/transactions', () => ({
+  Transaction: { from: vi.fn() },
+}))
+
+import { Transaction } from '@mysten/sui/transactions'
+import {
+  assertAliasEnforced,
+  invalidateAliasEnforcement,
+  isAliasEnforcementError,
+} from '#/wallet/aliasEnforcement'
+
+const OWNER = `0x${'a'.repeat(64)}`
+const ALIAS = `0x${'c'.repeat(64)}`
+
+function objectsWith(aliases: string[]) {
+  return {
+    objects: [{ objectId: '0x1', json: { aliases: { contents: aliases } } }],
+  }
+}
+
+function stubDecodedModule(module: string) {
+  vi.mocked(Transaction.from).mockReturnValue({
+    getData: () => ({ commands: [{ MoveCall: { package: '0x2', module } }] }),
+  } as never)
+}
+
+beforeEach(() => {
+  invalidateAliasEnforcement()
+  mockListOwnedObjects.mockReset()
+  vi.mocked(Transaction.from).mockReset()
+  vi.unstubAllEnvs()
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('assertAliasEnforced', () => {
+  it('throws when the owner has no non-self alias', async () => {
+    mockListOwnedObjects.mockResolvedValue(objectsWith([OWNER]))
+    await expect(
+      assertAliasEnforced({
+        chain: SUI_DEVNET_CHAIN,
+        owner: OWNER,
+        scope: 'TransactionData',
+        msgBytes: new Uint8Array([1]),
+      }),
+    ).rejects.toMatchObject({ code: 'alias_enforcement_required' })
+  })
+
+  it('resolves when a distinct alias exists', async () => {
+    mockListOwnedObjects.mockResolvedValue(objectsWith([ALIAS]))
+    stubDecodedModule('coin')
+    await expect(
+      assertAliasEnforced({
+        chain: SUI_DEVNET_CHAIN,
+        owner: OWNER,
+        scope: 'TransactionData',
+        msgBytes: new Uint8Array([1]),
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('bypasses an address-alias setup transaction even when unsatisfied', async () => {
+    mockListOwnedObjects.mockResolvedValue(objectsWith([OWNER]))
+    stubDecodedModule('address_alias')
+    await expect(
+      assertAliasEnforced({
+        chain: SUI_DEVNET_CHAIN,
+        owner: OWNER,
+        scope: 'TransactionData',
+        msgBytes: new Uint8Array([1]),
+      }),
+    ).resolves.toBeUndefined()
+    expect(mockListOwnedObjects).not.toHaveBeenCalled()
+  })
+
+  it('always enforces personal messages (no bypass)', async () => {
+    mockListOwnedObjects.mockResolvedValue(objectsWith([OWNER]))
+    await expect(
+      assertAliasEnforced({
+        chain: SUI_DEVNET_CHAIN,
+        owner: OWNER,
+        scope: 'PersonalMessage',
+        msgBytes: new Uint8Array([1]),
+      }),
+    ).rejects.toMatchObject({ code: 'alias_enforcement_required' })
+  })
+
+  it('is a no-op on localnet', async () => {
+    await expect(
+      assertAliasEnforced({
+        chain: SUI_LOCALNET_CHAIN,
+        owner: OWNER,
+        scope: 'TransactionData',
+        msgBytes: new Uint8Array([1]),
+      }),
+    ).resolves.toBeUndefined()
+    expect(mockListOwnedObjects).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op when the flag is disabled', async () => {
+    vi.stubEnv('VITE_ENFORCE_ADDRESS_ALIAS', 'false')
+    await expect(
+      assertAliasEnforced({
+        chain: SUI_DEVNET_CHAIN,
+        owner: OWNER,
+        scope: 'TransactionData',
+        msgBytes: new Uint8Array([1]),
+      }),
+    ).resolves.toBeUndefined()
+    expect(mockListOwnedObjects).not.toHaveBeenCalled()
+  })
+
+  it('caches a satisfied result and re-reads after invalidation', async () => {
+    mockListOwnedObjects.mockResolvedValue(objectsWith([ALIAS]))
+    stubDecodedModule('coin')
+    const params = {
+      chain: SUI_DEVNET_CHAIN,
+      owner: OWNER,
+      scope: 'TransactionData' as const,
+      msgBytes: new Uint8Array([1]),
+    }
+
+    await assertAliasEnforced(params)
+    await assertAliasEnforced(params)
+    expect(mockListOwnedObjects).toHaveBeenCalledTimes(1)
+
+    invalidateAliasEnforcement(OWNER, SUI_DEVNET_CHAIN)
+    await assertAliasEnforced(params)
+    expect(mockListOwnedObjects).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('isAliasEnforcementError', () => {
+  it('matches by error code and ignores unrelated errors', () => {
+    expect(
+      isAliasEnforcementError({ code: 'alias_enforcement_required' }),
+    ).toBe(true)
+    expect(isAliasEnforcementError(new Error('nope'))).toBe(false)
+    expect(isAliasEnforcementError(null)).toBe(false)
+  })
+})

--- a/packages/shared/src/wallet/__tests__/aliasEnforcement.test.ts
+++ b/packages/shared/src/wallet/__tests__/aliasEnforcement.test.ts
@@ -49,7 +49,25 @@ beforeEach(() => {
   vi.mocked(Transaction.from).mockReset()
 })
 
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
 describe('assertAliasEnforced', () => {
+  it('is a no-op when the feature flag is staged off', async () => {
+    vi.stubEnv('VITE_ADDRESS_ALIAS_ENFORCEMENT', 'false')
+    mockListOwnedObjects.mockResolvedValue(objectsWith([OWNER]))
+    await expect(
+      assertAliasEnforced({
+        chain: SUI_DEVNET_CHAIN,
+        owner: OWNER,
+        scope: 'TransactionData',
+        msgBytes: new Uint8Array([1]),
+      }),
+    ).resolves.toBeUndefined()
+    expect(mockListOwnedObjects).not.toHaveBeenCalled()
+  })
+
   it('throws when the owner has no non-self alias', async () => {
     mockListOwnedObjects.mockResolvedValue(objectsWith([OWNER]))
     await expect(

--- a/packages/shared/src/wallet/__tests__/aliasEnforcement.test.ts
+++ b/packages/shared/src/wallet/__tests__/aliasEnforcement.test.ts
@@ -176,13 +176,13 @@ describe('resolveEnforcementOverride (break-glass, fail-closed)', () => {
     ).toEqual({ reason: 'x', until: NOW + 1, actor: undefined })
   })
 
-  it('rejects an expired override', () => {
+  it('returns null for an expired override', () => {
     expect(
       resolveEnforcementOverride({ reason: 'x', until: NOW - 1 }, NOW),
     ).toBeNull()
   })
 
-  it('rejects malformed / missing claims', () => {
+  it('returns null for malformed / missing claims', () => {
     expect(resolveEnforcementOverride(null, NOW)).toBeNull()
     expect(resolveEnforcementOverride('nope', NOW)).toBeNull()
     expect(resolveEnforcementOverride({ until: NOW + 1 }, NOW)).toBeNull()

--- a/packages/shared/src/wallet/__tests__/signForChain.test.ts
+++ b/packages/shared/src/wallet/__tests__/signForChain.test.ts
@@ -5,6 +5,12 @@ vi.mock('#/wallet/zkSignAny', () => ({
   zkSignAny: vi.fn(),
 }))
 
+// Enforcement is exercised in aliasEnforcement.test.ts; keep it a no-op here
+// so these tests stay focused on routing/delegation.
+vi.mock('#/wallet/aliasEnforcement', () => ({
+  assertAliasEnforced: vi.fn().mockResolvedValue(undefined),
+}))
+
 import { SUI_LOCALNET_CHAIN, SUI_TESTNET_CHAIN } from '@mysten/wallet-standard'
 import { signForChain } from '#/wallet/signForChain'
 import { zkSignAny } from '#/wallet/zkSignAny'

--- a/packages/shared/src/wallet/aliasEnforcement.ts
+++ b/packages/shared/src/wallet/aliasEnforcement.ts
@@ -14,34 +14,68 @@ import { createLogger } from '#/utils'
 const log = createLogger()
 
 /**
- * Feature flag for address-alias enforcement. Defaults to ON; set
- * `VITE_ENFORCE_ADDRESS_ALIAS=false` in an app's env to disable both the UX
- * gate and the signing backstop (kill-switch for rollout).
+ * Ops break-glass override for the compliance-mandated alias enforcement. There
+ * is deliberately no env/build-time off-switch: enforcement is always on (see
+ * {@link assertAliasEnforced}). The only way to suspend it is an ops-issued,
+ * signed, expiring override — every use of which is logged.
  */
-export function isAddressAliasEnforcementEnabled(): boolean {
-  return import.meta.env.VITE_ENFORCE_ADDRESS_ALIAS !== 'false'
+export interface EnforcementOverride {
+  /** Ops-readable justification, recorded in the log. */
+  reason: string
+  /** Epoch ms after which the override is ignored (fail-closed on expiry). */
+  until: number
+  /** Optional identifier of who authorised it, for the audit trail. */
+  actor?: string
 }
 
 /**
- * Module-level cache of on-chain enforcement status keyed by owner+chain. Only
- * `satisfied` results are treated as durable (aliases don't disappear in normal
- * use); unsatisfied results are always re-read so a freshly registered alias is
- * picked up. Cleared via {@link invalidateAliasEnforcement} after registration.
+ * Validates a raw ops override claim. Fail-closed: any non-object, missing
+ * `reason`, or missing/expired `until` resolves to `null` (i.e. enforce), so a
+ * malformed override can never weaken the control.
  */
-const statusCache = new Map<string, AliasEnforcementStatus>()
-
-const cacheKey = (owner: string, chain: string) => `${owner}:${chain}`
-
-/** Clears cached status for one owner+chain, or the whole cache when no owner is given. */
-export function invalidateAliasEnforcement(
-  owner?: string,
-  chain?: string,
-): void {
-  if (!owner || !chain) {
-    statusCache.clear()
-    return
+export function resolveEnforcementOverride(
+  claim: unknown,
+  now: number,
+): EnforcementOverride | null {
+  if (typeof claim !== 'object' || claim === null) return null
+  const { reason, until, actor } = claim as Record<string, unknown>
+  if (typeof reason !== 'string' || reason.length === 0) return null
+  if (typeof until !== 'number' || !Number.isFinite(until) || until <= now) {
+    return null
   }
-  statusCache.delete(cacheKey(owner, chain))
+  return { reason, until, actor: typeof actor === 'string' ? actor : undefined }
+}
+
+/**
+ * Phase 2 seam for the break-glass. Returns the raw ops-issued override claim,
+ * or `null` when none is active. Returning `null` keeps enforcement on.
+ *
+ * TODO(phase-2): source this from the signed `alias_enforcement_override` claim
+ * on the authenticated zkLogin JWT (read via the auth store) so ops can engage
+ * it without a client redeploy and the JWT signature makes it tamper-evident.
+ */
+function getEnforcementOverrideClaim(): unknown {
+  return null
+}
+
+/**
+ * True when a valid ops break-glass override is currently active for `owner`,
+ * logging an audit line whenever one is engaged. Fail-closed: any missing,
+ * malformed, or expired override resolves to `false` (enforce).
+ */
+export function isEnforcementOverridden(owner: string): boolean {
+  const override = resolveEnforcementOverride(
+    getEnforcementOverrideClaim(),
+    Date.now(),
+  )
+  if (!override) return false
+  log.warn('AUDIT address-alias enforcement overridden', {
+    owner,
+    reason: override.reason,
+    until: override.until,
+    actor: override.actor,
+  })
+  return true
 }
 
 /** True for wallet-core's `AliasEnforcementError` (also matches across module copies via its code). */
@@ -66,21 +100,14 @@ function isAliasSetupBytes(msgBytes: Uint8Array): boolean {
 }
 
 /**
- * Resolves the enforcement status for an owner on a chain, reading on-chain
- * state via wallet-core. Cached once satisfied.
+ * Reads current on-chain enforcement status for an owner on a chain via
+ * wallet-core.
  */
 export async function resolveAliasEnforcementStatus(
   owner: string,
   chain: SuiChain,
 ): Promise<AliasEnforcementStatus> {
-  const key = cacheKey(owner, chain)
-  const cached = statusCache.get(key)
-  if (cached?.satisfied) {
-    return cached
-  }
-  const status = await checkAliasEnforcement(createSuiClient(chain), owner)
-  statusCache.set(key, status)
-  return status
+  return checkAliasEnforcement(createSuiClient(chain), owner)
 }
 
 export interface AssertAliasEnforcedParams {
@@ -92,9 +119,11 @@ export interface AssertAliasEnforcedParams {
 
 /**
  * Signing backstop: throws `AliasEnforcementError` when the owner has no
- * enforceable alias. No-op when the feature flag is off, on localnet, when the
- * owner is unknown, or when the transaction is an alias-setup call (so the
- * first alias can still be registered). Personal messages are always enforced.
+ * enforceable alias. Only on-chain transactions are gated. No-op on localnet,
+ * for non-transaction scopes (personal messages are never gated),
+ * when the owner is unknown, when the transaction is the alias-setup
+ * call itself (so the first alias can still be registered),
+ * or when a valid ops break-glass override is active.
  */
 export async function assertAliasEnforced({
   chain,
@@ -102,13 +131,16 @@ export async function assertAliasEnforced({
   scope,
   msgBytes,
 }: AssertAliasEnforcedParams): Promise<void> {
-  if (!isAddressAliasEnforcementEnabled()) return
   if (!chain || isLocalnetChain(chain)) return
   if (!owner) return
 
-  if (scope === 'TransactionData' && isAliasSetupBytes(msgBytes)) {
-    return
-  }
+  // Only on-chain transactions are gated; off-chain signatures pass through.
+  if (scope !== 'TransactionData') return
+
+  // Exempt the alias-setup transaction so the first alias can be registered.
+  if (isAliasSetupBytes(msgBytes)) return
+
+  if (isEnforcementOverridden(owner)) return
 
   const status = await resolveAliasEnforcementStatus(owner, chain as SuiChain)
   if (!status.satisfied) {

--- a/packages/shared/src/wallet/aliasEnforcement.ts
+++ b/packages/shared/src/wallet/aliasEnforcement.ts
@@ -14,6 +14,16 @@ import { createLogger } from '#/utils'
 const log = createLogger()
 
 /**
+ * App-side rollout gate for the whole alias-enforcement feature. Owned by the
+ * build/env. When on, enforcement applies — subject to the ops break-glass
+ * ({@link isEnforcementOverridden}). Defaults ON; set
+ * `VITE_ADDRESS_ALIAS_ENFORCEMENT=false` to stage the feature off in an env.
+ */
+export function isAliasEnforcementFeatureEnabled(): boolean {
+  return import.meta.env.VITE_ADDRESS_ALIAS_ENFORCEMENT !== 'false'
+}
+
+/**
  * Ops break-glass override for the compliance-mandated alias enforcement. There
  * is deliberately no env/build-time off-switch: enforcement is always on (see
  * {@link assertAliasEnforced}). The only way to suspend it is an ops-issued,
@@ -119,11 +129,11 @@ export interface AssertAliasEnforcedParams {
 
 /**
  * Signing backstop: throws `AliasEnforcementError` when the owner has no
- * enforceable alias. Only on-chain transactions are gated. No-op on localnet,
- * for non-transaction scopes (personal messages are never gated),
- * when the owner is unknown, when the transaction is the alias-setup
- * call itself (so the first alias can still be registered),
- * or when a valid ops break-glass override is active.
+ * enforceable alias. Only on-chain transactions are gated. No-op when the
+ * feature flag is off, on localnet, for non-transaction scopes (personal
+ * messages are never gated), when the owner is unknown, when the transaction is
+ * the alias-setup call itself (so the first alias can still be registered), or
+ * when a valid ops break-glass override is active.
  */
 export async function assertAliasEnforced({
   chain,
@@ -131,6 +141,7 @@ export async function assertAliasEnforced({
   scope,
   msgBytes,
 }: AssertAliasEnforcedParams): Promise<void> {
+  if (!isAliasEnforcementFeatureEnabled()) return
   if (!chain || isLocalnetChain(chain)) return
   if (!owner) return
 

--- a/packages/shared/src/wallet/aliasEnforcement.ts
+++ b/packages/shared/src/wallet/aliasEnforcement.ts
@@ -1,0 +1,121 @@
+import {
+  AliasEnforcementError,
+  type AliasEnforcementStatus,
+  checkAliasEnforcement,
+  isAddressAliasCall,
+} from '@evefrontier/wallet-core/address-alias'
+import type { IntentScope } from '@mysten/sui/cryptography'
+import { Transaction } from '@mysten/sui/transactions'
+import type { SuiChain } from '@mysten/wallet-standard'
+import { createSuiClient } from '#/sui'
+import { isLocalnetChain } from '#/types/networks'
+import { createLogger } from '#/utils'
+
+const log = createLogger()
+
+/**
+ * Feature flag for address-alias enforcement. Defaults to ON; set
+ * `VITE_ENFORCE_ADDRESS_ALIAS=false` in an app's env to disable both the UX
+ * gate and the signing backstop (kill-switch for rollout).
+ */
+export function isAddressAliasEnforcementEnabled(): boolean {
+  return import.meta.env.VITE_ENFORCE_ADDRESS_ALIAS !== 'false'
+}
+
+/**
+ * Module-level cache of on-chain enforcement status keyed by owner+chain. Only
+ * `satisfied` results are treated as durable (aliases don't disappear in normal
+ * use); unsatisfied results are always re-read so a freshly registered alias is
+ * picked up. Cleared via {@link invalidateAliasEnforcement} after registration.
+ */
+const statusCache = new Map<string, AliasEnforcementStatus>()
+
+const cacheKey = (owner: string, chain: string) => `${owner}:${chain}`
+
+/** Clears cached status for one owner+chain, or the whole cache when no owner is given. */
+export function invalidateAliasEnforcement(
+  owner?: string,
+  chain?: string,
+): void {
+  if (!owner || !chain) {
+    statusCache.clear()
+    return
+  }
+  statusCache.delete(cacheKey(owner, chain))
+}
+
+/** True for wallet-core's `AliasEnforcementError` (also matches across module copies via its code). */
+export function isAliasEnforcementError(err: unknown): boolean {
+  return (
+    err instanceof AliasEnforcementError ||
+    (typeof err === 'object' &&
+      err !== null &&
+      (err as { code?: unknown }).code === 'alias_enforcement_required')
+  )
+}
+
+/** True when the transaction bytes are an address-alias setup call (enable/add/remove). */
+function isAliasSetupBytes(msgBytes: Uint8Array): boolean {
+  try {
+    const { commands } = Transaction.from(msgBytes).getData()
+    return commands.some((command) => isAddressAliasCall(command))
+  } catch {
+    // Undecodable bytes are never treated as an alias-setup exemption.
+    return false
+  }
+}
+
+/**
+ * Resolves the enforcement status for an owner on a chain, reading on-chain
+ * state via wallet-core. Cached once satisfied.
+ */
+export async function resolveAliasEnforcementStatus(
+  owner: string,
+  chain: SuiChain,
+): Promise<AliasEnforcementStatus> {
+  const key = cacheKey(owner, chain)
+  const cached = statusCache.get(key)
+  if (cached?.satisfied) {
+    return cached
+  }
+  const status = await checkAliasEnforcement(createSuiClient(chain), owner)
+  statusCache.set(key, status)
+  return status
+}
+
+export interface AssertAliasEnforcedParams {
+  chain: SuiChain | string | null | undefined
+  owner: string | null | undefined
+  scope: IntentScope
+  msgBytes: Uint8Array
+}
+
+/**
+ * Signing backstop: throws `AliasEnforcementError` when the owner has no
+ * enforceable alias. No-op when the feature flag is off, on localnet, when the
+ * owner is unknown, or when the transaction is an alias-setup call (so the
+ * first alias can still be registered). Personal messages are always enforced.
+ */
+export async function assertAliasEnforced({
+  chain,
+  owner,
+  scope,
+  msgBytes,
+}: AssertAliasEnforcedParams): Promise<void> {
+  if (!isAddressAliasEnforcementEnabled()) return
+  if (!chain || isLocalnetChain(chain)) return
+  if (!owner) return
+
+  if (scope === 'TransactionData' && isAliasSetupBytes(msgBytes)) {
+    return
+  }
+
+  const status = await resolveAliasEnforcementStatus(owner, chain as SuiChain)
+  if (!status.satisfied) {
+    log.info('Blocking sign: address alias enforcement not satisfied', {
+      owner,
+      reason: status.reason,
+    })
+    throw new AliasEnforcementError(owner, status)
+  }
+}

--- a/packages/shared/src/wallet/hooks/__tests__/useAliasProvisioning.test.tsx
+++ b/packages/shared/src/wallet/hooks/__tests__/useAliasProvisioning.test.tsx
@@ -47,7 +47,9 @@ beforeEach(() => {
   mockSigningContext.mockReturnValue({
     chain: 'sui:devnet',
     senderAddress: OWNER,
-    suiClient: {},
+    suiClient: {
+      core: { waitForTransaction: vi.fn().mockResolvedValue(undefined) },
+    },
     sign: vi.fn().mockResolvedValue({ bytes: 'b', signature: 's' }),
   })
 })
@@ -62,9 +64,6 @@ describe('useAliasProvisioning', () => {
   })
 
   it('surfaces the error and does not register when acknowledged is false', async () => {
-    mockRegisterAcknowledgedAlias.mockRejectedValue(
-      new Error('Alias registration requires the user to acknowledge'),
-    )
     const { result } = renderHook(() => useAliasProvisioning(), { wrapper })
     act(() => {
       result.current.generate()
@@ -76,7 +75,8 @@ describe('useAliasProvisioning', () => {
     })
 
     expect(ok).toBe(false)
-    expect(result.current.error).toContain('acknowledge')
+    expect(result.current.error).toContain('saved your personal access key')
+    expect(mockRegisterAcknowledgedAlias).not.toHaveBeenCalled()
     expect(mockInvalidate).not.toHaveBeenCalled()
   })
 

--- a/packages/shared/src/wallet/hooks/__tests__/useAliasProvisioning.test.tsx
+++ b/packages/shared/src/wallet/hooks/__tests__/useAliasProvisioning.test.tsx
@@ -1,0 +1,108 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockSigningContext = vi.fn()
+const mockGenerateAliasKey = vi.fn()
+const mockRegisterAcknowledgedAlias = vi.fn()
+const mockInvalidate = vi.fn()
+
+vi.mock('#/wallet/hooks/useWalletSigningContext', () => ({
+  useWalletSigningContext: () => mockSigningContext(),
+}))
+vi.mock('#/wallet/aliasEnforcement', () => ({
+  invalidateAliasEnforcement: (...args: unknown[]) => mockInvalidate(...args),
+  isAliasEnforcementError: () => false,
+}))
+vi.mock('@evefrontier/wallet-core/address-alias', () => ({
+  generateAliasKey: () => mockGenerateAliasKey(),
+  registerAcknowledgedAlias: (args: unknown) =>
+    mockRegisterAcknowledgedAlias(args),
+}))
+
+import { useAliasProvisioning } from '#/wallet/hooks/useAliasProvisioning'
+
+const OWNER = `0x${'a'.repeat(64)}`
+const ALIAS = `0x${'c'.repeat(64)}`
+const KEY = {
+  mnemonic: 'word '.repeat(24).trim(),
+  privateKey: 'suiprivkey1x',
+  address: ALIAS,
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+beforeEach(() => {
+  mockGenerateAliasKey.mockReset().mockReturnValue(KEY)
+  mockRegisterAcknowledgedAlias.mockReset()
+  mockInvalidate.mockReset()
+  mockSigningContext.mockReturnValue({
+    chain: 'sui:devnet',
+    senderAddress: OWNER,
+    suiClient: {},
+    sign: vi.fn().mockResolvedValue({ bytes: 'b', signature: 's' }),
+  })
+})
+
+describe('useAliasProvisioning', () => {
+  it('generates and holds a personal access key', () => {
+    const { result } = renderHook(() => useAliasProvisioning(), { wrapper })
+    act(() => {
+      result.current.generate()
+    })
+    expect(result.current.aliasKey).toEqual(KEY)
+  })
+
+  it('surfaces the error and does not register when acknowledged is false', async () => {
+    mockRegisterAcknowledgedAlias.mockRejectedValue(
+      new Error('Alias registration requires the user to acknowledge'),
+    )
+    const { result } = renderHook(() => useAliasProvisioning(), { wrapper })
+    act(() => {
+      result.current.generate()
+    })
+
+    let ok = true
+    await act(async () => {
+      ok = await result.current.register(false)
+    })
+
+    expect(ok).toBe(false)
+    expect(result.current.error).toContain('acknowledge')
+    expect(mockInvalidate).not.toHaveBeenCalled()
+  })
+
+  it('registers and invalidates caches when acknowledged', async () => {
+    mockRegisterAcknowledgedAlias.mockResolvedValue({ addDigest: 'digest-1' })
+    const { result } = renderHook(() => useAliasProvisioning(), { wrapper })
+    act(() => {
+      result.current.generate()
+    })
+
+    let ok = false
+    await act(async () => {
+      ok = await result.current.register(true)
+    })
+
+    expect(ok).toBe(true)
+    expect(mockRegisterAcknowledgedAlias).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: OWNER,
+        aliasAddress: ALIAS,
+        acknowledged: true,
+      }),
+    )
+    await waitFor(() =>
+      expect(mockInvalidate).toHaveBeenCalledWith(OWNER, 'sui:devnet'),
+    )
+    expect(result.current.txDigest).toBe('digest-1')
+  })
+})

--- a/packages/shared/src/wallet/hooks/__tests__/useAliasProvisioning.test.tsx
+++ b/packages/shared/src/wallet/hooks/__tests__/useAliasProvisioning.test.tsx
@@ -6,13 +6,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mockSigningContext = vi.fn()
 const mockGenerateAliasKey = vi.fn()
 const mockRegisterAcknowledgedAlias = vi.fn()
-const mockInvalidate = vi.fn()
 
 vi.mock('#/wallet/hooks/useWalletSigningContext', () => ({
   useWalletSigningContext: () => mockSigningContext(),
 }))
 vi.mock('#/wallet/aliasEnforcement', () => ({
-  invalidateAliasEnforcement: (...args: unknown[]) => mockInvalidate(...args),
   isAliasEnforcementError: () => false,
 }))
 vi.mock('@evefrontier/wallet-core/address-alias', () => ({
@@ -43,7 +41,6 @@ function wrapper({ children }: { children: ReactNode }) {
 beforeEach(() => {
   mockGenerateAliasKey.mockReset().mockReturnValue(KEY)
   mockRegisterAcknowledgedAlias.mockReset()
-  mockInvalidate.mockReset()
   mockSigningContext.mockReturnValue({
     chain: 'sui:devnet',
     senderAddress: OWNER,
@@ -77,10 +74,9 @@ describe('useAliasProvisioning', () => {
     expect(ok).toBe(false)
     expect(result.current.error).toContain('saved your personal access key')
     expect(mockRegisterAcknowledgedAlias).not.toHaveBeenCalled()
-    expect(mockInvalidate).not.toHaveBeenCalled()
   })
 
-  it('registers and invalidates caches when acknowledged', async () => {
+  it('registers and records the tx digest when acknowledged', async () => {
     mockRegisterAcknowledgedAlias.mockResolvedValue({ addDigest: 'digest-1' })
     const { result } = renderHook(() => useAliasProvisioning(), { wrapper })
     act(() => {
@@ -100,9 +96,6 @@ describe('useAliasProvisioning', () => {
         acknowledged: true,
       }),
     )
-    await waitFor(() =>
-      expect(mockInvalidate).toHaveBeenCalledWith(OWNER, 'sui:devnet'),
-    )
-    expect(result.current.txDigest).toBe('digest-1')
+    await waitFor(() => expect(result.current.txDigest).toBe('digest-1'))
   })
 })

--- a/packages/shared/src/wallet/hooks/__tests__/useTransactions.test.tsx
+++ b/packages/shared/src/wallet/hooks/__tests__/useTransactions.test.tsx
@@ -85,16 +85,16 @@ function createMockGraphQLResponse(
       ownerAddress: string
     }>
   }>,
-  hasNextPage = false,
-  endCursor: string | null = null,
+  hasPreviousPage = false,
+  startCursor: string | null = null,
 ) {
   return {
     data: {
       address: {
         transactions: {
           pageInfo: {
-            hasNextPage,
-            endCursor,
+            hasPreviousPage,
+            startCursor,
           },
           nodes: transactions.map((tx) => ({
             digest: tx.digest,
@@ -312,6 +312,60 @@ describe('useTransactionHistory hook (GraphQL)', () => {
     unmount()
   })
 
+  it('returns page transactions newest-first (reversed from oldest-first connection order)', async () => {
+    // The connection is ordered oldest-first; the hook reverses each page so
+    // the most recent transaction leads without re-sorting by timestamp.
+    const mockResponse = createMockGraphQLResponse([
+      {
+        digest: 'tx-old',
+        timestamp: '2024-01-01T00:00:00.000Z',
+        balanceChanges: [
+          {
+            amount: '-1000000000',
+            coinType: '0x2::sui::SUI',
+            ownerAddress: '0x123',
+          },
+        ],
+      },
+      {
+        digest: 'tx-new',
+        timestamp: '2024-06-01T00:00:00.000Z',
+        balanceChanges: [
+          {
+            amount: '-1000000000',
+            coinType: '0x2::sui::SUI',
+            ownerAddress: '0x123',
+          },
+        ],
+      },
+    ])
+
+    mockGraphQLQuery.mockResolvedValue(mockResponse)
+
+    const user = createMockUser()
+    const wrapper = createWrapper(queryClient)
+
+    const { result, unmount } = renderHook(
+      () =>
+        useTransactionHistory({
+          user,
+          chain: SUI_DEVNET_CHAIN,
+        }),
+      { wrapper },
+    )
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    const digests = result.current.data?.pages[0].transactions.map(
+      (tx) => tx.digest,
+    )
+    expect(digests).toEqual(['tx-new', 'tx-old'])
+
+    unmount()
+  })
+
   it('handles GraphQL errors by throwing', async () => {
     // When GraphQL returns errors, the hook throws an error
     // The hook will retry twice before failing (retry: 2)
@@ -398,8 +452,8 @@ describe('useTransactionHistory hook (GraphQL)', () => {
           ],
         },
       ],
-      true, // hasNextPage
-      'cursor123', // endCursor
+      true, // hasPreviousPage
+      'cursor123', // startCursor
     )
 
     mockGraphQLQuery.mockResolvedValue(mockResponse)
@@ -500,8 +554,8 @@ describe('useTransactionHistory hook (GraphQL)', () => {
 
     const callArgs = mockGraphQLQuery.mock.calls[0][0]
     expect(callArgs.variables.address).toBe('0x123')
-    expect(callArgs.variables.first).toBe(50)
-    expect(callArgs.variables.after).toBeUndefined()
+    expect(callArgs.variables.last).toBe(50)
+    expect(callArgs.variables.before).toBeUndefined()
 
     unmount()
   })

--- a/packages/shared/src/wallet/hooks/useAddressAliases.ts
+++ b/packages/shared/src/wallet/hooks/useAddressAliases.ts
@@ -149,14 +149,19 @@ export function useAddressAliases(): UseAddressAliasesResult {
       }
       const trimmed = addressAlias.trim()
       const digest = await run(
-        () =>
-          executeAddressAliasTx({
+        async () => {
+          const digest = await executeAddressAliasTx({
             suiClient,
             sender: senderAddress,
             signer,
             buildBytes: (sender, client) =>
               buildBytes(sender, objectId, trimmed, client),
-          }),
+          })
+          // Wait for finality before refetching, else the read can race the
+          // write and still return the pre-change alias list.
+          await suiClient.core.waitForTransaction({ digest })
+          return digest
+        },
         {
           fallbackMessage,
           onSuccess: async () => {

--- a/packages/shared/src/wallet/hooks/useAliasProvisioning.ts
+++ b/packages/shared/src/wallet/hooks/useAliasProvisioning.ts
@@ -5,7 +5,6 @@ import {
 } from '@evefrontier/wallet-core/address-alias'
 import { useQueryClient } from '@tanstack/react-query'
 import { useCallback, useMemo, useState } from 'react'
-import { invalidateAliasEnforcement } from '../aliasEnforcement'
 import { useTransactionWrite } from './useTransactionWrite'
 import { useWalletSigningContext } from './useWalletSigningContext'
 
@@ -81,15 +80,14 @@ export function useAliasProvisioning(): UseAliasProvisioningResult {
             aliasAddress: aliasKey.address,
             acknowledged,
           })
-          // Wait for finality before invalidating, else the refetch can race
-          // the write.
+          // Wait for finality before refetching, else the read (and the next
+          // sign's on-chain enforcement check) can race the write.
           await suiClient.core.waitForTransaction({ digest: addDigest })
           return addDigest
         },
         {
           fallbackMessage: 'Failed to register personal access alias',
           onSuccess: async () => {
-            invalidateAliasEnforcement(senderAddress, chain)
             await queryClient.invalidateQueries({
               queryKey: ['address-aliases', senderAddress, chain],
             })

--- a/packages/shared/src/wallet/hooks/useAliasProvisioning.ts
+++ b/packages/shared/src/wallet/hooks/useAliasProvisioning.ts
@@ -68,15 +68,24 @@ export function useAliasProvisioning(): UseAliasProvisioningResult {
         setError('Generate a personal access key first')
         return false
       }
+      if (!acknowledged) {
+        setError('Confirm you have saved your personal access key first')
+        return false
+      }
       const digest = await run(
-        () =>
-          registerAcknowledgedAlias({
+        async () => {
+          const { addDigest } = await registerAcknowledgedAlias({
             suiClient,
             owner: senderAddress,
             signer,
             aliasAddress: aliasKey.address,
             acknowledged,
-          }).then((result) => result.addDigest),
+          })
+          // Wait for finality before invalidating, else the refetch can race
+          // the write.
+          await suiClient.core.waitForTransaction({ digest: addDigest })
+          return addDigest
+        },
         {
           fallbackMessage: 'Failed to register personal access alias',
           onSuccess: async () => {

--- a/packages/shared/src/wallet/hooks/useAliasProvisioning.ts
+++ b/packages/shared/src/wallet/hooks/useAliasProvisioning.ts
@@ -1,0 +1,115 @@
+import {
+  type GeneratedAliasKey,
+  generateAliasKey,
+  registerAcknowledgedAlias,
+} from '@evefrontier/wallet-core/address-alias'
+import { useQueryClient } from '@tanstack/react-query'
+import { useCallback, useMemo, useState } from 'react'
+import { invalidateAliasEnforcement } from '../aliasEnforcement'
+import { useTransactionWrite } from './useTransactionWrite'
+import { useWalletSigningContext } from './useWalletSigningContext'
+
+export interface UseAliasProvisioningResult {
+  /** The one-time personal access key to display, or `null` before generation / after registration. */
+  aliasKey: GeneratedAliasKey | null
+  ownerAddress: string | null
+  /** Generates a fresh client-only personal access key and holds it in memory only. */
+  generate: () => GeneratedAliasKey
+  /** Drops the in-memory personal access key. */
+  clear: () => void
+  /**
+   * Registers the generated key's address on-chain as an alias. `acknowledged`
+   * must be true (user confirmed they saved the key), else it surfaces the
+   * acknowledgement error. Resolves `true` on success.
+   */
+  register: (acknowledged: boolean) => Promise<boolean>
+  isSubmitting: boolean
+  error: string | null
+  txDigest: string | null
+}
+
+/**
+ * Drives one-time recovery-alias provisioning: generate a client-only key
+ * (shown once, never persisted), then register it on-chain once the user
+ * acknowledges saving it. Reuses the app signing context and the shared write
+ * lifecycle, and invalidates alias caches/queries on success so the
+ * enforcement gate clears.
+ */
+export function useAliasProvisioning(): UseAliasProvisioningResult {
+  const queryClient = useQueryClient()
+  const { chain, senderAddress, suiClient, sign } = useWalletSigningContext()
+  const { isSubmitting, error, txDigest, run, setError } = useTransactionWrite()
+  const [aliasKey, setAliasKey] = useState<GeneratedAliasKey | null>(null)
+
+  // Adapts the signing-context callback to wallet-core's signer shape (same as
+  // useAddressAliases). Alias-setup txs bypass the enforcement backstop.
+  const signer = useMemo(
+    () => ({
+      signTransaction: (bytes: Uint8Array) => sign('TransactionData', bytes),
+    }),
+    [sign],
+  )
+
+  const generate = useCallback(() => {
+    const key = generateAliasKey()
+    setAliasKey(key)
+    return key
+  }, [])
+
+  const clear = useCallback(() => setAliasKey(null), [])
+
+  const register = useCallback(
+    async (acknowledged: boolean): Promise<boolean> => {
+      if (!senderAddress) {
+        setError('Connect wallet first')
+        return false
+      }
+      if (!aliasKey) {
+        setError('Generate a personal access key first')
+        return false
+      }
+      const digest = await run(
+        () =>
+          registerAcknowledgedAlias({
+            suiClient,
+            owner: senderAddress,
+            signer,
+            aliasAddress: aliasKey.address,
+            acknowledged,
+          }).then((result) => result.addDigest),
+        {
+          fallbackMessage: 'Failed to register personal access alias',
+          onSuccess: async () => {
+            invalidateAliasEnforcement(senderAddress, chain)
+            await queryClient.invalidateQueries({
+              queryKey: ['address-aliases', senderAddress, chain],
+            })
+            setAliasKey(null)
+          },
+        },
+      )
+      return digest !== null
+    },
+    [
+      senderAddress,
+      aliasKey,
+      run,
+      setError,
+      suiClient,
+      signer,
+      chain,
+      queryClient,
+    ],
+  )
+
+  return {
+    aliasKey,
+    ownerAddress: senderAddress,
+    generate,
+    clear,
+    register,
+    isSubmitting,
+    error,
+    txDigest,
+  }
+}

--- a/packages/shared/src/wallet/hooks/useTransactionHistory.ts
+++ b/packages/shared/src/wallet/hooks/useTransactionHistory.ts
@@ -67,8 +67,8 @@ export function useTransactionHistory({
         query: TRANSACTIONS_QUERY,
         variables: {
           address: userAddress,
-          first: pageSize,
-          after: pageParam as string | undefined,
+          last: pageSize,
+          before: pageParam as string | undefined,
         },
       })
 
@@ -84,36 +84,38 @@ export function useTransactionHistory({
         log.debug('No transactions found')
         return {
           transactions: [],
-          nextCursor: null,
-          hasNextPage: false,
+          prevCursor: null,
+          hasPreviousPage: false,
         }
       }
 
-      // Parse transactions (one row per digest, with all balance changes aggregated)
+      // Connection nodes are oldest-first; reverse so each page reads
+      // newest-first without re-sorting by timestamp.
       const parsed = await Promise.all(
-        transactionsData.nodes.map((node: GraphQLTransactionNode) =>
-          parseGraphQLTransaction(node, userAddress, graphqlClient),
-        ),
+        transactionsData.nodes
+          .slice()
+          .reverse()
+          .map((node: GraphQLTransactionNode) =>
+            parseGraphQLTransaction(node, userAddress, graphqlClient),
+          ),
       )
 
-      const transactions = parsed
-        .filter(isNonNullable)
-        .sort((a, b) => b.timestamp - a.timestamp)
+      const transactions = parsed.filter(isNonNullable)
 
       log.debug('Transactions fetched successfully via GraphQL', {
         count: transactions.length,
-        hasNextPage: transactionsData.pageInfo.hasNextPage,
+        hasPreviousPage: transactionsData.pageInfo.hasPreviousPage,
       })
 
       return {
         transactions,
-        nextCursor: transactionsData.pageInfo.endCursor ?? null,
-        hasNextPage: transactionsData.pageInfo.hasNextPage,
+        prevCursor: transactionsData.pageInfo.startCursor ?? null,
+        hasPreviousPage: transactionsData.pageInfo.hasPreviousPage,
       }
     },
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) =>
-      lastPage.hasNextPage ? lastPage.nextCursor : undefined,
+      lastPage.hasPreviousPage ? lastPage.prevCursor : undefined,
     enabled: !!userAddress && !!chain && !!graphqlClient,
     staleTime: 1000 * 60, // 1 minute
     retry: 2,

--- a/packages/shared/src/wallet/hooks/useTransactionWrite.ts
+++ b/packages/shared/src/wallet/hooks/useTransactionWrite.ts
@@ -2,7 +2,10 @@ import { useCallback, useRef, useState } from 'react'
 import { createLogger } from '#/utils'
 import { isAliasEnforcementError } from '../aliasEnforcement'
 
-/** Shown when signing is blocked by address-alias enforcement (rare race past the UX gate). */
+/**
+ * When the signing backstop blocks a sign — a path that skipped
+ * the UX gate, or an alias removed after the gate passed.
+ */
 const ALIAS_ENFORCEMENT_MESSAGE = 'Set up your personal access key to continue'
 
 const log = createLogger()

--- a/packages/shared/src/wallet/hooks/useTransactionWrite.ts
+++ b/packages/shared/src/wallet/hooks/useTransactionWrite.ts
@@ -1,5 +1,10 @@
 import { useCallback, useRef, useState } from 'react'
 import { createLogger } from '#/utils'
+import { isAliasEnforcementError } from '../aliasEnforcement'
+
+/** Shown when signing is blocked by address-alias enforcement (rare race past the UX gate). */
+const ALIAS_ENFORCEMENT_MESSAGE =
+  'Set up your personal access alias to continue'
 
 const log = createLogger()
 
@@ -70,7 +75,11 @@ export function useTransactionWrite(): UseTransactionWriteResult {
         await onSuccess?.(digest)
         return digest
       } catch (err) {
-        const message = err instanceof Error ? err.message : fallbackMessage
+        const message = isAliasEnforcementError(err)
+          ? ALIAS_ENFORCEMENT_MESSAGE
+          : err instanceof Error
+            ? err.message
+            : fallbackMessage
         log.error(logLabel ?? fallbackMessage, err)
         setError(message)
         return null

--- a/packages/shared/src/wallet/hooks/useTransactionWrite.ts
+++ b/packages/shared/src/wallet/hooks/useTransactionWrite.ts
@@ -3,8 +3,7 @@ import { createLogger } from '#/utils'
 import { isAliasEnforcementError } from '../aliasEnforcement'
 
 /** Shown when signing is blocked by address-alias enforcement (rare race past the UX gate). */
-const ALIAS_ENFORCEMENT_MESSAGE =
-  'Set up your personal access alias to continue'
+const ALIAS_ENFORCEMENT_MESSAGE = 'Set up your personal access key to continue'
 
 const log = createLogger()
 

--- a/packages/shared/src/wallet/index.ts
+++ b/packages/shared/src/wallet/index.ts
@@ -19,8 +19,16 @@ export {
   createWebCryptoPlaceholder,
   isWebCryptoMarker,
 } from '../types/wallet'
+export {
+  assertAliasEnforced,
+  invalidateAliasEnforcement,
+  isAddressAliasEnforcementEnabled,
+  isAliasEnforcementError,
+  resolveAliasEnforcementStatus,
+} from './aliasEnforcement'
 export { useActiveSuiAddress } from './hooks/useActiveSuiAddress'
 export { useAddressAliases } from './hooks/useAddressAliases'
+export { useAliasProvisioning } from './hooks/useAliasProvisioning'
 export { useBalance } from './hooks/useBalance'
 export { useSendToken } from './hooks/useSendToken'
 export { useTransactionHistory } from './hooks/useTransactionHistory'

--- a/packages/shared/src/wallet/index.ts
+++ b/packages/shared/src/wallet/index.ts
@@ -22,6 +22,7 @@ export {
 export {
   assertAliasEnforced,
   isAliasEnforcementError,
+  isAliasEnforcementFeatureEnabled,
   isEnforcementOverridden,
   resolveAliasEnforcementStatus,
 } from './aliasEnforcement'

--- a/packages/shared/src/wallet/index.ts
+++ b/packages/shared/src/wallet/index.ts
@@ -21,9 +21,8 @@ export {
 } from '../types/wallet'
 export {
   assertAliasEnforced,
-  invalidateAliasEnforcement,
-  isAddressAliasEnforcementEnabled,
   isAliasEnforcementError,
+  isEnforcementOverridden,
   resolveAliasEnforcementStatus,
 } from './aliasEnforcement'
 export { useActiveSuiAddress } from './hooks/useActiveSuiAddress'

--- a/packages/shared/src/wallet/queries/transactions.ts
+++ b/packages/shared/src/wallet/queries/transactions.ts
@@ -3,8 +3,7 @@
  * Returns transactions where the address is either sender or affected party
  *
  * Paginates backward (`last`/`before`) because the connection is ordered
- * oldest-first: `last` returns the most recent window, and walking `before`
- * the window's startCursor loads progressively older transactions.
+ * oldest-first: `last` returns the most recent window.
  *
  * Schema reference (testnet/devnet 2025+):
  * - Address.transactions (not transactionBlocks)

--- a/packages/shared/src/wallet/queries/transactions.ts
+++ b/packages/shared/src/wallet/queries/transactions.ts
@@ -2,25 +2,50 @@
  * GraphQL query for fetching transactions for an address
  * Returns transactions where the address is either sender or affected party
  *
+ * Paginates backward (`last`/`before`) because the connection is ordered
+ * oldest-first: `last` returns the most recent window, and walking `before`
+ * the window's startCursor loads progressively older transactions.
+ *
  * Schema reference (testnet/devnet 2025+):
  * - Address.transactions (not transactionBlocks)
  * - timestamp is on effects, not transaction
  * - BalanceChange.owner is Address (not Owner union)
+ * - kind is the TransactionKind union; move-call targets come from
+ *   ProgrammableTransaction.commands, used to label coin-less calls
+ *   (e.g. address_alias::add) instead of a bare "System" counterparty
  */
 export const TRANSACTIONS_QUERY = `
   query TransactionsForAddress(
     $address: SuiAddress!
-    $first: Int
-    $after: String
+    $last: Int
+    $before: String
   ) {
     address(address: $address) {
-      transactions(first: $first, after: $after, relation: AFFECTED) {
+      transactions(last: $last, before: $before, relation: AFFECTED) {
         pageInfo {
-          hasNextPage
-          endCursor
+          hasPreviousPage
+          startCursor
         }
         nodes {
           digest
+          kind {
+            __typename
+            ... on ProgrammableTransaction {
+              commands {
+                nodes {
+                  __typename
+                  ... on MoveCallCommand {
+                    function {
+                      name
+                      module {
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
           effects {
             timestamp
             balanceChanges {

--- a/packages/shared/src/wallet/signForChain.ts
+++ b/packages/shared/src/wallet/signForChain.ts
@@ -4,6 +4,7 @@ import { browser } from '@wxt-dev/browser'
 import { VaultMessageTypes } from '#/types'
 import type { ZkSignAnyParams } from '#/types/wallet'
 import { toErrorMessage } from '#/utils/errorMessage'
+import { assertAliasEnforced } from './aliasEnforcement'
 import { zkSignAny } from './zkSignAny'
 
 /**
@@ -76,6 +77,15 @@ export async function signForChain(
   if (!opts.getZkProof) {
     throw new Error('[signForChain] getZkProof is required for zkLogin signing')
   }
+
+  // Enforcement backstop: block signing until the account has a non-self alias.
+  // Alias-setup transactions are exempt so the first alias can be registered.
+  await assertAliasEnforced({
+    chain: opts.chain,
+    owner: (opts.user?.profile?.sui_address as string | undefined) ?? null,
+    scope,
+    msgBytes,
+  })
 
   const { bytes, zkSignature } = await zkSignAny(scope, msgBytes, {
     user: opts.user,

--- a/packages/shared/src/wallet/types/graphql.ts
+++ b/packages/shared/src/wallet/types/graphql.ts
@@ -21,10 +21,30 @@ export interface GraphQLBalanceChange {
 }
 
 /**
+ * Move-call command within a programmable transaction. Only the fields needed
+ * to label the call (module + function) are requested.
+ */
+export interface GraphQLMoveCallCommand {
+  __typename: string
+  function?: {
+    name: string | null
+    module: {
+      name: string | null
+    } | null
+  } | null
+}
+
+/**
  * Transaction node from a GraphQL response
  */
 export interface GraphQLTransactionNode {
   digest: string | null
+  kind: {
+    __typename: string
+    commands?: {
+      nodes: GraphQLMoveCallCommand[]
+    } | null
+  } | null
   effects: {
     timestamp: string | null
     balanceChanges: {
@@ -40,8 +60,8 @@ export interface TransactionsQueryResponse {
   address: {
     transactions: {
       pageInfo: {
-        hasNextPage: boolean
-        endCursor: string | null
+        hasPreviousPage: boolean
+        startCursor: string | null
       }
       nodes: GraphQLTransactionNode[]
     } | null
@@ -53,8 +73,8 @@ export interface TransactionsQueryResponse {
  */
 export interface TransactionPage {
   transactions: import('#/types/components').Transaction[]
-  nextCursor: string | null
-  hasNextPage: boolean
+  prevCursor: string | null
+  hasPreviousPage: boolean
 }
 
 /**

--- a/packages/shared/src/wallet/types/graphql.ts
+++ b/packages/shared/src/wallet/types/graphql.ts
@@ -21,8 +21,10 @@ export interface GraphQLBalanceChange {
 }
 
 /**
- * Move-call command within a programmable transaction. Only the fields needed
- * to label the call (module + function) are requested.
+ * A command node within a programmable transaction. Every `commands.nodes`
+ * entry has this shape; `function` is only present on MoveCall commands (other
+ * command types carry just `__typename`). Only the fields needed to label a
+ * move call (module + function) are requested.
  */
 export interface GraphQLMoveCallCommand {
   __typename: string

--- a/packages/shared/src/wallet/utils/__tests__/parseTransaction.test.ts
+++ b/packages/shared/src/wallet/utils/__tests__/parseTransaction.test.ts
@@ -215,6 +215,73 @@ describe('parseGraphQLTransaction — outgoing fallback', () => {
   })
 })
 
+describe('parseGraphQLTransaction — move-call counterparty label', () => {
+  beforeEach(() => mockFetchCoinMetadata.mockReset())
+
+  const moveCallKind = (moduleName: string, functionName: string) => ({
+    kind: {
+      __typename: 'ProgrammableTransaction',
+      commands: {
+        nodes: [
+          {
+            __typename: 'MoveCallCommand',
+            function: { name: functionName, module: { name: moduleName } },
+          },
+        ],
+      },
+    },
+  })
+
+  it('labels a coin-less move call with module::function instead of System', async () => {
+    mockFetchCoinMetadata.mockResolvedValue(metadata(9, 'SUI'))
+
+    // Alias registration: user pays gas, no coin moves to another address.
+    const result = await parseGraphQLTransaction(
+      txNode(
+        [change({ amount: '-5000', coinType: SUI, owner: USER })],
+        moveCallKind('address_alias', 'add'),
+      ),
+      USER,
+      client,
+    )
+
+    expect(result).toMatchObject({
+      direction: 'sent',
+      counterparty: 'address_alias::add',
+    })
+  })
+
+  it('keeps a real counterparty address over the move-call label', async () => {
+    mockFetchCoinMetadata.mockResolvedValue(metadata(9, 'SUI'))
+
+    const result = await parseGraphQLTransaction(
+      txNode(
+        [
+          change({ amount: '-100', coinType: SUI, owner: USER }),
+          change({ amount: '100', coinType: SUI, owner: '0xRecipient' }),
+        ],
+        moveCallKind('address_alias', 'add'),
+      ),
+      USER,
+      client,
+    )
+
+    expect(result?.counterparty).toBe('0xRecipient')
+  })
+
+  it('stays System when the tx has no move call', async () => {
+    mockFetchCoinMetadata.mockResolvedValue(metadata(9, 'SUI'))
+
+    const result = await parseGraphQLTransaction(
+      txNode([change({ amount: '-5000', coinType: SUI, owner: USER })]),
+      USER,
+      client,
+    )
+
+    expect(result?.counterparty).toBe('System')
+  })
+})
+
 describe('parseGraphQLTransaction — metadata fallbacks', () => {
   beforeEach(() => mockFetchCoinMetadata.mockReset())
 

--- a/packages/shared/src/wallet/utils/parseTransaction.ts
+++ b/packages/shared/src/wallet/utils/parseTransaction.ts
@@ -14,12 +14,16 @@ import {
 import { createLogger } from '#/utils/logger'
 import type {
   GraphQLBalanceChange,
+  GraphQLMoveCallCommand,
   GraphQLTransactionNode,
 } from '#/wallet/types/graphql'
 import { fetchCoinMetadata } from './coinMetadata'
 import { extractSymbolFromCoinType } from './formatTransaction'
 
 const log = createLogger()
+
+/** Counterparty shown when no address moved coins (e.g. a pure move call). */
+const SYSTEM_COUNTERPARTY = 'System'
 
 function findCounterparty(
   balanceChanges: GraphQLBalanceChange[],
@@ -42,7 +46,7 @@ function findCounterparty(
   })
   const sameCoin = withOppositeSign.find(sameCoinType)
   const counterpartyChange = sameCoin ?? withOppositeSign[0]
-  return counterpartyChange?.owner?.address ?? 'System'
+  return counterpartyChange?.owner?.address ?? SYSTEM_COUNTERPARTY
 }
 
 /**
@@ -71,6 +75,8 @@ type TransactionContext = {
   digest: string
   timestamp: number
   balanceChanges: GraphQLBalanceChange[]
+  /** `module::function` of the first move call, used to label coin-less txs. */
+  moveCallLabel: string | null
 }
 
 const getTransactionContext = (
@@ -85,8 +91,38 @@ const getTransactionContext = (
           ? new Date(effects.timestamp).getTime()
           : Date.now(),
         balanceChanges,
+        moveCallLabel: getMoveCallLabel(txNode),
       }
     : null
+}
+
+/**
+ * Derives a `module::function` label from the transaction's first move call,
+ * so coin-less calls (e.g. address_alias::add) read as their target instead of
+ * a bare "System" counterparty. Returns null when the tx has no move call.
+ */
+const getMoveCallLabel = (txNode: GraphQLTransactionNode): string | null => {
+  const command = txNode.kind?.commands?.nodes?.find(isMoveCallCommand)
+  const fn = command?.function
+  const moduleName = fn?.module?.name
+  return fn?.name && moduleName ? `${moduleName}::${fn.name}` : null
+}
+
+const isMoveCallCommand = (command: GraphQLMoveCallCommand): boolean => {
+  return command.__typename === 'MoveCallCommand'
+}
+
+/**
+ * Falls back to the move-call label when no address moved coins, keeping a real
+ * counterparty address whenever one exists.
+ */
+const resolveCounterparty = (
+  counterparty: string,
+  context: TransactionContext,
+): string => {
+  return counterparty === SYSTEM_COUNTERPARTY
+    ? (context.moveCallLabel ?? counterparty)
+    : counterparty
 }
 
 const buildUserBalanceTransaction = async (
@@ -106,11 +142,14 @@ const buildUserBalanceTransaction = async (
         digest: context.digest,
         timestamp: context.timestamp,
         direction: primary.direction,
-        counterparty: findCounterparty(
-          context.balanceChanges,
-          userAddress,
-          primary.direction,
-          primary.coinType,
+        counterparty: resolveCounterparty(
+          findCounterparty(
+            context.balanceChanges,
+            userAddress,
+            primary.direction,
+            primary.coinType,
+          ),
+          context,
         ),
         balanceChanges: balanceChangeItems,
       }
@@ -132,9 +171,9 @@ const buildOutgoingBalanceTransaction = async (
         digest: context.digest,
         timestamp: context.timestamp,
         direction: 'sent',
-        counterparty: findRecipientCounterparty(
-          context.balanceChanges,
-          userAddress,
+        counterparty: resolveCounterparty(
+          findRecipientCounterparty(context.balanceChanges, userAddress),
+          context,
         ),
         balanceChanges: [balanceChange],
       }
@@ -229,7 +268,7 @@ const findRecipientCounterparty = (
       ownerAddress?.toLowerCase() !== userAddress.toLowerCase()
     )
   })
-  return recipientChange?.owner?.address ?? 'System'
+  return recipientChange?.owner?.address ?? SYSTEM_COUNTERPARTY
 }
 
 const isOutgoingChange = (bc: GraphQLBalanceChange): boolean => {


### PR DESCRIPTION
Requires zkLogin accounts to register a recovery alias before signing **on-chain transactions**. Enforcement is always on. Suspending this requires an auditable, expiring ops override break-glass.

## Enforcement

- **Just-in-time gate (`useRequireAlias`)** — callers `await ensureAlias()` right before signing; it opens the recovery-setup modal only when an on-chain lookup finds no non-self alias. Wired into `SignTransactionFlow`, `SignSponsoredTransaction`, and `SendTokenScreen`.
- **Signing backstop (`assertAliasEnforced`)** — throws at the signing layer when no enforceable alias exists, so the policy holds even if a UI path misses the gate. Only on-chain transactions (`TransactionData`) are gated. Localnet is skipped.
- **On-chain state is the source of truth** — enforcement status is read live on every check (no client-side cache), so adding or removing an alias never requires cache invalidation and can't leave a stale "satisfied" result.
- **No kill-switch — auditable break-glass instead.** Enforcement is unconditional. The only escape is an ops-issued, **signed, expiring** override that is **fail-closed** (any malformed/expired/absent override → enforce) and logged on every use. The override validator, both call sites, and the audit logging are implemented; sourcing the override from a signed `alias_enforcement_override` JWT claim is stubbed as a fast-follow.

## Provisioning & setup UX

- **One-time client-only key** — generates a personal access key (24-word BIP-39 mnemonic + Ed25519 private key), shown once and never persisted; registered on-chain as the account's alias.

<img width="785" height="508" alt="Screenshot 2026-08-27 at 11 52 03" src="https://github.com/user-attachments/assets/8b50a4b7-dbf8-48ed-859f-9ac40124bc72" />
<img width="479" height="460" alt="Screenshot 2026-09-01 at 12 04 32" src="https://github.com/user-attachments/assets/c55610a7-727a-4dda-ae35-35f9b7192a0e" />

## Transaction history

- **Newest-first ordering** — the query paginated forward against an oldest-first connection. Switched to backward pagination (`last`/`before`).
- **Move-call counterparty labels** — coin-less transactions that only pay gas showed a bare `System`. They now read as `module::function` (e.g. `address_alias::add`); a real sender/recipient address still takes precedence.

## Follow-ups

- **Break-glass source:** wire `getEnforcementOverrideClaim()` to the signed `alias_enforcement_override` claim on the zkLogin JWT (backend change) so ops can engage the override without a client redeploy; validation, fail-closed handling, and audit logging are already in place.