### PR TITLE
fix(extension): show PIN screen when keeper locks before signing

### DIFF
--- a/apps/extension/entrypoints/keeper/__tests__/keeper.operations.test.ts
+++ b/apps/extension/entrypoints/keeper/__tests__/keeper.operations.test.ts
@@ -6,6 +6,7 @@ import {
   decrypt,
   encrypt,
   type HashedData,
+  KEEPER_EPH_SIGN_LOCKED_ERROR,
   KeeperMessageTypes,
 } from '@evevault/shared'
 import type { ZkProofResponse } from '@evevault/shared/types'
@@ -228,7 +229,7 @@ describe('Keeper EPH_SIGN handler', () => {
       msgBytes: [1],
     })
 
-    expect(resp.error).toBe('[KEEPER_EPH_SIGN] LOCKED')
+    expect(resp.error).toBe(KEEPER_EPH_SIGN_LOCKED_ERROR)
   })
 
   it('converts msgBytes to Uint8Array and calls signTransaction for TransactionData scope', async () => {

--- a/apps/extension/entrypoints/keeper/vaultHandlers.ts
+++ b/apps/extension/entrypoints/keeper/vaultHandlers.ts
@@ -2,7 +2,12 @@ import {
   ZKEd25519Keypair,
   type ZKProofData,
 } from '@evefrontier/wallet-core/crypto'
-import { encrypt, encryptWithKey, type HashedData } from '@evevault/shared'
+import {
+  encrypt,
+  encryptWithKey,
+  type HashedData,
+  KEEPER_EPH_SIGN_LOCKED_ERROR,
+} from '@evevault/shared'
 import { createLogger } from '@evevault/shared/utils'
 import type { BackgroundMessage } from '@/lib/background/types'
 import {
@@ -163,7 +168,7 @@ export function handleEphSign(
 ): boolean {
   const key = getEphemeralKey()
   if (enforceExpiry() || !key) {
-    sendResponse({ error: '[KEEPER_EPH_SIGN] LOCKED' })
+    sendResponse({ error: KEEPER_EPH_SIGN_LOCKED_ERROR })
     return false
   }
   // Capture the current key before async work so a later lock does not mutate it.

--- a/apps/extension/src/features/wallet/components/SignPersonalMessage.tsx
+++ b/apps/extension/src/features/wallet/components/SignPersonalMessage.tsx
@@ -56,6 +56,7 @@ function SignPersonalMessage() {
     setError,
     auth,
     handleReject,
+    recoverIfLocked,
     storeResult,
     storeErrorResult,
   } = usePendingSignAction({
@@ -98,8 +99,9 @@ function SignPersonalMessage() {
 
       window.close()
     } catch (err) {
-      log.error('Personal message signing failed', err)
       const errorMessage = toErrorMessage(err, 'Unknown error occurred')
+      if (await recoverIfLocked(errorMessage)) return
+      log.error('Personal message signing failed', err)
       setError(errorMessage)
       await storeErrorResult(errorMessage)
     } finally {

--- a/apps/extension/src/features/wallet/components/SignRequestView.tsx
+++ b/apps/extension/src/features/wallet/components/SignRequestView.tsx
@@ -116,7 +116,10 @@ export function SignRequestView({
   children,
 }: SignRequestViewProps) {
   const [acknowledged, setAcknowledged] = useState(false)
-  const approveDisabled = loading || (requireAcknowledgement && !acknowledged)
+  // Keep Approve disabled until the keeper's lock state is confirmed, so a stale
+  // unlocked flag can't let the user fire a sign the keeper will reject.
+  const approveDisabled =
+    loading || !auth.lockChecked || (requireAcknowledgement && !acknowledged)
   return (
     <SignPopupAuthGate
       isLocked={auth.isLocked}

--- a/apps/extension/src/features/wallet/components/SignSponsoredTransaction.tsx
+++ b/apps/extension/src/features/wallet/components/SignSponsoredTransaction.tsx
@@ -97,6 +97,7 @@ function SignSponsoredTransaction() {
     setError,
     auth,
     handleReject,
+    recoverIfLocked,
     storeResult,
     storeErrorResult,
   } = usePendingSignAction({
@@ -138,9 +139,10 @@ function SignSponsoredTransaction() {
       }
       window.close()
     } catch (err) {
-      log.error('Sponsored transaction signing failed', err)
       const errorMessage =
         err instanceof Error ? err.message : 'Unknown error occurred'
+      if (await recoverIfLocked(errorMessage)) return
+      log.error('Sponsored transaction signing failed', err)
       setError(errorMessage)
       await storeErrorResult(errorMessage)
     } finally {

--- a/apps/extension/src/features/wallet/components/__tests__/SignPersonalMessage.test.tsx
+++ b/apps/extension/src/features/wallet/components/__tests__/SignPersonalMessage.test.tsx
@@ -79,6 +79,7 @@ function stubPending(
     setError: vi.fn(),
     auth: AUTH_STUB,
     handleReject: vi.fn(),
+    recoverIfLocked: vi.fn(() => Promise.resolve(false)),
     storeResult: vi.fn(() => Promise.resolve(true)),
     storeErrorResult: vi.fn(() => Promise.resolve(true)),
     ...overrides,

--- a/apps/extension/src/features/wallet/components/__tests__/SignRequestView.test.tsx
+++ b/apps/extension/src/features/wallet/components/__tests__/SignRequestView.test.tsx
@@ -55,6 +55,7 @@ vi.mock('@evevault/shared/components', async (importOriginal) => {
 
 const AUTH_STUB = {
   isLocked: false,
+  lockChecked: true,
   isPinSet: true,
   unlock: vi.fn(),
   user: { id_token: 'tok' },
@@ -117,6 +118,15 @@ describe('SignRequestView', () => {
     )
     expect(screen.getByRole('button', { name: 'Approve' })).not.toBeDisabled()
     expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+  })
+
+  it('Approve is disabled until the keeper lock state is confirmed', () => {
+    render(
+      <SignRequestView
+        {...defaultProps({ auth: { ...AUTH_STUB, lockChecked: false } })}
+      />,
+    )
+    expect(screen.getByRole('button', { name: 'Approve' })).toBeDisabled()
   })
 
   it('Approve is disabled when requireAcknowledgement is true and not yet acknowledged', () => {

--- a/apps/extension/src/features/wallet/components/__tests__/SignSponsoredTransaction.test.tsx
+++ b/apps/extension/src/features/wallet/components/__tests__/SignSponsoredTransaction.test.tsx
@@ -121,6 +121,7 @@ function stubPending(
     setError: vi.fn(),
     auth: AUTH_STUB,
     handleReject: vi.fn(),
+    recoverIfLocked: vi.fn(() => Promise.resolve(false)),
     storeResult: vi.fn(() => Promise.resolve(true)),
     storeErrorResult: vi.fn(() => Promise.resolve(true)),
     ...overrides,

--- a/apps/extension/src/features/wallet/hooks/__tests__/usePendingSignAction.test.tsx
+++ b/apps/extension/src/features/wallet/hooks/__tests__/usePendingSignAction.test.tsx
@@ -25,8 +25,10 @@ vi.mock('@evevault/shared/utils', async (importOriginal) => {
 
 const AUTH_STUB = {
   isLocked: false,
+  lockChecked: true,
   isPinSet: true,
   unlock: vi.fn(),
+  lock: vi.fn(() => Promise.resolve()),
   user: { id_token: 'tok' },
   loading: false,
   login: vi.fn(),
@@ -245,6 +247,43 @@ describe('usePendingSignAction', () => {
 
       expect(closeSpy).not.toHaveBeenCalled()
       expect(result.current.error).toBe('Reject failed')
+    })
+  })
+
+  describe('recoverIfLocked', () => {
+    it('locks the vault and reports handled for the keeper locked error', async () => {
+      const action = { windowId: 1, requestId: 'req-lock' }
+      stubStorage(action)
+      const { result } = renderHook(() => usePendingSignAction(makeOptions()))
+      await waitFor(() => expect(result.current.pending).toEqual(action))
+
+      let handled: boolean | undefined
+      await act(async () => {
+        handled = await result.current.recoverIfLocked(
+          '[KEEPER_EPH_SIGN] LOCKED',
+        )
+      })
+
+      expect(handled).toBe(true)
+      expect(AUTH_STUB.lock).toHaveBeenCalledTimes(1)
+      // The dApp request must stay pending, so no error result is written.
+      expect(browser.storage.local.set).not.toHaveBeenCalled()
+      expect(result.current.error).toBeNull()
+    })
+
+    it('does not handle unrelated errors', async () => {
+      const action = { windowId: 1, requestId: 'req-other' }
+      stubStorage(action)
+      const { result } = renderHook(() => usePendingSignAction(makeOptions()))
+      await waitFor(() => expect(result.current.pending).toEqual(action))
+
+      let handled: boolean | undefined
+      await act(async () => {
+        handled = await result.current.recoverIfLocked('some other failure')
+      })
+
+      expect(handled).toBe(false)
+      expect(AUTH_STUB.lock).not.toHaveBeenCalled()
     })
   })
 })

--- a/apps/extension/src/features/wallet/hooks/__tests__/usePendingSignAction.test.tsx
+++ b/apps/extension/src/features/wallet/hooks/__tests__/usePendingSignAction.test.tsx
@@ -1,3 +1,4 @@
+import { KEEPER_EPH_SIGN_LOCKED_ERROR } from '@evevault/shared'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { usePendingSignAction } from '../usePendingSignAction'
@@ -260,7 +261,7 @@ describe('usePendingSignAction', () => {
       let handled: boolean | undefined
       await act(async () => {
         handled = await result.current.recoverIfLocked(
-          '[KEEPER_EPH_SIGN] LOCKED',
+          KEEPER_EPH_SIGN_LOCKED_ERROR,
         )
       })
 

--- a/apps/extension/src/features/wallet/hooks/__tests__/useSignPopupAuth.test.tsx
+++ b/apps/extension/src/features/wallet/hooks/__tests__/useSignPopupAuth.test.tsx
@@ -1,0 +1,110 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSignPopupAuth } from '../useSignPopupAuth'
+
+const {
+  mockUseAuth,
+  mockUseDevice,
+  mockUseContext,
+  mockUseVaultAutoLock,
+  mockGetUnlockRemainingMs,
+} = vi.hoisted(() => ({
+  mockUseAuth: vi.fn(),
+  mockUseDevice: vi.fn(),
+  mockUseContext: vi.fn(),
+  mockUseVaultAutoLock: vi.fn(),
+  mockGetUnlockRemainingMs: vi.fn(),
+}))
+
+vi.mock('@evevault/shared/auth', () => ({ useAuth: mockUseAuth }))
+vi.mock('@evevault/shared/hooks', () => ({
+  useDevice: mockUseDevice,
+  useContext: mockUseContext,
+  useVaultAutoLock: mockUseVaultAutoLock,
+}))
+vi.mock('@evevault/shared/services/vaultService', () => ({
+  ephKeyService: { getUnlockRemainingMs: mockGetUnlockRemainingMs },
+}))
+vi.mock('@evevault/shared/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@evevault/shared/utils')>()
+  return {
+    ...actual,
+    createLogger: () => ({
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    }),
+  }
+})
+
+function stubDevice(overrides: Record<string, unknown> = {}) {
+  const lock = vi.fn(() => Promise.resolve())
+  mockUseDevice.mockReturnValue({
+    isLocked: false,
+    isPinSet: true,
+    unlock: vi.fn(),
+    lock,
+    initializeForChain: vi.fn(() => Promise.resolve()),
+    maxEpoch: 100,
+    nonce: 'n',
+    getZkProof: vi.fn(),
+    ephemeralPublicKey: {},
+    ...overrides,
+  })
+  return lock
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockUseAuth.mockReturnValue({
+    initialize: vi.fn(),
+    user: { id_token: 'tok' },
+    loading: false,
+    login: vi.fn(),
+  })
+  mockUseContext.mockReturnValue({ chain: 'sui:testnet' })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('useSignPopupAuth', () => {
+  it('arms auto-lock for the standalone sign popup', () => {
+    stubDevice()
+    mockGetUnlockRemainingMs.mockResolvedValue(60_000)
+    renderHook(() => useSignPopupAuth())
+    expect(mockUseVaultAutoLock).toHaveBeenCalled()
+  })
+
+  it('locks the vault when the keeper window has already expired', async () => {
+    const lock = stubDevice()
+    mockGetUnlockRemainingMs.mockResolvedValue(0)
+
+    const { result } = renderHook(() => useSignPopupAuth())
+
+    await waitFor(() => expect(result.current.lockChecked).toBe(true))
+    expect(lock).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves the vault unlocked when the keeper window is still open', async () => {
+    const lock = stubDevice()
+    mockGetUnlockRemainingMs.mockResolvedValue(30_000)
+
+    const { result } = renderHook(() => useSignPopupAuth())
+
+    await waitFor(() => expect(result.current.lockChecked).toBe(true))
+    expect(lock).not.toHaveBeenCalled()
+  })
+
+  it('still confirms the check when the keeper query fails', async () => {
+    const lock = stubDevice()
+    mockGetUnlockRemainingMs.mockRejectedValue(new Error('keeper down'))
+
+    const { result } = renderHook(() => useSignPopupAuth())
+
+    await waitFor(() => expect(result.current.lockChecked).toBe(true))
+    expect(lock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/extension/src/features/wallet/hooks/__tests__/useTransactionSigning.test.tsx
+++ b/apps/extension/src/features/wallet/hooks/__tests__/useTransactionSigning.test.tsx
@@ -153,6 +153,23 @@ describe('useTransactionSigning', () => {
       expect(onSigned).not.toHaveBeenCalled()
     })
 
+    it('recovers in-place without surfacing an error when the vault is locked', async () => {
+      const { setError, storeErrorResult } = stubPendingTransaction({
+        recoverIfLocked: vi.fn(() => Promise.resolve(true)),
+      })
+      mockPrepare.mockRejectedValue(new Error('[KEEPER_EPH_SIGN] LOCKED'))
+
+      const onSigned = vi.fn()
+      const { result } = renderHook(() => useTransactionSigning())
+
+      await act(() => result.current.withSigning(onSigned))
+
+      // recoverIfLocked handled it: no error written back to the dApp.
+      expect(setError).not.toHaveBeenCalledWith('[KEEPER_EPH_SIGN] LOCKED')
+      expect(storeErrorResult).not.toHaveBeenCalled()
+      expect(onSigned).not.toHaveBeenCalled()
+    })
+
     it('uses "Unknown error occurred" message for non-Error throws', async () => {
       const { setError, storeErrorResult } = stubPendingTransaction()
       mockPrepare.mockRejectedValue('plain string error')

--- a/apps/extension/src/features/wallet/hooks/__tests__/useTransactionSigning.test.tsx
+++ b/apps/extension/src/features/wallet/hooks/__tests__/useTransactionSigning.test.tsx
@@ -63,6 +63,7 @@ function stubPendingTransaction(overrides: Record<string, unknown> = {}) {
     setError,
     auth: { user: { id_token: 'tok' } },
     handleReject,
+    recoverIfLocked: vi.fn(() => Promise.resolve(false)),
     storeResult,
     storeErrorResult,
     ...overrides,

--- a/apps/extension/src/features/wallet/hooks/usePendingSignAction.ts
+++ b/apps/extension/src/features/wallet/hooks/usePendingSignAction.ts
@@ -1,3 +1,4 @@
+import { isKeeperLockedError } from '@evevault/shared'
 import { createLogger } from '@evevault/shared/utils'
 import { useEffect, useState } from 'react'
 import { browser } from 'wxt/browser'
@@ -114,6 +115,18 @@ export function usePendingSignAction<TPending extends { requestId?: string }>({
     return storeResult({ status: 'error', error: errorMessage }, targetPending)
   }
 
+  // If a sign attempt reaches the keeper after its unlock window expired, flip
+  // this popup to the lock screen and keep the request pending instead of
+  // failing the dApp. The same request continues to approval after unlock.
+  // Returns true when the error was the recoverable locked-vault signal.
+  const recoverIfLocked = async (errorMessage: string): Promise<boolean> => {
+    if (!isKeeperLockedError(errorMessage)) return false
+    log.info('Sign request hit locked keeper; showing unlock screen for retry')
+    setError(null)
+    await auth.lock()
+    return true
+  }
+
   const handleReject = async () => {
     if (!pending) return
 
@@ -139,6 +152,7 @@ export function usePendingSignAction<TPending extends { requestId?: string }>({
     setError,
     auth,
     handleReject,
+    recoverIfLocked,
     storeResult,
     storeErrorResult,
   }

--- a/apps/extension/src/features/wallet/hooks/useSignPopupAuth.ts
+++ b/apps/extension/src/features/wallet/hooks/useSignPopupAuth.ts
@@ -31,8 +31,10 @@ export function useSignPopupAuth() {
     ephKeyService
       .getUnlockRemainingMs()
       .then((remainingMs) => {
-        if (cancelled) return
-        if (remainingMs <= 0) return device.lock()
+        if (cancelled || remainingMs > 0) return
+        return device.lock().catch((error) => {
+          log.warn('Failed to lock sign popup after keeper expiry', { error })
+        })
       })
       .catch((error) => {
         log.warn('Failed to confirm keeper lock state for sign popup', {

--- a/apps/extension/src/features/wallet/hooks/useSignPopupAuth.ts
+++ b/apps/extension/src/features/wallet/hooks/useSignPopupAuth.ts
@@ -1,7 +1,8 @@
 import { useAuth } from '@evevault/shared/auth'
-import { useContext, useDevice } from '@evevault/shared/hooks'
+import { useContext, useDevice, useVaultAutoLock } from '@evevault/shared/hooks'
+import { ephKeyService } from '@evevault/shared/services/vaultService'
 import { createLogger } from '@evevault/shared/utils'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
 const log = createLogger()
 
@@ -14,6 +15,37 @@ export function useSignPopupAuth() {
   const device = useDevice()
   const auth = useAuth()
   const { chain } = useContext()
+
+  // Sign popups are standalone entrypoints, so they must arm auto-lock
+  // themselves — otherwise a keeper that expires while the approval screen sits
+  // open never flips this popup to the lock screen.
+  useVaultAutoLock()
+
+  // The persisted `isLocked` flag can still read false on this popup's first
+  // render while the keeper has already expired (its async refresh hasn't landed
+  // yet). Confirm the authoritative lock state before Approve is enabled so the
+  // popup shows the PIN screen instead of a doomed sign attempt.
+  const [lockChecked, setLockChecked] = useState(false)
+  useEffect(() => {
+    let cancelled = false
+    ephKeyService
+      .getUnlockRemainingMs()
+      .then((remainingMs) => {
+        if (cancelled) return
+        if (remainingMs <= 0) return device.lock()
+      })
+      .catch((error) => {
+        log.warn('Failed to confirm keeper lock state for sign popup', {
+          error,
+        })
+      })
+      .finally(() => {
+        if (!cancelled) setLockChecked(true)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [device.lock])
 
   useEffect(() => {
     auth.initialize()
@@ -42,8 +74,10 @@ export function useSignPopupAuth() {
 
   return {
     isLocked: device.isLocked,
+    lockChecked,
     isPinSet: device.isPinSet,
     unlock: device.unlock,
+    lock: device.lock,
     user: auth.user,
     loading: auth.loading,
     login: auth.login,

--- a/apps/extension/src/features/wallet/hooks/useTransactionSigning.ts
+++ b/apps/extension/src/features/wallet/hooks/useTransactionSigning.ts
@@ -23,6 +23,7 @@ export function useTransactionSigning() {
     setError,
     auth,
     handleReject,
+    recoverIfLocked,
     storeResult,
     storeErrorResult,
   } = usePendingTransaction()
@@ -48,9 +49,10 @@ export function useTransactionSigning() {
       await onSigned(result)
       window.close()
     } catch (err) {
-      log.error('Transaction signing failed', err)
       const errorMessage =
         err instanceof Error ? err.message : 'Unknown error occurred'
+      if (await recoverIfLocked(errorMessage)) return
+      log.error('Transaction signing failed', err)
       setError(errorMessage)
       await storeErrorResult(errorMessage)
     } finally {

--- a/packages/shared/src/types/messages.ts
+++ b/packages/shared/src/types/messages.ts
@@ -85,6 +85,17 @@ export enum KeeperMessageTypes {
   LOCALNET_SIGN = 'KEEPER_LOCALNET_SIGN',
 }
 
+/**
+ * Returned by the keeper when a sign request arrives after the unlock window
+ * expired. Recoverable: re-unlocking and re-approving the same request succeeds,
+ * so the popup should catch this rather than surface it to the dApp.
+ */
+export const KEEPER_EPH_SIGN_LOCKED_ERROR = `[${KeeperMessageTypes.EPH_SIGN}] LOCKED`
+
+/** True when an error message is the keeper's recoverable locked-vault signal. */
+export const isKeeperLockedError = (message: unknown): boolean =>
+  typeof message === 'string' && message.includes(KEEPER_EPH_SIGN_LOCKED_ERROR)
+
 // Response type for vault/keeper message handlers
 export interface VaultResponse {
   ok?: boolean


### PR DESCRIPTION
fixes #148

When the vault auto-locks while a dApp is waiting to sign, the signing popup sometimes opens on the **Approve** screen instead of the PIN screen. Pressing Approve then fails with the raw `[KEEPER_EPH_SIGN] LOCKED` error, and the pending request cannot resume after unlocking; the dApp has to re-request.

## Root cause
The popup chooses between the lock and approval views from the UI store's persisted `isLocked` flag. On the extension that flag is corrected against the keeper's authoritative unlock expiry **asynchronously and fire-and-forget** after rehydration (`refreshVaultLockState`). So the popup's first render can still read `isLocked === false` while the keeper has already expired — a timing race. Whichever wins decides whether you see the PIN screen (works) or Approve (fails with the raw keeper error). Sign popups are also standalone entrypoints that never armed `useVaultAutoLock`, so a keeper expiring while the approval screen sat open was never caught either.

## Fix

Three layers:

1. **Confirm the authoritative lock state before enabling Approve.** `useSignPopupAuth` now queries the keeper's remaining unlock time on mount, locks immediately if expired, and exposes a `lockChecked` flag; `SignRequestView` keeps Approve disabled until that check resolves. It also arms `useVaultAutoLock` so a keeper that expires while the popup is open flips it to the PIN screen.

2. **Recover in-place instead of failing the dApp.** If a sign attempt still races the expiry, `recoverIfLocked` transitions the popup to the lock screen and keeps the request pending — no raw error is written back. After unlocking, the same pending request continues to approval.

3. **Share the error string** between the keeper (producer) and the popup (detector) via `KEEPER_EPH_SIGN_LOCKED_ERROR` / `isKeeperLockedError`, so they can't drift.