### PR TITLE
chore: use wallet-core coin cache

### DIFF
--- a/apps/extension/src/features/wallet/hooks/__tests__/useTransactionSimulation.test.ts
+++ b/apps/extension/src/features/wallet/hooks/__tests__/useTransactionSimulation.test.ts
@@ -7,14 +7,21 @@ const {
   mockSimulateTransactionOutcome,
   mockClassifyBuildFailure,
   mockCreateSuiGraphQLClient,
-  mockFetchCoinMetadata,
-} = vi.hoisted(() => ({
-  mockBuildTransactionBytes: vi.fn(),
-  mockSimulateTransactionOutcome: vi.fn(),
-  mockClassifyBuildFailure: vi.fn(),
-  mockCreateSuiGraphQLClient: vi.fn(() => ({})),
-  mockFetchCoinMetadata: vi.fn(),
-}))
+  mockCoinMetadataResolve,
+  mockCreateGraphQLCoinMetadataResolver,
+} = vi.hoisted(() => {
+  const mockCoinMetadataResolve = vi.fn()
+  return {
+    mockBuildTransactionBytes: vi.fn(),
+    mockSimulateTransactionOutcome: vi.fn(),
+    mockClassifyBuildFailure: vi.fn(),
+    mockCreateSuiGraphQLClient: vi.fn(() => ({})),
+    mockCoinMetadataResolve,
+    mockCreateGraphQLCoinMetadataResolver: vi.fn(() => ({
+      resolve: mockCoinMetadataResolve,
+    })),
+  }
+})
 
 vi.mock('@evefrontier/wallet-core/crypto', () => ({
   buildTransactionBytes: mockBuildTransactionBytes,
@@ -31,7 +38,7 @@ vi.mock('@evevault/shared/sui', () => ({
 vi.mock('@evevault/shared/wallet', () => ({
   simulateTransactionOutcome: mockSimulateTransactionOutcome,
   classifyBuildFailure: mockClassifyBuildFailure,
-  fetchCoinMetadata: mockFetchCoinMetadata,
+  createGraphQLCoinMetadataResolver: mockCreateGraphQLCoinMetadataResolver,
 }))
 
 vi.mock('@evevault/shared/utils', async (importOriginal) => {
@@ -80,6 +87,9 @@ function makeParams(overrides: Record<string, unknown> = {}) {
 beforeEach(() => {
   vi.resetAllMocks()
   mockCreateSuiGraphQLClient.mockReturnValue({})
+  mockCreateGraphQLCoinMetadataResolver.mockReturnValue({
+    resolve: mockCoinMetadataResolve,
+  })
 })
 
 describe('useTransactionSimulation', () => {
@@ -171,7 +181,7 @@ describe('useTransactionSimulation', () => {
     )
   })
 
-  it('maps cached GraphQL metadata through resolveCoinMetadata, falling back to null when absent', async () => {
+  it('delegates resolveCoinMetadata to the per-network cached resolver', async () => {
     mockBuildTransactionBytes.mockResolvedValue(new Uint8Array([1]))
     mockSimulateTransactionOutcome.mockResolvedValue(SUCCESS_SIMULATION)
 
@@ -186,32 +196,24 @@ describe('useTransactionSimulation', () => {
       }),
     )
 
+    // Resolver built once from the network's GraphQL client.
+    expect(mockCreateGraphQLCoinMetadataResolver).toHaveBeenCalledTimes(1)
+
     const { resolveCoinMetadata } =
       mockSimulateTransactionOutcome.mock.calls[0][0]
 
-    mockFetchCoinMetadata.mockResolvedValueOnce({
+    const metadata = {
       decimals: 6,
       symbol: 'USDC',
       name: 'USD Coin',
-    })
-    expect(await resolveCoinMetadata('0x2::usdc::USDC')).toEqual({
-      decimals: 6,
-      symbol: 'USDC',
-      name: 'USD Coin',
-    })
+      description: 'USD Coin',
+      iconUrl: 'https://x',
+    }
+    mockCoinMetadataResolve.mockResolvedValueOnce(metadata)
+    expect(await resolveCoinMetadata('0x2::usdc::USDC')).toBe(metadata)
+    expect(mockCoinMetadataResolve).toHaveBeenCalledWith('0x2::usdc::USDC')
 
-    mockFetchCoinMetadata.mockResolvedValueOnce({
-      decimals: 9,
-      symbol: 'EVE',
-      name: null,
-    })
-    expect(await resolveCoinMetadata('0x2::eve::EVE')).toEqual({
-      decimals: 9,
-      symbol: 'EVE',
-      name: undefined,
-    })
-
-    mockFetchCoinMetadata.mockResolvedValueOnce(null)
+    mockCoinMetadataResolve.mockResolvedValueOnce(null)
     expect(await resolveCoinMetadata('0x2::unknown::UNKNOWN')).toBeNull()
   })
 

--- a/apps/extension/src/features/wallet/hooks/useTransactionSimulation.ts
+++ b/apps/extension/src/features/wallet/hooks/useTransactionSimulation.ts
@@ -3,7 +3,7 @@ import { createSuiGraphQLClient } from '@evevault/shared/sui'
 import { createLogger } from '@evevault/shared/utils'
 import {
   classifyBuildFailure,
-  fetchCoinMetadata,
+  createGraphQLCoinMetadataResolver,
   simulateTransactionOutcome,
   type TransactionSimulation,
 } from '@evevault/shared/wallet'
@@ -11,7 +11,7 @@ import type { SuiGrpcClient } from '@mysten/sui/grpc'
 import { Transaction } from '@mysten/sui/transactions'
 import { fromBase64 } from '@mysten/sui/utils'
 import type { SuiChain } from '@mysten/wallet-standard'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 const log = createLogger()
 
@@ -65,6 +65,12 @@ export function useTransactionSimulation({
   const [state, setState] = useState<SimulationState | null>(null)
   const runIdRef = useRef(0)
 
+  // One resolver per network, holding the metadata cache across simulation runs.
+  const coinMetadataResolver = useMemo(
+    () => createGraphQLCoinMetadataResolver(createSuiGraphQLClient(chain)),
+    [chain],
+  )
+
   useEffect(() => {
     if (!payload) {
       setState(null)
@@ -81,23 +87,14 @@ export function useTransactionSimulation({
           throw new Error('No sender address available')
         }
         const bytes = await resolveBytes(mode, payload, sender, suiClient)
-        const graphqlClient = createSuiGraphQLClient(chain)
         const simulation = await simulateTransactionOutcome({
           transactionBytes: bytes,
           sender,
           suiClient,
           // Inject evevault's cached GraphQL metadata source; wallet-core falls
           // back to 9 decimals + coin-type-derived symbol when this returns null.
-          resolveCoinMetadata: async (coinType) => {
-            const metadata = await fetchCoinMetadata(graphqlClient, coinType)
-            return metadata
-              ? {
-                  decimals: metadata.decimals,
-                  symbol: metadata.symbol,
-                  name: metadata.name ?? undefined,
-                }
-              : null
-          },
+          resolveCoinMetadata: (coinType) =>
+            coinMetadataResolver.resolve(coinType),
         })
         if (runId === runIdRef.current) {
           setState({ status: 'ready', simulation })
@@ -123,7 +120,14 @@ export function useTransactionSimulation({
     return () => {
       runIdRef.current++
     }
-  }, [payload, mode, suiClient, chain, getSenderAddress, fallbackSender])
+  }, [
+    payload,
+    mode,
+    suiClient,
+    coinMetadataResolver,
+    getSenderAddress,
+    fallbackSender,
+  ])
 
   return state
 }

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "eve-frontier-vault",
       "dependencies": {
-        "@evefrontier/wallet-core": "0.0.10",
+        "@evefrontier/wallet-core": "0.0.11",
         "@mysten/sui": "^2.23.1",
         "@mysten/wallet-standard": "^0.20.3",
         "jose": "6.0.12",
@@ -33,7 +33,7 @@
     },
     "apps/extension": {
       "name": "@evevault/extension",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "dependencies": {
         "@evevault/shared": "workspace:*",
         "@mysten/sui": "^2.17.0",
@@ -56,7 +56,7 @@
     },
     "apps/web": {
       "name": "@evevault/web",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "dependencies": {
         "@evevault/shared": "workspace:*",
         "@tanstack/react-query": "^5.100.9",
@@ -81,7 +81,7 @@
     },
     "packages/shared": {
       "name": "@evevault/shared",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "dependencies": {
         "@mysten/signers": "^1.0.5",
         "@wxt-dev/browser": "0.2.5",
@@ -449,7 +449,7 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
-    "@evefrontier/wallet-core": ["@evefrontier/wallet-core@0.0.10", "https://npm.pkg.github.com/download/@evefrontier/wallet-core/0.0.10/24446f2898d1b623368a284fc79905b8bec65493", { "dependencies": { "@mysten/sui": "^2.23.1", "@mysten/wallet-standard": "^0.20.3", "@mysten/webcrypto-signer": "^0.1.2", "@scure/bip39": "^2.2.0" }, "peerDependencies": { "@ledgerhq/hw-transport-webhid": "^6.0.0", "@mysten/ledgerjs-hw-app-sui": "^0.9.1", "@mysten/signers": "^1.1.18" } }, "sha512-Asihtzgn0VPnO2g3Jmh1xx2tKROK5GSl2Cx3G2i5EBqDd/HC9/7M1mb2PR7xk5xTEcP/buwvM4j1vlHv+3Ovhg=="],
+    "@evefrontier/wallet-core": ["@evefrontier/wallet-core@0.0.11", "https://npm.pkg.github.com/download/@evefrontier/wallet-core/0.0.11/30cdae23326e2ac05e3b638f0b62cb740703e6e0", { "dependencies": { "@mysten/sui": "^2.23.1", "@mysten/wallet-standard": "^0.20.3", "@mysten/webcrypto-signer": "^0.1.2", "@scure/bip39": "^2.2.0" }, "peerDependencies": { "@ledgerhq/hw-transport-webhid": "^6.0.0", "@mysten/ledgerjs-hw-app-sui": "^0.9.1", "@mysten/signers": "^1.1.18" } }, "sha512-HPPynQarGLB3g1DwOqmt8TOuYSv/NJjcBvEEVbEfgOe9VCx0r+mWyTNrL59ouqWfoUBe3WKJT56VMSENz/vpPA=="],
 
     "@evevault/extension": ["@evevault/extension@workspace:apps/extension"],
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     ]
   },
   "dependencies": {
-    "@evefrontier/wallet-core": "0.0.10",
+    "@evefrontier/wallet-core": "0.0.11",
     "@mysten/sui": "^2.23.1",
     "@mysten/wallet-standard": "^0.20.3",
     "jose": "6.0.12",

--- a/packages/shared/src/wallet/index.ts
+++ b/packages/shared/src/wallet/index.ts
@@ -6,8 +6,10 @@ export {
   type AddressAliasesInfo,
 } from '@evefrontier/wallet-core/address-alias'
 export {
+  CachedCoinMetadataResolver,
   classifyBuildFailure,
   type ObjectChangeKind,
+  type ResolvedCoinMetadata,
   type SimulatedBalanceChange,
   type SimulatedEvent,
   type SimulatedGas,
@@ -38,12 +40,10 @@ export {
   TransactionFailedError,
 } from './signAndExecute'
 export { signForChain } from './signForChain'
-export type {
-  CoinMetadataQueryResponse,
-  CoinMetadataResult,
-} from './types/coinMetadata'
+export type { CoinMetadataQueryResponse } from './types/coinMetadata'
 export type { BalanceAndMetadataResponse } from './types/graphql'
 export {
+  createGraphQLCoinMetadataResolver,
   fetchCoinMetadata,
   invalidateCoinMetadataCache,
 } from './utils/coinMetadata'

--- a/packages/shared/src/wallet/types/coinMetadata.ts
+++ b/packages/shared/src/wallet/types/coinMetadata.ts
@@ -7,11 +7,3 @@ export interface CoinMetadataQueryResponse {
     iconUrl: string | null
   } | null
 }
-
-export interface CoinMetadataResult {
-  decimals: number
-  symbol: string
-  name?: string | null
-  description?: string | null
-  iconUrl?: string | null
-}

--- a/packages/shared/src/wallet/utils/coinMetadata.ts
+++ b/packages/shared/src/wallet/utils/coinMetadata.ts
@@ -1,16 +1,12 @@
+import {
+  CachedCoinMetadataResolver,
+  type ResolvedCoinMetadata,
+} from '@evefrontier/wallet-core/transaction'
 import type { SuiGraphQLClient } from '@mysten/sui/graphql'
-import { isSuiCoinType } from '#/utils'
 import { createLogger } from '#/utils/logger'
-import type {
-  CoinMetadataQueryResponse,
-  CoinMetadataResult,
-} from '#/wallet/types/coinMetadata'
-import type { CacheEntry } from '#/wallet/types/hooks'
+import type { CoinMetadataQueryResponse } from '#/wallet/types/coinMetadata'
 
 const log = createLogger()
-const CACHE_TTL_MS = 30 * 60 * 1000 // 30 minutes cache expiry
-
-const coinMetadataCache = new Map<string, CacheEntry<CoinMetadataResult>>()
 
 const COIN_METADATA_QUERY = `
   query CoinMetadata($coinType: String!) {
@@ -24,70 +20,56 @@ const COIN_METADATA_QUERY = `
   }
 `
 
+// One resolver per GraphQL client, so each client reuses its metadata cache.
+const resolvers = new Map<SuiGraphQLClient, CachedCoinMetadataResolver>()
+
 /**
- * Manually invalidate cache for a specific coin type or clear entire cache
+ * Builds a cached resolver backed by evevault's GraphQL metadata source. Create
+ * it once per GraphQL client or wallet session; a fresh resolver starts empty.
+ */
+export function createGraphQLCoinMetadataResolver(
+  graphqlClient: SuiGraphQLClient,
+): CachedCoinMetadataResolver {
+  return new CachedCoinMetadataResolver((coinType) =>
+    queryCoinMetadata(graphqlClient, coinType),
+  )
+}
+
+const getResolver = (
+  graphqlClient: SuiGraphQLClient,
+): CachedCoinMetadataResolver => {
+  let resolver = resolvers.get(graphqlClient)
+  if (!resolver) {
+    resolver = createGraphQLCoinMetadataResolver(graphqlClient)
+    resolvers.set(graphqlClient, resolver)
+  }
+  return resolver
+}
+
+/**
+ * Manually invalidate cache for a specific coin type or clear entire cache.
  */
 export function invalidateCoinMetadataCache(coinType?: string): void {
-  if (coinType) {
-    coinMetadataCache.delete(coinType)
-  } else {
-    coinMetadataCache.clear()
+  for (const resolver of resolvers.values()) {
+    resolver.clearCache(coinType)
   }
 }
 
 /**
- * Fetches coin metadata for a given coin type via Sui GraphQL RPC (Beta).
+ * Fetches coin metadata for a given coin type through the shared per-client
+ * cached resolver.
  */
 export async function fetchCoinMetadata(
   graphqlClient: SuiGraphQLClient,
   coinType: string,
-): Promise<CoinMetadataResult | null> {
-  try {
-    const metadata =
-      getCachedCoinMetadata(coinType) ??
-      getKnownCoinMetadata(coinType) ??
-      (await queryCoinMetadata(graphqlClient, coinType))
-
-    cacheCoinMetadata(coinType, metadata)
-    return metadata
-  } catch (error) {
-    log.error('Failed to fetch coin metadata', { coinType, error })
-    return null
-  }
-}
-
-const getCachedCoinMetadata = (coinType: string): CoinMetadataResult | null => {
-  const cached = coinMetadataCache.get(coinType)
-  const isFresh = cached && Date.now() - cached.timestamp < CACHE_TTL_MS
-
-  if (!cached) {
-    return null
-  }
-
-  if (!isFresh) {
-    coinMetadataCache.delete(coinType)
-    return null
-  }
-
-  return cached.data as CoinMetadataResult
-}
-
-const getKnownCoinMetadata = (coinType: string): CoinMetadataResult | null => {
-  return isSuiCoinType(coinType)
-    ? {
-        decimals: 9,
-        symbol: 'SUI',
-        name: 'Sui',
-        description: 'Sui Native Token',
-        iconUrl: null,
-      }
-    : null
+): Promise<ResolvedCoinMetadata | null> {
+  return getResolver(graphqlClient).resolve(coinType)
 }
 
 const queryCoinMetadata = async (
   graphqlClient: SuiGraphQLClient,
   coinType: string,
-): Promise<CoinMetadataResult | null> => {
+): Promise<ResolvedCoinMetadata | null> => {
   const result = await graphqlClient.query<CoinMetadataQueryResponse>({
     query: COIN_METADATA_QUERY,
     variables: { coinType },
@@ -107,7 +89,7 @@ const queryCoinMetadata = async (
 const normalizeCoinMetadataNode = (
   node: CoinMetadataQueryResponse['coinMetadata'] | undefined,
   coinType: string,
-): CoinMetadataResult | null => {
+): ResolvedCoinMetadata | null => {
   if (!node || node.decimals == null || node.symbol == null) {
     log.warn('No metadata found for coin type', { coinType })
     return null
@@ -119,14 +101,5 @@ const normalizeCoinMetadataNode = (
     name: node.name ?? undefined,
     description: node.description ?? undefined,
     iconUrl: node.iconUrl ?? undefined,
-  }
-}
-
-const cacheCoinMetadata = (
-  coinType: string,
-  metadata: CoinMetadataResult | null,
-) => {
-  if (metadata) {
-    coinMetadataCache.set(coinType, { data: metadata, timestamp: Date.now() })
   }
 }


### PR DESCRIPTION
Upgrades `@evefrontier/wallet-core` to `0.0.11` and moves coin-metadata caching out of evevault into wallet-core's `CachedCoinMetadataResolver`. wallet-core now owns the cache, its 30-minute TTL, and the known-coin (SUI/EVE) shortcuts; evevault supplies only the GraphQL lookup.

### Changes
- **`packages/shared/.../utils/coinMetadata.ts`** — removed the local `Map` cache, TTL constant, and SUI-only known-coin handling. Added `createGraphQLCoinMetadataResolver(graphqlClient)`, which wraps evevault's GraphQL query as the resolver's lookup. `fetchCoinMetadata`/`invalidateCoinMetadataCache` are retained (used by transaction-history parsing) and now delegate to one resolver per GraphQL client.
- **`apps/extension/.../useTransactionSimulation.ts`** — builds the resolver once per network via `useMemo(chain)` and passes `resolver.resolve` straight into `simulateTransactionOutcome`, instead of constructing an inline metadata mapper on every run. `description`/`iconUrl` now flow through to simulated balance changes.
- **Types/exports** — deleted the now-redundant `CoinMetadataResult` interface (replaced by wallet-core's `ResolvedCoinMetadata`); exported `createGraphQLCoinMetadataResolver`, `CachedCoinMetadataResolver`, and `ResolvedCoinMetadata`.

### Behavior change
The previous local cache was keyed by coin type across all networks. Caches are now isolated per GraphQL client (per network), so the same coin type on different networks no longer shares an entry — more correct, since metadata can differ across networks.