### PR TITLE
feat: guard address alias calls from dapps

### DIFF
--- a/apps/extension/src/features/wallet/__tests__/aliasCallGuard.test.ts
+++ b/apps/extension/src/features/wallet/__tests__/aliasCallGuard.test.ts
@@ -1,0 +1,54 @@
+import { addAddressAliasTx } from '@evefrontier/wallet-core/address-alias'
+import { Transaction } from '@mysten/sui/transactions'
+import { describe, expect, it } from 'vitest'
+import { transactionContainsAddressAliasCall } from '../aliasCallGuard'
+
+const OWNER = `0x${'a'.repeat(64)}`
+const ALIASES_OBJECT = `0x${'b'.repeat(64)}`
+const ALIAS = `0x${'c'.repeat(64)}`
+const COIN = `0x${'d'.repeat(64)}`
+
+describe('transactionContainsAddressAliasCall', () => {
+  it('is true for a transaction whose only command is an alias call', async () => {
+    const tx = addAddressAliasTx(OWNER, ALIASES_OBJECT, ALIAS)
+    expect(transactionContainsAddressAliasCall(await tx.toJSON())).toBe(true)
+  })
+
+  it('is true when an alias call is bundled with unrelated commands', async () => {
+    const tx = new Transaction()
+    tx.setSender(OWNER)
+    tx.transferObjects([tx.object(COIN)], ALIAS)
+    tx.moveCall({
+      target: '0x2::address_alias::add',
+      arguments: [tx.object(ALIASES_OBJECT), tx.pure.address(ALIAS)],
+    })
+    expect(transactionContainsAddressAliasCall(await tx.toJSON())).toBe(true)
+  })
+
+  it('is false for a plain transfer with no alias call', async () => {
+    const tx = new Transaction()
+    tx.setSender(OWNER)
+    tx.transferObjects([tx.object(COIN)], ALIAS)
+    expect(transactionContainsAddressAliasCall(await tx.toJSON())).toBe(false)
+  })
+
+  it('fails closed (true) for undecodable input', () => {
+    expect(transactionContainsAddressAliasCall('not a transaction')).toBe(true)
+    expect(transactionContainsAddressAliasCall(new Uint8Array([1, 2, 3]))).toBe(
+      true,
+    )
+  })
+
+  it('fails open (false) for undecodable input when failClosed is false', () => {
+    expect(
+      transactionContainsAddressAliasCall('not a transaction', {
+        failClosed: false,
+      }),
+    ).toBe(false)
+    expect(
+      transactionContainsAddressAliasCall(new Uint8Array([1, 2, 3]), {
+        failClosed: false,
+      }),
+    ).toBe(false)
+  })
+})

--- a/apps/extension/src/features/wallet/aliasCallGuard.ts
+++ b/apps/extension/src/features/wallet/aliasCallGuard.ts
@@ -1,0 +1,7 @@
+// Single source of truth lives in @evevault/shared/wallet so the signing-layer
+// backstop (signForChain) and this UI gate share one detection rule. Re-exported
+// here to keep the existing feature-local import path and test mocks stable.
+export {
+  ADDRESS_ALIAS_SIGNING_BLOCKED,
+  transactionContainsAddressAliasCall,
+} from '@evevault/shared/wallet/aliasCall'

