### PR TITLE
fix: bind nonce to rotating ephkey

### DIFF
--- a/apps/extension/src/lib/adapters/SuiWallet/__tests__/index.test.ts
+++ b/apps/extension/src/lib/adapters/SuiWallet/__tests__/index.test.ts
@@ -238,7 +238,7 @@ describe('EveVaultWallet', () => {
         },
       }),
     )
-    // The genuine same-window response still settles the connect.
+    // Same-window response still settles the connect.
     dispatchVaultMessage({
       type: 'auth_success',
       chain: SUI_LOCALNET_CHAIN,

--- a/packages/shared/src/stores/__tests__/deviceStore.proofActions.test.ts
+++ b/packages/shared/src/stores/__tests__/deviceStore.proofActions.test.ts
@@ -1,4 +1,5 @@
 import { Ed25519PublicKey } from '@mysten/sui/keypairs/ed25519'
+import { generateNonce } from '@mysten/sui/zklogin'
 import { SUI_DEVNET_CHAIN } from '@mysten/wallet-standard'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createProofActions } from '#/stores/deviceStore/actions/proofActions'
@@ -64,6 +65,11 @@ function stubAsync() {
   return Promise.resolve()
 }
 
+// Randomness must be a BigInt-convertible string for generateNonce.
+const DEVICE_PK = new Ed25519PublicKey(new Uint8Array(32).fill(4))
+const DEVICE_RANDOMNESS = '1234567890'
+const DEVICE_NONCE = generateNonce(DEVICE_PK, 10, DEVICE_RANDOMNESS)
+
 function buildProofHarness(overrides: Partial<DeviceState> = {}) {
   let state: DeviceState
 
@@ -76,7 +82,7 @@ function buildProofHarness(overrides: Partial<DeviceState> = {}) {
 
   const { getZkProof } = createProofActions(set, get)
 
-  const pk = new Ed25519PublicKey(new Uint8Array(32).fill(4))
+  const pk = DEVICE_PK
 
   state = {
     isLocked: false,
@@ -86,10 +92,10 @@ function buildProofHarness(overrides: Partial<DeviceState> = {}) {
     ephemeralKeyPairSecretKey: null,
     networkData: {
       [SUI_DEVNET_CHAIN]: {
-        nonce: 'nonce-1',
+        nonce: DEVICE_NONCE,
         maxEpoch: '10',
         maxEpochTimestampMs: Date.now() + 60_000,
-        jwtRandomness: 'random',
+        jwtRandomness: DEVICE_RANDOMNESS,
       },
     },
     loading: false,
@@ -238,7 +244,7 @@ describe('createProofActions.getZkProof', () => {
     expect(fetchZkProofMock).toHaveBeenCalledWith(
       expect.objectContaining({
         idToken: 'vended.id.token',
-        jwtRandomness: 'random',
+        jwtRandomness: DEVICE_RANDOMNESS,
         maxEpoch: '10',
       }),
     )
@@ -268,6 +274,45 @@ describe('createProofActions.getZkProof', () => {
           maxEpoch: '10',
           maxEpochTimestampMs: Date.now() - 1_000,
           jwtRandomness: 'old-random',
+        },
+      },
+    })
+
+    await getZkProof(SUI_DEVNET_CHAIN)
+
+    expect(rotateEphemeralKey).toHaveBeenCalledOnce()
+    expect(resolveVendedMock).toHaveBeenCalledWith(
+      SUI_DEVNET_CHAIN,
+      expect.anything(),
+      'rotated-nonce',
+      expect.any(Number),
+    )
+    expect(fetchZkProofMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jwtRandomness: 'rotated-random',
+        maxEpoch: '22',
+      }),
+    )
+  })
+
+  it('rotates the eph key when the stored nonce does not match the current key', async () => {
+    const rotateEphemeralKey = vi.fn().mockImplementation(async () => {
+      state.networkData[SUI_DEVNET_CHAIN] = {
+        nonce: 'rotated-nonce',
+        maxEpoch: '22',
+        maxEpochTimestampMs: Date.now() + 60_000,
+        jwtRandomness: 'rotated-random',
+      }
+    })
+    // Recompute guard detects drift between epoch and stored nonce and rotates.
+    const { getZkProof, state } = buildProofHarness({
+      rotateEphemeralKey,
+      networkData: {
+        [SUI_DEVNET_CHAIN]: {
+          nonce: 'nonce-from-a-rotated-away-keypair',
+          maxEpoch: '10',
+          maxEpochTimestampMs: Date.now() + 60_000,
+          jwtRandomness: DEVICE_RANDOMNESS,
         },
       },
     })

--- a/packages/shared/src/stores/__tests__/deviceStore.proofActions.test.ts
+++ b/packages/shared/src/stores/__tests__/deviceStore.proofActions.test.ts
@@ -296,15 +296,21 @@ describe('createProofActions.getZkProof', () => {
   })
 
   it('rotates the eph key when the stored nonce does not match the current key', async () => {
+    // Rotation swaps the ephemeral key and regenerates the nonce from it.
+    const rotatedPk = new Ed25519PublicKey(new Uint8Array(32).fill(7))
+    const rotatedRandomness = '9876543210'
+    const rotatedNonce = generateNonce(rotatedPk, 22, rotatedRandomness)
     const rotateEphemeralKey = vi.fn().mockImplementation(async () => {
+      state.ephemeralPublicKey = rotatedPk
       state.networkData[SUI_DEVNET_CHAIN] = {
-        nonce: 'rotated-nonce',
+        nonce: rotatedNonce,
         maxEpoch: '22',
         maxEpochTimestampMs: Date.now() + 60_000,
-        jwtRandomness: 'rotated-random',
+        jwtRandomness: rotatedRandomness,
       }
     })
-    // Recompute guard detects drift between epoch and stored nonce and rotates.
+    // Stored nonce is bound to a previously-rotated keypair; the recompute guard detects
+    // the drift against the current key and rotates even though the epoch is valid.
     const { getZkProof, state } = buildProofHarness({
       rotateEphemeralKey,
       networkData: {
@@ -323,13 +329,14 @@ describe('createProofActions.getZkProof', () => {
     expect(resolveVendedMock).toHaveBeenCalledWith(
       SUI_DEVNET_CHAIN,
       expect.anything(),
-      'rotated-nonce',
+      rotatedNonce,
       expect.any(Number),
     )
     expect(fetchZkProofMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        jwtRandomness: 'rotated-random',
+        jwtRandomness: rotatedRandomness,
         maxEpoch: '22',
+        ephemeralPublicKey: rotatedPk,
       }),
     )
   })

--- a/packages/shared/src/stores/__tests__/deviceStore.zkjwt.test.ts
+++ b/packages/shared/src/stores/__tests__/deviceStore.zkjwt.test.ts
@@ -1,4 +1,5 @@
 import { Ed25519PublicKey } from '@mysten/sui/keypairs/ed25519'
+import { generateNonce } from '@mysten/sui/zklogin'
 import { SUI_DEVNET_CHAIN } from '@mysten/wallet-standard'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useContextStore } from '#/stores/contextStore'
@@ -62,11 +63,16 @@ vi.mock('#/auth/verifyJwt', () => ({
 import { useDeviceStore } from '#/stores/deviceStore'
 import { makeJwtWithExp } from '#/testing'
 
+const devicePublicKey = new Ed25519PublicKey(new Uint8Array(32).fill(1))
+// Randomness must be a BigInt-convertible string for generateNonce.
+const deviceRandomness = '987654321'
+const deviceNonce = generateNonce(devicePublicKey, 123, deviceRandomness)
+
 describe('deviceStore.getZkProof with expired stored zkLogin JWT', () => {
   beforeEach(() => {
     useContextStore.setState({ chain: SUI_DEVNET_CHAIN })
 
-    const publicKey = new Ed25519PublicKey(new Uint8Array(32).fill(1))
+    const publicKey = devicePublicKey
     useDeviceStore.setState({
       isLocked: false,
       ephemeralPublicKey: publicKey,
@@ -74,10 +80,10 @@ describe('deviceStore.getZkProof with expired stored zkLogin JWT', () => {
       ephemeralPublicKeyFlag: publicKey.flag(),
       networkData: {
         [SUI_DEVNET_CHAIN]: {
-          nonce: 'device-nonce',
+          nonce: deviceNonce,
           maxEpoch: '123',
           maxEpochTimestampMs: Date.now() + 60_000,
-          jwtRandomness: 'randomness',
+          jwtRandomness: deviceRandomness,
         },
       },
       error: null,
@@ -120,7 +126,7 @@ describe('deviceStore.getZkProof with expired stored zkLogin JWT', () => {
 
     expect(vendJwtMock).toHaveBeenCalledOnce()
     expect(vendJwtMock).toHaveBeenCalledWith('primary.jwt.token', {
-      nonce: 'device-nonce',
+      nonce: deviceNonce,
     })
 
     const freshToken = vendJwtMock.mock.results[0]?.value

--- a/packages/shared/src/stores/deviceStore/actions/initChainHelpers.ts
+++ b/packages/shared/src/stores/deviceStore/actions/initChainHelpers.ts
@@ -1,3 +1,4 @@
+import type { PublicKey } from '@mysten/sui/cryptography'
 import { generateNonce, generateRandomness } from '@mysten/sui/zklogin'
 import type { SuiChain } from '@mysten/wallet-standard'
 import { clearAllZkLoginJwts } from '#/auth/storageService'
@@ -18,6 +19,8 @@ import type { GetDeviceState, SetDeviceState } from './types'
 
 const log = createLogger()
 
+type EpochData = Awaited<ReturnType<typeof getCurrentEpochFromGraphQL>>
+
 const NULL_EPOCH = { maxEpoch: null, maxEpochTimestampMs: null } as const
 
 export const initializeForChainData = async (
@@ -35,18 +38,41 @@ export const initializeForChainData = async (
   await initializeZkLoginChainData(chain, set, get)
 }
 
-/** Clears JWTs and cached ZK proofs before rotating so stale proofs tied to the old key can't be reused. */
+/**
+ * Rotates the ephemeral key and regenerates the current chain's nonce, so
+ * the store never persists a nonce bound to a superseded key.
+ *
+ * Epoch fetch runs before keeper rotate, so a network failure aborts
+ * with the old key + old nonce still mutually consistent. After rotation,
+ * nonce derivation is synchronous — no await between the new key and nonce
+ * that might introduce drift.
+ *
+ * Clears JWTs and cached ZK proofs first so stale proofs tied to the old key can't
+ * be reused.
+ */
 export const rotateEphemeralKeyForChain = async (
   currentChain: SuiChain,
   set: SetDeviceState,
   get: GetDeviceState,
 ) => {
   log.info('Rotating ephemeral key', { currentChain })
+
+  const epoch = isZkLoginSuiChain(currentChain)
+    ? await getCurrentEpochFromGraphQL(currentChain)
+    : null
+
   await clearDerivedZkLoginState()
 
   const { ephKeyService } = await import('#/services/vaultService')
   const { hashedSecretKey, publicKey } =
     await ephKeyService.rotateEphemeralKeyPair()
+
+  const networkData = epoch
+    ? {
+        ...createInitialNetworkData(),
+        [currentChain]: buildNonceEntry(publicKey, epoch),
+      }
+    : createInitialNetworkData()
 
   set({
     ephemeralPublicKey: publicKey,
@@ -55,12 +81,16 @@ export const rotateEphemeralKeyForChain = async (
     ephemeralKeyPairSecretKey: isWeb()
       ? createWebCryptoPlaceholder()
       : hashedSecretKey,
-    networkData: createInitialNetworkData(),
+    networkData,
     error: null,
     isLocked: false,
   })
 
-  await get().initializeForChain(currentChain)
+  // Localnet epoch lives on state.localnet, not networkData, and has no nonce to
+  // bind; refresh it separately after the atomic zkLogin commit.
+  if (isLocalnetChain(currentChain)) {
+    await get().initializeForChain(currentChain)
+  }
 }
 
 /** Guards against redundant network calls when the chain was already initialized (e.g. after rehydration). */
@@ -121,17 +151,31 @@ const initializeZkLoginChainData = async (
     throw new Error('Ephemeral public key not found')
   }
 
-  const jwtRandomness = generateRandomness().toString()
-  const { numericMaxEpoch, maxEpochTimestampMs } =
-    await getCurrentEpochFromGraphQL(chain)
-  const nonce = generateNonce(ephemeralPubkey, numericMaxEpoch, jwtRandomness)
+  const epoch = await getCurrentEpochFromGraphQL(chain)
+  setChainData(set, get, chain, buildNonceEntry(ephemeralPubkey, epoch))
+}
 
-  setChainData(set, get, chain, {
-    maxEpoch: numericMaxEpoch.toString(),
-    maxEpochTimestampMs,
+/**
+ * Derives network data entry with nonce from a specific key + epoch. Synchronous
+ * so callers can compute it before committing, keeping the nonce and the key
+ * in a single atomic write.
+ */
+const buildNonceEntry = (
+  ephemeralPubkey: PublicKey,
+  epoch: EpochData,
+): NetworkDataEntry => {
+  const jwtRandomness = generateRandomness().toString()
+  const nonce = generateNonce(
+    ephemeralPubkey,
+    epoch.numericMaxEpoch,
+    jwtRandomness,
+  )
+  return {
+    maxEpoch: epoch.numericMaxEpoch.toString(),
+    maxEpochTimestampMs: epoch.maxEpochTimestampMs,
     nonce,
     jwtRandomness,
-  })
+  }
 }
 
 const setLocalnetEpochData = (

--- a/packages/shared/src/stores/deviceStore/actions/proofHelpers.ts
+++ b/packages/shared/src/stores/deviceStore/actions/proofHelpers.ts
@@ -1,3 +1,4 @@
+import { generateNonce } from '@mysten/sui/zklogin'
 import type { SuiChain } from '@mysten/wallet-standard'
 import { useAuthStore } from '#/auth'
 import { getJwt } from '#/auth/storageService'
@@ -123,15 +124,50 @@ const ensureProofNonce = async (
   get: GetDeviceState,
 ): Promise<string> => {
   const nonce = get().getNonce(chain)
-  if (nonce && !isEpochExpired(chain, get)) {
+  if (
+    nonce &&
+    !isEpochExpired(chain, get) &&
+    isNonceBoundToCurrentKey(chain, get, nonce)
+  ) {
     return nonce
   }
 
-  log.info('Device nonce missing or epoch expired; rotating ephemeral key', {
-    chain,
-  })
+  log.info(
+    'Device nonce missing, epoch expired, or bound to a stale ephemeral key; rotating ephemeral key',
+    { chain },
+  )
   await get().rotateEphemeralKey(chain)
   return requireNonceAfterRotation(chain, network, get)
+}
+
+/**
+ * Recomputes the nonce from the current ephemeral key, epoch, and randomness and
+ * compares it to the stored nonce. The ephemeral key lives in a different store
+ * than the per-chain nonce, so a key rotation elsewhere can leave the stored nonce
+ * bound to a stale key; this catches that mismatch before Enoki rejects it as
+ * incorrect_nonce.
+ */
+const isNonceBoundToCurrentKey = (
+  chain: SuiChain,
+  get: GetDeviceState,
+  nonce: string,
+): boolean => {
+  const ephemeralPublicKey = get().ephemeralPublicKey
+  const maxEpoch = get().getMaxEpoch(chain)
+  const jwtRandomness = get().getJwtRandomness(chain)
+  if (!ephemeralPublicKey || !maxEpoch || !jwtRandomness) {
+    return false
+  }
+  try {
+    return (
+      generateNonce(ephemeralPublicKey, Number(maxEpoch), jwtRandomness) ===
+      nonce
+    )
+  } catch {
+    // Malformed stored epoch/randomness can't recompute; treat as unbound so the
+    // caller rotates and regenerates from scratch.
+    return false
+  }
 }
 
 const requireNonceAfterRotation = (


### PR DESCRIPTION
fixes #126

zkLogin proof requests fail with Enoki `status 400: incorrect_nonce`. The `nonce`/`maxEpoch`/`jwtRandomness` triple is stored **per-chain** in `networkData`, but `ephemeralPublicKey` is a **global** field sourced from the keeper. Those can drift out of sync, leaving a stored nonce bound to a key the request no longer carries. `ensureProofNonce` only regenerated on *missing* or *epoch-expired* nonces, so a stale-but-unexpired nonce sailed straight through to a hard 400.

The keeper's unlock is deterministic decryption. Drift comes from the key and the nonce being written **non-atomically**: `rotateEphemeralKeyForChain` committed the new key with a blanked nonce, then `await`ed a second step (with a network call) to fill the nonce in. An interruption in that window persisted a new key with no/stale matching nonce.

### Changes on the branch

**1. Detection backstop — `proofHelpers.ts`**
`ensureProofNonce` now recomputes `generateNonce(currentKey, storedEpoch, storedRandomness)` and compares it to the stored nonce (`isNonceBoundToCurrentKey`). On mismatch it takes the existing rotate-and-regenerate path instead of sending a doomed request — the same check the backend does, moved client-side so drift self-heals. Wrapped in try/catch so malformed stored epoch/randomness also rotate rather than throw.

**2. Test fidelity — `deviceStore.proofActions.test.ts`**
The drift test now models rotation: the stub swaps `ephemeralPublicKey` to a new key and derives the nonce from it, assertions confirm the rotated key/nonce/randomness actually reach `resolveVendedIdTokenForZkProof` and `fetchZkProof` (including `ephemeralPublicKey`) — closing the gap where the test could pass with a mismatched key.

**3. Root-cause fix — atomic rotation in `initChainHelpers.ts`**
`rotateEphemeralKeyForChain` is now compute-then-commit: fetch the epoch *before* the irreversible keeper rotate, derive the nonce from the freshly-rotated key synchronously, and commit key + matching nonce in a **single `set()`**. The store can no longer persist a nonce bound to a superseded key. Extracted a pure `buildNonceEntry` helper reused by the normal init path.