--- a/apps/extension/src/features/wallet/components/SignRequestView.tsx
+++ b/apps/extension/src/features/wallet/components/SignRequestView.tsx
@@ -29,6 +29,11 @@ type SignRequestViewProps = {
   /** When true, Approve stays disabled until the user ticks the acknowledgement. */
   requireAcknowledgement?: boolean
   acknowledgementLabel?: string
+  /**
+   * When set, Approve is disabled, this message renders as a warning banner, and
+   * the acknowledgement checkbox is hidden. Reject stays available.
+   */
+  approveBlockedReason?: string | null
   onApprove: () => void | Promise<void>
   onReject: () => void | Promise<void>
   children: ReactNode
@@ -111,6 +116,7 @@ export function SignRequestView({
   requestKind,
   requireAcknowledgement = false,
   acknowledgementLabel = DEFAULT_ACKNOWLEDGEMENT_LABEL,
+  approveBlockedReason = null,
   onApprove,
   onReject,
   children,
@@ -119,7 +125,10 @@ export function SignRequestView({
   // Keep Approve disabled until the keeper's lock state is confirmed, so a stale
   // unlocked flag can't let the user fire a sign the keeper will reject.
   const approveDisabled =
-    loading || !auth.lockChecked || (requireAcknowledgement && !acknowledged)
+    loading ||
+    !auth.lockChecked ||
+    !!approveBlockedReason ||
+    (requireAcknowledgement && !acknowledged)
   return (
     <SignPopupAuthGate
       isLocked={auth.isLocked}
@@ -157,7 +166,19 @@ export function SignRequestView({
               </div>
             )}
 
-            {requireAcknowledgement && (
+            {approveBlockedReason && (
+              <div
+                className="w-[320px] max-w-[88vw] rounded border border-critical bg-critical/50 p-2"
+                role="alert"
+                data-testid="approve-blocked-reason"
+              >
+                <Text variant="light" size="xsmall">
+                  {approveBlockedReason}
+                </Text>
+              </div>
+            )}
+
+            {!approveBlockedReason && requireAcknowledgement && (
               <Checkbox
                 name="acknowledge-risk"
                 isChecked={acknowledged}

--- a/apps/extension/src/features/wallet/components/SignSponsoredTransaction.tsx
+++ b/apps/extension/src/features/wallet/components/SignSponsoredTransaction.tsx
@@ -7,12 +7,20 @@ import { useRequireAlias } from '@evevault/shared'
 import { Text } from '@evevault/shared/components'
 import Json from '@evevault/shared/components/Json'
 import type { PendingSponsoredTransaction } from '@evevault/shared/types'
-import { createLogger, parseTransactionBytes } from '@evevault/shared/utils'
+import {
+  b64ToBytesOrNull,
+  createLogger,
+  parseTransactionBytes,
+} from '@evevault/shared/utils'
 import { useWalletSigningContext } from '@evevault/shared/wallet'
 import {
   usePendingSignAction,
   useTransactionSimulation,
 } from '@/features/wallet/hooks'
+import {
+  ADDRESS_ALIAS_SIGNING_BLOCKED,
+  transactionContainsAddressAliasCall,
+} from '../aliasCallGuard'
 import { type ApprovalTab, ApprovalTabs } from './ApprovalTabs'
 import { SignRequestView } from './SignRequestView'
 import { TransactionRiskPanel } from './TransactionRiskPanel'
@@ -111,8 +119,26 @@ function SignSponsoredTransaction() {
     getWindowId: (pending) => pending.windowId,
   })
 
+  // Decode the backend payload once. `null` means undecodable base64, which we
+  // treat as blocked below..
+  const sponsoredBytes =
+    typeof pending?.sponsoredTxB64 === 'string'
+      ? b64ToBytesOrNull(pending.sponsoredTxB64)
+      : null
+
+  // Block Approve (with a warning) when the payload carries an alias call or
+  // can't be decoded.
+  const aliasBlockReason =
+    typeof pending?.sponsoredTxB64 === 'string' &&
+    (sponsoredBytes === null ||
+      transactionContainsAddressAliasCall(sponsoredBytes))
+      ? ADDRESS_ALIAS_SIGNING_BLOCKED
+      : null
+
   const handleApprove = async () => {
     if (!pending) return
+    // Never sign an alias call, even if the disabled button is bypassed.
+    if (aliasBlockReason) return
     const validationError = getSponsoredApproveError(isLocalnet, auth)
     if (validationError) {
       setError(validationError)
@@ -121,14 +147,18 @@ function SignSponsoredTransaction() {
 
     if (!(await ensureAlias())) return
 
+    // sponsoredBytes is non-null here: a null decode sets aliasBlockReason, which
+    // the guard above already returned on.
+    if (!sponsoredBytes) return
+
     try {
       setLoading(true)
       setError(null)
 
-      const txbBytes = Uint8Array.from(atob(pending.sponsoredTxB64), (c) =>
-        c.charCodeAt(0),
+      const { signature: zkSignature } = await sign(
+        'TransactionData',
+        sponsoredBytes,
       )
-      const { signature: zkSignature } = await sign('TransactionData', txbBytes)
 
       const stored = await storeResult({
         status: 'signed',
@@ -224,6 +254,7 @@ function SignSponsoredTransaction() {
             ? PREDICTED_FAILURE_ACKNOWLEDGEMENT
             : undefined
         }
+        approveBlockedReason={aliasBlockReason}
         onApprove={handleApprove}
         onReject={handleReject}
       >
@@ -255,7 +286,16 @@ function SignSponsoredTransaction() {
             </div>
           </div>
 
-          {pending && <ApprovalTabs tabs={tabs} />}
+          {pending && (
+            <ApprovalTabs
+              tabs={tabs}
+              initialId={
+                aliasBlockReason && riskFindings.length > 0
+                  ? 'warnings'
+                  : undefined
+              }
+            />
+          )}
         </div>
       </SignRequestView>
       {aliasSetupModal}

--- a/apps/extension/src/features/wallet/components/SignSponsoredTransaction.tsx
+++ b/apps/extension/src/features/wallet/components/SignSponsoredTransaction.tsx
@@ -120,7 +120,7 @@ function SignSponsoredTransaction() {
   })
 
   // Decode the backend payload once. `null` means undecodable base64, which we
-  // treat as blocked below..
+  // treat as blocked below.
   const sponsoredBytes =
     typeof pending?.sponsoredTxB64 === 'string'
       ? b64ToBytesOrNull(pending.sponsoredTxB64)

--- a/apps/extension/src/features/wallet/components/SignTransactionFlow.tsx
+++ b/apps/extension/src/features/wallet/components/SignTransactionFlow.tsx
@@ -14,6 +14,10 @@ import type {
   SignResult,
   StoreResult,
 } from '@/features/wallet/hooks/useTransactionSigning'
+import {
+  ADDRESS_ALIAS_SIGNING_BLOCKED,
+  transactionContainsAddressAliasCall,
+} from '../aliasCallGuard'
 import { type ApprovalTab, ApprovalTabs } from './ApprovalTabs'
 import { SignRequestView } from './SignRequestView'
 import { TransactionRiskPanel } from './TransactionRiskPanel'
@@ -51,7 +55,16 @@ export function SignTransactionFlow({
 
   const { ensureAlias, aliasSetupModal } = useRequireAlias()
 
+  // Block Approve (with a warning) when the request carries an alias call.
+  const aliasBlockReason =
+    typeof pendingTransaction?.transaction === 'string' &&
+    transactionContainsAddressAliasCall(pendingTransaction.transaction)
+      ? ADDRESS_ALIAS_SIGNING_BLOCKED
+      : null
+
   const handleApprove = async () => {
+    // Never sign an alias call.
+    if (aliasBlockReason) return
     if (!(await ensureAlias())) return
     await withSigning((result) => onSign(result, storeResult))
   }
@@ -111,6 +124,7 @@ export function SignTransactionFlow({
         hasPending={!!pendingTransaction}
         loading={loading}
         error={error}
+        approveBlockedReason={aliasBlockReason}
         loadingMessage="Loading transaction..."
         chain={pendingTransaction?.chain}
         dapp={pendingTransaction?.dapp}
@@ -127,7 +141,14 @@ export function SignTransactionFlow({
       >
         {pendingTransaction && (
           <div className="flex w-full flex-col items-center gap-2">
-            <ApprovalTabs tabs={tabs} />
+            <ApprovalTabs
+              tabs={tabs}
+              initialId={
+                aliasBlockReason && riskFindings.length > 0
+                  ? 'warnings'
+                  : undefined
+              }
+            />
           </div>
         )}
       </SignRequestView>

--- a/apps/extension/src/features/wallet/components/__tests__/SignRequestView.test.tsx
+++ b/apps/extension/src/features/wallet/components/__tests__/SignRequestView.test.tsx
@@ -180,4 +180,28 @@ describe('SignRequestView', () => {
     )
     expect(screen.getByText('I accept the risk')).toBeInTheDocument()
   })
+
+  it('shows the warning and disables Approve when approveBlockedReason is set', () => {
+    render(
+      <SignRequestView
+        {...defaultProps({ approveBlockedReason: 'Cannot sign this request.' })}
+      />,
+    )
+    expect(screen.getByText('Cannot sign this request.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Approve' })).toBeDisabled()
+  })
+
+  it('hides the acknowledgement checkbox and keeps Approve disabled when blocked', () => {
+    render(
+      <SignRequestView
+        {...defaultProps({
+          requireAcknowledgement: true,
+          approveBlockedReason: 'Cannot sign this request.',
+        })}
+      />,
+    )
+    // The acknowledgement path must not offer a way to enable Approve.
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Approve' })).toBeDisabled()
+  })
 })

--- a/apps/extension/src/features/wallet/components/__tests__/SignSponsoredTransaction.test.tsx
+++ b/apps/extension/src/features/wallet/components/__tests__/SignSponsoredTransaction.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ADDRESS_ALIAS_SIGNING_BLOCKED } from '../../aliasCallGuard'
 import {
   getSponsoredApproveError,
   parsePendingSponsoredAction,
@@ -10,12 +11,22 @@ const {
   mockUseWalletSigningContext,
   mockUseTransactionSimulation,
   mockAddressAliasModule,
+  mockContainsAlias,
 } = vi.hoisted(() => ({
   mockUsePendingSignAction: vi.fn(),
   mockUseWalletSigningContext: vi.fn(),
   mockUseTransactionSimulation: vi.fn(),
   mockAddressAliasModule: '0xaddress_alias_module',
+  mockContainsAlias: vi.fn(),
 }))
+
+vi.mock('../../aliasCallGuard', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../aliasCallGuard')>()
+  return {
+    ...actual,
+    transactionContainsAddressAliasCall: mockContainsAlias,
+  }
+})
 
 vi.mock('@/features/wallet/hooks', () => ({
   usePendingSignAction: mockUsePendingSignAction,
@@ -57,6 +68,7 @@ vi.mock('@/features/wallet/components/SignRequestView', () => ({
     error,
     requireAcknowledgement,
     acknowledgementLabel,
+    approveBlockedReason,
     onApprove,
     onReject,
   }: {
@@ -66,19 +78,28 @@ vi.mock('@/features/wallet/components/SignRequestView', () => ({
     error: string | null
     requireAcknowledgement?: boolean
     acknowledgementLabel?: string
+    approveBlockedReason?: string | null
     onApprove?: () => void
     onReject?: () => void
   }) => (
     <div>
       {!hasPending ? <span>{loadingMessage}</span> : children}
       {error && <span data-testid="error">{error}</span>}
+      {approveBlockedReason && (
+        <span data-testid="approve-blocked-reason">{approveBlockedReason}</span>
+      )}
       {requireAcknowledgement && (
         <span data-testid="ack-required">ack-required</span>
       )}
       {acknowledgementLabel && (
         <span data-testid="ack-label">{acknowledgementLabel}</span>
       )}
-      <button data-testid="approve-btn" type="button" onClick={onApprove}>
+      <button
+        data-testid="approve-btn"
+        type="button"
+        disabled={!!approveBlockedReason}
+        onClick={onApprove}
+      >
         Approve
       </button>
       <button data-testid="reject-btn" type="button" onClick={onReject}>
@@ -131,6 +152,7 @@ function stubPending(
 
 beforeEach(() => {
   vi.clearAllMocks()
+  mockContainsAlias.mockReturnValue(false)
   mockUseWalletSigningContext.mockReturnValue({
     isLocalnet: false,
     sign: vi.fn(),
@@ -257,6 +279,54 @@ describe('SignSponsoredTransaction', () => {
     expect(screen.getByTestId('ack-required')).toBeInTheDocument()
     // predictedFailure && !needsRiskAck is false, so no failure-specific label.
     expect(screen.queryByTestId('ack-label')).not.toBeInTheDocument()
+  })
+
+  it('warns, defaults to Warnings, and disables Approve when the sponsored tx contains an alias call', async () => {
+    mockContainsAlias.mockReturnValue(true)
+    stubPending({
+      windowId: 1,
+      requestId: 'req-alias',
+      sponsoredTxB64: btoa('bytes'),
+      preparationId: 'prep-alias',
+      // The alias MoveCall yields a danger "Modifies address aliases" finding.
+      reviewValue: {
+        commands: [{ MoveCall: { package: '0x2', module: 'address_alias' } }],
+        inputs: [],
+      },
+      chain: 'sui:testnet',
+    })
+    await renderSignSponsored()
+    expect(screen.getByTestId('approve-blocked-reason')).toHaveTextContent(
+      ADDRESS_ALIAS_SIGNING_BLOCKED,
+    )
+    expect(screen.getByTestId('approve-btn')).toBeDisabled()
+    expect(screen.getByRole('tab', { name: /Warnings/ })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    )
+    expect(screen.getByRole('tab', { name: 'Outcome' })).toHaveAttribute(
+      'aria-selected',
+      'false',
+    )
+  })
+
+  it('blocks (without crashing) when sponsoredTxB64 is not valid base64', async () => {
+    // Undecodable payload: decoding must fail closed in the UI, not throw during
+    // render. The alias detector is never reached.
+    mockContainsAlias.mockReturnValue(false)
+    stubPending({
+      windowId: 1,
+      requestId: 'req-bad',
+      sponsoredTxB64: '!!!not-base64!!!',
+      preparationId: 'prep-bad',
+      chain: 'sui:testnet',
+    })
+    await renderSignSponsored()
+    expect(screen.getByTestId('approve-blocked-reason')).toHaveTextContent(
+      ADDRESS_ALIAS_SIGNING_BLOCKED,
+    )
+    expect(screen.getByTestId('approve-btn')).toBeDisabled()
+    expect(mockContainsAlias).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/extension/src/features/wallet/components/__tests__/SignTransactionFlow.test.tsx
+++ b/apps/extension/src/features/wallet/components/__tests__/SignTransactionFlow.test.tsx
@@ -1,5 +1,7 @@
+import { addAddressAliasTx } from '@evefrontier/wallet-core/address-alias'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ADDRESS_ALIAS_SIGNING_BLOCKED } from '../../aliasCallGuard'
 
 const { mockUseTransactionSigning, mockUseTransactionSimulation } = vi.hoisted(
   () => ({
@@ -40,6 +42,7 @@ vi.mock('@/features/wallet/components/SignRequestView', () => ({
     requireAcknowledgement,
     onApprove,
     onReject,
+    approveBlockedReason,
   }: {
     children: React.ReactNode
     title?: string
@@ -47,6 +50,7 @@ vi.mock('@/features/wallet/components/SignRequestView', () => ({
     loadingMessage: string
     error?: string | null
     requireAcknowledgement?: boolean
+    approveBlockedReason?: string | null
     onApprove?: () => void
     onReject?: () => void
   }) => (
@@ -54,10 +58,18 @@ vi.mock('@/features/wallet/components/SignRequestView', () => ({
       {title && <span data-testid="title">{title}</span>}
       {!hasPending ? <span>{loadingMessage}</span> : children}
       {error && <span data-testid="error">{error}</span>}
+      {approveBlockedReason && (
+        <span data-testid="approve-blocked-reason">{approveBlockedReason}</span>
+      )}
       {requireAcknowledgement && (
         <span data-testid="ack-required">ack-required</span>
       )}
-      <button data-testid="approve-btn" type="button" onClick={onApprove}>
+      <button
+        data-testid="approve-btn"
+        type="button"
+        disabled={!!approveBlockedReason}
+        onClick={onApprove}
+      >
         Approve
       </button>
       <button data-testid="reject-btn" type="button" onClick={onReject}>
@@ -278,6 +290,52 @@ describe('SignTransactionFlow', () => {
     await waitFor(() =>
       expect(withSigning).toHaveBeenCalledWith(expect.any(Function)),
     )
+  })
+
+  it('warns, defaults to Warnings, and disables Approve when the pending tx contains an alias call', async () => {
+    const aliasTx = await addAddressAliasTx(
+      `0x${'a'.repeat(64)}`,
+      `0x${'b'.repeat(64)}`,
+      `0x${'c'.repeat(64)}`,
+    ).toJSON()
+    const withSigning = vi.fn()
+    stubSigning({
+      pendingTransaction: {
+        windowId: 1,
+        requestId: 'r1',
+        transaction: aliasTx,
+        // The alias MoveCall yields a danger "Modifies address aliases" finding.
+        reviewValue: {
+          commands: [{ MoveCall: { package: '0x2', module: 'address_alias' } }],
+          inputs: [],
+        },
+        displayValue: '{}',
+        chain: 'sui:testnet',
+        account: { address: '0xabc' },
+      },
+      withSigning,
+    })
+    render(<SignTransactionFlow title="Sign Transaction" onSign={vi.fn()} />)
+
+    expect(screen.getByTestId('approve-blocked-reason')).toHaveTextContent(
+      ADDRESS_ALIAS_SIGNING_BLOCKED,
+    )
+    expect(screen.getByTestId('approve-btn')).toBeDisabled()
+
+    // Warnings is the default tab (not Outcome), so its risk panel is mounted.
+    expect(screen.getByRole('tab', { name: /Warnings/ })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    )
+    expect(screen.getByRole('tab', { name: 'Outcome' })).toHaveAttribute(
+      'aria-selected',
+      'false',
+    )
+    expect(screen.getByTestId('risk-panel')).toBeInTheDocument()
+
+    // Even if the click fires, signing is refused.
+    fireEvent.click(screen.getByTestId('approve-btn'))
+    await waitFor(() => expect(withSigning).not.toHaveBeenCalled())
   })
 })
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -18,6 +18,10 @@
       "development": "./src/wallet/index.ts",
       "default": "./dist/wallet/index.js"
     },
+    "./wallet/aliasCall": {
+      "development": "./src/wallet/aliasCall.ts",
+      "default": "./dist/wallet/aliasCall.js"
+    },
     "./sui": {
       "development": "./src/sui/index.ts",
       "default": "./dist/sui/index.js"

--- a/packages/shared/src/utils/base64.ts
+++ b/packages/shared/src/utils/base64.ts
@@ -21,3 +21,14 @@ export const bytesToB64 = (bytes: Uint8Array): string => {
 
 export const b64ToBytes = (b64: string): Uint8Array<ArrayBuffer> =>
   Uint8Array.from(atob(b64), (c) => c.charCodeAt(0))
+
+/** Like {@link b64ToBytes}, but returns `null` instead of throwing on malformed input. */
+export const b64ToBytesOrNull = (
+  b64: string,
+): Uint8Array<ArrayBuffer> | null => {
+  try {
+    return b64ToBytes(b64)
+  } catch {
+    return null
+  }
+}

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -4,6 +4,7 @@ export {
 } from '@evefrontier/wallet-core/transaction'
 export * from './address'
 export * from './authCleanup'
+export { b64ToBytes, b64ToBytesOrNull, bytesToB64 } from './base64'
 export * from './calculate'
 export * from './coinTypes'
 export * from './constants'

--- a/packages/shared/src/wallet/__tests__/aliasEnforcement.test.ts
+++ b/packages/shared/src/wallet/__tests__/aliasEnforcement.test.ts
@@ -39,8 +39,16 @@ function objectsWith(aliases: string[]) {
 }
 
 function stubDecodedModule(module: string) {
+  stubDecodedModules([module])
+}
+
+function stubDecodedModules(modules: string[]) {
   vi.mocked(Transaction.from).mockReturnValue({
-    getData: () => ({ commands: [{ MoveCall: { package: '0x2', module } }] }),
+    getData: () => ({
+      commands: modules.map((module) => ({
+        MoveCall: { package: '0x2', module },
+      })),
+    }),
   } as never)
 }
 
@@ -105,6 +113,47 @@ describe('assertAliasEnforced', () => {
       }),
     ).resolves.toBeUndefined()
     expect(mockListOwnedObjects).not.toHaveBeenCalled()
+  })
+
+  it('still exempts a pure multi-command alias setup tx', async () => {
+    mockListOwnedObjects.mockResolvedValue(objectsWith([OWNER]))
+    stubDecodedModules(['address_alias', 'address_alias'])
+    await expect(
+      assertAliasEnforced({
+        chain: SUI_DEVNET_CHAIN,
+        owner: OWNER,
+        scope: 'TransactionData',
+        msgBytes: new Uint8Array([1]),
+      }),
+    ).resolves.toBeUndefined()
+    expect(mockListOwnedObjects).not.toHaveBeenCalled()
+  })
+
+  it('does NOT exempt an alias call bundled with other commands (enforces it)', async () => {
+    mockListOwnedObjects.mockResolvedValue(objectsWith([OWNER]))
+    // A dApp bundling an alias call with a transfer must not claim the exemption.
+    stubDecodedModules(['address_alias', 'coin'])
+    await expect(
+      assertAliasEnforced({
+        chain: SUI_DEVNET_CHAIN,
+        owner: OWNER,
+        scope: 'TransactionData',
+        msgBytes: new Uint8Array([1]),
+      }),
+    ).rejects.toMatchObject({ code: 'alias_enforcement_required' })
+  })
+
+  it('does NOT exempt an empty-command tx', async () => {
+    mockListOwnedObjects.mockResolvedValue(objectsWith([OWNER]))
+    stubDecodedModules([])
+    await expect(
+      assertAliasEnforced({
+        chain: SUI_DEVNET_CHAIN,
+        owner: OWNER,
+        scope: 'TransactionData',
+        msgBytes: new Uint8Array([1]),
+      }),
+    ).rejects.toMatchObject({ code: 'alias_enforcement_required' })
   })
 
   it('never gates personal messages (off-chain signatures)', async () => {

--- a/packages/shared/src/wallet/__tests__/signForChain.test.ts
+++ b/packages/shared/src/wallet/__tests__/signForChain.test.ts
@@ -11,7 +11,15 @@ vi.mock('#/wallet/aliasEnforcement', () => ({
   assertAliasEnforced: vi.fn().mockResolvedValue(undefined),
 }))
 
+// Detection is unit-tested in aliasCall.test.ts; stub it so we can drive the
+// backstop's routing (blocked vs allowed) directly.
+vi.mock('#/wallet/aliasCall', () => ({
+  ADDRESS_ALIAS_SIGNING_BLOCKED: 'BLOCKED_ALIAS',
+  transactionContainsAddressAliasCall: vi.fn(),
+}))
+
 import { SUI_LOCALNET_CHAIN, SUI_TESTNET_CHAIN } from '@mysten/wallet-standard'
+import { transactionContainsAddressAliasCall } from '#/wallet/aliasCall'
 import { signForChain } from '#/wallet/signForChain'
 import { zkSignAny } from '#/wallet/zkSignAny'
 
@@ -192,5 +200,93 @@ describe('signForChain — zkLogin path', () => {
 
     expect(zkSignAny).toHaveBeenCalled()
     expect(result).toEqual({ bytes: 'zk_bytes', signature: 'zk_sig' })
+  })
+})
+
+describe('signForChain — address-alias backstop', () => {
+  afterEach(() => {
+    clearBrowser()
+    vi.clearAllMocks()
+  })
+
+  it('refuses a TransactionData carrying an alias call and never signs', async () => {
+    vi.mocked(transactionContainsAddressAliasCall).mockReturnValue(true)
+
+    await expect(
+      signForChain('TransactionData', MSG, {
+        chain: TESTNET,
+        user: minimalUser,
+        getZkProof: vi.fn(),
+        localnetAddress: null,
+      }),
+    ).rejects.toThrow('BLOCKED_ALIAS')
+    expect(zkSignAny).not.toHaveBeenCalled()
+  })
+
+  it('detects with failClosed:false so a parse hiccup never blocks all signing', async () => {
+    vi.mocked(transactionContainsAddressAliasCall).mockReturnValue(false)
+
+    await signForChain('TransactionData', MSG, {
+      chain: TESTNET,
+      user: minimalUser,
+      getZkProof: vi.fn(),
+      localnetAddress: null,
+    })
+
+    expect(transactionContainsAddressAliasCall).toHaveBeenCalledWith(MSG, {
+      failClosed: false,
+    })
+  })
+
+  it('allows an alias call when the caller opts in (Eve Vault alias setup)', async () => {
+    vi.mocked(transactionContainsAddressAliasCall).mockReturnValue(true)
+    vi.mocked(zkSignAny).mockResolvedValue({
+      bytes: 'zk_bytes',
+      zkSignature: 'zk_sig',
+    })
+
+    const result = await signForChain('TransactionData', MSG, {
+      chain: TESTNET,
+      user: minimalUser,
+      getZkProof: vi.fn(),
+      localnetAddress: null,
+      allowAddressAliasCalls: true,
+    })
+
+    expect(result).toEqual({ bytes: 'zk_bytes', signature: 'zk_sig' })
+  })
+
+  it('does not gate non-transaction scopes (personal messages)', async () => {
+    vi.mocked(transactionContainsAddressAliasCall).mockReturnValue(true)
+    vi.mocked(zkSignAny).mockResolvedValue({
+      bytes: 'zk_bytes',
+      zkSignature: 'zk_sig',
+    })
+
+    await signForChain('PersonalMessage', MSG, {
+      chain: TESTNET,
+      user: minimalUser,
+      getZkProof: vi.fn(),
+      localnetAddress: null,
+    })
+
+    expect(transactionContainsAddressAliasCall).not.toHaveBeenCalled()
+    expect(zkSignAny).toHaveBeenCalled()
+  })
+
+  it('blocks before the localnet branch, so localnet is covered too', async () => {
+    vi.mocked(transactionContainsAddressAliasCall).mockReturnValue(true)
+    const sendMessage = vi.fn()
+    setBrowser(sendMessage)
+
+    await expect(
+      signForChain('TransactionData', MSG, {
+        chain: LOCALNET,
+        user: null,
+        getZkProof: null,
+        localnetAddress: LOCAL_ADDR,
+      }),
+    ).rejects.toThrow('BLOCKED_ALIAS')
+    expect(sendMessage).not.toHaveBeenCalled()
   })
 })

--- a/packages/shared/src/wallet/aliasCall.ts
+++ b/packages/shared/src/wallet/aliasCall.ts
@@ -1,0 +1,33 @@
+import { isAddressAliasCall } from '@evefrontier/wallet-core/address-alias'
+import { Transaction } from '@mysten/sui/transactions'
+import { createLogger } from '#/utils'
+
+const log = createLogger()
+
+/** Shown in the approval popup, and thrown as the refusal message, when a request carries an address-alias call. */
+export const ADDRESS_ALIAS_SIGNING_BLOCKED =
+  'Unable to complete signing: transactions containing address-aliasing ' +
+  'calls can only be performed from within Eve Vault.'
+
+/**
+ * True when any command in the transaction is an address-alias MoveCall
+ * ({@link isAddressAliasCall}). Returns `failClosed` (default `true`) when the
+ * input can't be decoded.
+ *
+ * @param source A transaction JSON string (from `Transaction.toJSON()`) or its
+ *   serialized kind bytes.
+ */
+export function transactionContainsAddressAliasCall(
+  source: string | Uint8Array,
+  opts: { failClosed?: boolean } = {},
+): boolean {
+  try {
+    const { commands } = Transaction.from(source).getData()
+    return commands.some((command) => isAddressAliasCall(command))
+  } catch (error) {
+    log.warn('Treating undecodable transaction as a possible alias call', {
+      error,
+    })
+    return opts.failClosed ?? true
+  }
+}

--- a/packages/shared/src/wallet/aliasCall.ts
+++ b/packages/shared/src/wallet/aliasCall.ts
@@ -25,9 +25,13 @@ export function transactionContainsAddressAliasCall(
     const { commands } = Transaction.from(source).getData()
     return commands.some((command) => isAddressAliasCall(command))
   } catch (error) {
-    log.warn('Treating undecodable transaction as a possible alias call', {
-      error,
-    })
-    return opts.failClosed ?? true
+    const blocked = opts.failClosed ?? true
+    // Warn only when this blocks.
+    if (blocked) {
+      log.warn('Blocking undecodable transaction as a possible alias call', {
+        error,
+      })
+    }
+    return blocked
   }
 }

--- a/packages/shared/src/wallet/aliasEnforcement.ts
+++ b/packages/shared/src/wallet/aliasEnforcement.ts
@@ -98,11 +98,17 @@ export function isAliasEnforcementError(err: unknown): boolean {
   )
 }
 
-/** True when the transaction bytes are an address-alias setup call (enable/add/remove). */
+/**
+ * True when every command in the transaction is an address-alias call
+ * (enable/add/remove). Empty or mixed command sets are false.
+ */
 function isAliasSetupBytes(msgBytes: Uint8Array): boolean {
   try {
     const { commands } = Transaction.from(msgBytes).getData()
-    return commands.some((command) => isAddressAliasCall(command))
+    return (
+      commands.length > 0 &&
+      commands.every((command) => isAddressAliasCall(command))
+    )
   } catch {
     // Undecodable bytes are never treated as an alias-setup exemption.
     return false

--- a/packages/shared/src/wallet/hooks/useAddressAliases.ts
+++ b/packages/shared/src/wallet/hooks/useAddressAliases.ts
@@ -58,7 +58,8 @@ export function useAddressAliases(): UseAddressAliasesResult {
   // Adapts the signing-context callback to wallet-core's signer shape.
   const signer = useMemo(
     () => ({
-      signTransaction: (bytes: Uint8Array) => sign('TransactionData', bytes),
+      signTransaction: (bytes: Uint8Array) =>
+        sign('TransactionData', bytes, { allowAddressAliasCalls: true }),
     }),
     [sign],
   )

--- a/packages/shared/src/wallet/hooks/useAliasProvisioning.ts
+++ b/packages/shared/src/wallet/hooks/useAliasProvisioning.ts
@@ -41,10 +41,12 @@ export function useAliasProvisioning(): UseAliasProvisioningResult {
   const [aliasKey, setAliasKey] = useState<GeneratedAliasKey | null>(null)
 
   // Adapts the signing-context callback to wallet-core's signer shape (same as
-  // useAddressAliases). Alias-setup txs bypass the enforcement backstop.
+  // useAddressAliases). Alias-setup txs bypass the enforcement backstop and the
+  // alias-call signing gate.
   const signer = useMemo(
     () => ({
-      signTransaction: (bytes: Uint8Array) => sign('TransactionData', bytes),
+      signTransaction: (bytes: Uint8Array) =>
+        sign('TransactionData', bytes, { allowAddressAliasCalls: true }),
     }),
     [sign],
   )

--- a/packages/shared/src/wallet/hooks/useWalletSigningContext.helpers.ts
+++ b/packages/shared/src/wallet/hooks/useWalletSigningContext.helpers.ts
@@ -28,13 +28,18 @@ export const useWalletSigningCallbacks = ({
   }, [chain, isLocalnet])
 
   const sign = useCallback(
-    async (scope: IntentScope, msgBytes: Uint8Array) => {
+    async (
+      scope: IntentScope,
+      msgBytes: Uint8Array,
+      signOpts?: { allowAddressAliasCalls?: boolean },
+    ) => {
       const zkLoginUser = await getZkLoginUser()
       return signForChain(scope, msgBytes, {
         chain,
         user: zkLoginUser,
         getZkProof: isLocalnet ? null : getZkProof,
         localnetAddress,
+        allowAddressAliasCalls: signOpts?.allowAddressAliasCalls,
       })
     },
     [chain, isLocalnet, getZkProof, localnetAddress, getZkLoginUser],

--- a/packages/shared/src/wallet/index.ts
+++ b/packages/shared/src/wallet/index.ts
@@ -20,6 +20,10 @@ export {
   isWebCryptoMarker,
 } from '../types/wallet'
 export {
+  ADDRESS_ALIAS_SIGNING_BLOCKED,
+  transactionContainsAddressAliasCall,
+} from './aliasCall'
+export {
   assertAliasEnforced,
   isAliasEnforcementError,
   isAliasEnforcementFeatureEnabled,

--- a/packages/shared/src/wallet/index.ts
+++ b/packages/shared/src/wallet/index.ts
@@ -20,10 +20,6 @@ export {
   isWebCryptoMarker,
 } from '../types/wallet'
 export {
-  ADDRESS_ALIAS_SIGNING_BLOCKED,
-  transactionContainsAddressAliasCall,
-} from './aliasCall'
-export {
   assertAliasEnforced,
   isAliasEnforcementError,
   isAliasEnforcementFeatureEnabled,

--- a/packages/shared/src/wallet/signForChain.ts
+++ b/packages/shared/src/wallet/signForChain.ts
@@ -4,6 +4,10 @@ import { browser } from '@wxt-dev/browser'
 import { VaultMessageTypes } from '#/types'
 import type { ZkSignAnyParams } from '#/types/wallet'
 import { toErrorMessage } from '#/utils/errorMessage'
+import {
+  ADDRESS_ALIAS_SIGNING_BLOCKED,
+  transactionContainsAddressAliasCall,
+} from './aliasCall'
 import { assertAliasEnforced } from './aliasEnforcement'
 import { zkSignAny } from './zkSignAny'
 
@@ -19,8 +23,21 @@ export async function signForChain(
     user: ZkSignAnyParams['user'] | null
     getZkProof: ZkSignAnyParams['getZkProof'] | null
     localnetAddress?: string | null
+    /** When unset, a TransactionData carrying an address-alias call is refused. */
+    allowAddressAliasCalls?: boolean
   },
 ): Promise<{ bytes: string; signature: string }> {
+  // Refuse an opted-out TransactionData that carries an address-alias call.
+  // Runs before the chain branch (covers localnet). Detection fails open:
+  // undecodable bytes are not treated as an alias call.
+  if (
+    !opts.allowAddressAliasCalls &&
+    scope === 'TransactionData' &&
+    transactionContainsAddressAliasCall(msgBytes, { failClosed: false })
+  ) {
+    throw new Error(ADDRESS_ALIAS_SIGNING_BLOCKED)
+  }
+
   if (opts.chain === SUI_LOCALNET_CHAIN) {
     if (!opts.localnetAddress) {
       throw new Error(


### PR DESCRIPTION
Alias transactions must only ever be driven from Eve Vault's own UI, never signed on from a third-party dApp. This PR adds that guard at two layers and closes a gap in the existing enforcement exemption.

### 1. `feat: alias guard UI` — user-facing gate
- Detects when a pending transaction (regular or sponsored) contains an `address_alias` MoveCall and disables **Approve**, showing a warning banner while still letting the user review and **Reject**.
- Defaults the approval view to the **Warnings** tab when a request is blocked.
- Detection lives in one place (`packages/shared/src/wallet/aliasCall.ts`, `transactionContainsAddressAliasCall`) and is re-exported for the extension.

<img width="496" height="748" alt="Screenshot 2026-09-04 at 16 37 50" src="https://github.com/user-attachments/assets/eee000d5-242c-43fe-8dfc-447b86504eba" />

Also folds in two correctness fixes to that flow:
- The sponsored payload is now decoded via `b64ToBytesOrNull`, so a malformed base64 payload blocks Approve instead of throwing during render.
- `initialId` no longer points at a `warnings` tab that may not exist.

### 2. `feat: enforce address alias guard` — signing-layer backstop
- `signForChain` refuses any `TransactionData` carrying an alias call, on all chains, before the button is ever involved.
- `sign` gained an opt-in `{ allowAddressAliasCalls }`; only Eve Vault's own alias flows (`useAddressAliases`, `useAliasProvisioning`) set it. Every dApp path — normal signing, sponsored, and the SuiWallet adapter — is refused by default. Detection fails open here so a parser hiccup can't block unrelated signatures.
- Tightens the enforcement setup-exemption from `.some` to `.every`: only a *pure* alias-setup transaction is exempt, so a dApp can't bundle an alias call with other commands to dodge enforcement. Pure single- or multi-command alias setups (including first-time passkey `enable` + `add`) remain exempt.

## Behavior

| Origin                         | Contains alias call | Result                                       |
| ------------------------------ | ------------------- | -------------------------------------------- |
| dApp (any signing path)        | yes                 | Approve disabled + refused at `signForChain` |
| dApp                           | no                  | signs normally                               |
| Eve Vault alias setup/recovery | yes                 | signs (opted in)                             |